### PR TITLE
Use Pydantic models to represent domain concepts, starting with `Article`

### DIFF
--- a/src/poprox_recommender/domain/__init__.py
+++ b/src/poprox_recommender/domain/__init__.py
@@ -1,0 +1,1 @@
+from poprox_recommender.domain.article import Article

--- a/src/poprox_recommender/domain/article.py
+++ b/src/poprox_recommender/domain/article.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timezone
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Article(BaseModel):
+    article_id: UUID = None
+    title: str
+    content: str = ""
+    url: str
+    published_at: datetime = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
This is a first step toward representing domain concepts like articles, accounts, entities, etc with Python classes instead of dictionaries. That will make it easier for us to validate the data we're working with and know what fields to expect will be present. We'll also get better type-checking since we'll be able to annotate more of the function parameters and return types.