### PR TITLE
Update MIND test data and Modify the MMR_diversify 

### DIFF
--- a/src/poprox_recommender/test_json.py
+++ b/src/poprox_recommender/test_json.py
@@ -1,0 +1,153 @@
+import io
+import json
+import os
+import sys
+sys.path.append('../')
+import torch as th
+from safetensors.torch import load_file
+from uuid import UUID
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+from poprox_recommender.domain import Article, ClickHistory
+from poprox_recommender.default import select_articles
+from poprox_recommender.paths import project_root
+
+
+
+def load_model(device_name=None):
+
+    if device_name is None:
+        device_name = "cuda" if th.cuda.is_available() else "cpu"
+
+    load_path = f"/home/XLL1713/POPROX/engine0/NRMS_bert/NRMS_BERT_checkpoint/model.safetensors"
+    checkpoint = load_file(load_path)
+
+    return checkpoint, device_name
+
+
+def custom_encoder(obj):
+    if isinstance(obj, UUID):
+        return str(obj)
+
+def compute_mrr(y_pred, y_true):
+    # 关心原本label为1的item在y_pred中的位置 y_pred =list[排好的item id]
+    relevant_items = {item.split('-')[0] for item in y_true if item.endswith('-1')}
+    mrr = 0
+    for rank, pred_item in enumerate(y_pred, start = 1):
+        if pred_item in relevant_items:
+            mrr += (1/rank)
+    return mrr/len(relevant_items)
+
+
+
+def compute_dcg(y_pred, y_true, k=5):
+    '''
+    y_pred: 排好的item顺序
+    y_true:[item-label]
+    '''
+    item_label = {}
+    for pair in y_true:
+        item_label[pair.split('-')[0]] = int(pair.split('-')[1])
+
+    y_true = np.array([item_label[item] for item in y_pred[:k]])
+
+    gains = 2 ** y_true - 1
+    discounts = np.log2(np.arange(len(y_true)) + 2)
+
+    return np.sum(gains / discounts)
+
+
+def compute_ndcg(y_pred, y_true, k):
+    '''
+    y_pred: 排好的item顺序
+    y_true:[item-label]
+    '''
+    # y_true2 作为best的item排序
+    y_true_score = [item.split('-')[1] for item in y_true]
+    order = np.argsort(y_true_score)[::-1]
+    y_true_item = [y_true[index].split('-')[0] for index in order]
+
+    best = compute_dcg(y_true_item, y_true, k)
+    actual = compute_dcg(y_pred, y_true, k)
+    return actual / best
+
+def recsys_metric(recommendations, row_index, news_struuid_ID ):
+    # recommendations {account id (uuid): LIST[Article]}
+    # use the url of Article
+    impressions_truth = pd.read_table("/home/XLL1713/POPROX/engine0/NRMS_bert/data/mind/large/val/behaviors.tsv",
+                                    header='infer',
+                                    usecols=range(5),
+                                    names=[
+                                        'impression_id', 'user', 'time',
+                                        'clicked_news', 'impressions'
+                                    ]).iloc[row_index].impressions.split() # LIST[ID-label]
+
+    account_id = list(recommendations.keys())[0]
+    recommended_list = recommendations[account_id]
+    recommended_list = [news_struuid_ID[item.url] for item in recommended_list]
+
+    single_mrr = compute_mrr(recommended_list, impressions_truth)
+    single_ndcg5 = compute_ndcg(recommended_list, impressions_truth, 5)
+    single_ndcg10 = compute_ndcg(recommended_list, impressions_truth, 10)
+
+    return single_ndcg5, single_ndcg10, single_mrr
+
+if __name__ == '__main__':
+    '''
+    For offline evaluation, set theta in mmr_diversity = 1
+    '''
+    MODEL, DEVICE = load_model()
+    TOKEN_MAPPING = 'distilbert-base-uncased'  # can be modified
+
+    with open('/home/XLL1713/POPROX/poprox-recommender/tests/news_uuid_ID.json', 'r') as json_file:
+        news_struuid_ID = json.load(json_file)
+
+    # load the mind test json file
+    with open('/home/XLL1713/POPROX/poprox-recommender/tests/mind_test.json', 'r') as json_file:
+        mind_data = json.load(json_file)
+
+    ndcg5 = []
+    ndcg10 = []
+    mrr = []
+
+    for impression_idx in range(len(mind_data)): # one by one
+
+        request_body = mind_data[impression_idx]
+
+        todays_articles = [Article.parse_obj(item) for item in request_body["todays_articles"]]
+        past_articles = [Article.parse_obj(item) for item in request_body["past_articles"]]
+
+        click_data = [ClickHistory.parse_obj(request_body["click_data"])]
+
+
+        num_recs = len(todays_articles)
+
+        recommendations = select_articles(
+            todays_articles,
+            past_articles,
+            click_data,
+            MODEL,
+            DEVICE,
+            TOKEN_MAPPING,
+            num_recs,
+        )
+
+        single_ndcg5, single_ndcg10, single_mrr = recsys_metric(recommendations, impression_idx, news_struuid_ID )
+        # recommendations {account id (uuid): LIST[Article]}
+        print(f"----------------evaluation using the first {impression_idx + 1} is ndcg5 = {single_ndcg5}, ndcg10 = {single_ndcg10}, mrr = {single_mrr}")
+
+        ndcg5.append(single_ndcg5)
+        ndcg10.append(single_ndcg10)
+        mrr.append(single_mrr)
+
+
+
+    print(f"Offline evaluation metrics on MIND data: ndcg5 = {np.mean(ndcg5)}, ndcg10 = {np.mean(ndcg10)}, mrr = {np.mean(mrr)}")
+
+
+        #response = {"statusCode": 200, "body": json.dump(body, default=custom_encoder)}
+
+
+
+

--- a/tests/test_data.ipynb
+++ b/tests/test_data.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5fce14df",
+   "metadata": {},
+   "source": [
+    "#### expected test MIND data format\n",
+    "{\n",
+    "\"past_articles\": [\n",
+    "{'article_id': UUID,\n",
+    "\"title\": \"title1\", \n",
+    "\"content\": \"content\",\n",
+    "\"url\": \"url 1\" \n",
+    "}\n",
+    "],\n",
+    "\n",
+    "\"todays_articles\": [\n",
+    "{'article_id': UUID,\n",
+    "\"title\": \"title1\", \n",
+    "\"url\": \"url 1\" \n",
+    "}, \n",
+    "], \n",
+    "\n",
+    "\"click_data\": {\n",
+    "UUID: [list of articel ids]\n",
+    "}\n",
+    "\n",
+    "\"num_recs\": int\n",
+    "\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "43ff30a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "from os import path\n",
+    "import random\n",
+    "import numpy as np\n",
+    "import csv\n",
+    "from ast import literal_eval\n",
+    "import json\n",
+    "from pydantic import BaseModel\n",
+    "from uuid import UUID, uuid4\n",
+    "from datetime import datetime, timezone\n",
+    "from pydantic import BaseModel, UUID4\n",
+    "from typing import List\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "43ae5539",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The total unique uuid is 448494\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 加载original news和behavior 数据\n",
+    "val_behavior_df = pd.read_table(\"/home/XLL1713/POPROX/engine0/NRMS_bert/data/mind/large/val/behaviors.tsv\",\n",
+    "               header='infer',\n",
+    "               usecols=range(5),\n",
+    "               names=[\n",
+    "                   'impression_id', 'user', 'time',\n",
+    "                   'clicked_news', 'impressions'\n",
+    "               ])\n",
+    "\n",
+    "val_behavior_df.fillna('', inplace = True)\n",
+    "\n",
+    "val_news_df = pd.read_table(\"/home/XLL1713/POPROX/engine0/NRMS_bert/data/mind/large/val/news.tsv\", \n",
+    "            header = 'infer', \n",
+    "            usecols = range(4),\n",
+    "            names = ['id', 'topic', 'subtopic', 'title'])\n",
+    "\n",
+    "print(f\"The total unique uuid is {val_behavior_df.shape[0] + val_news_df.shape[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "a6413ebb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 448494 unique uuids are generated\n"
+     ]
+    }
+   ],
+   "source": [
+    "uuids = [uuid4() for _ in range(448494)]\n",
+    "print(f\"There are {len(set(uuids))} unique uuids are generated\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "450a7ae9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 将uuid assign到news id和impression id中\n",
+    "val_news_df['uuid'] = uuids[:val_news_df.shape[0]]\n",
+    "val_news_df['str_uuid'] = val_news_df['uuid'].apply(lambda x: str(x))\n",
+    "\n",
+    "val_behavior_df['uuid'] = uuids[val_news_df.shape[0]:]\n",
+    "val_behavior_df['str_uuid'] = val_behavior_df['uuid'].apply(lambda x: str(x))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "4933c002",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>impression_id</th>\n",
+       "      <th>user</th>\n",
+       "      <th>time</th>\n",
+       "      <th>clicked_news</th>\n",
+       "      <th>impressions</th>\n",
+       "      <th>uuid</th>\n",
+       "      <th>str_uuid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>U134050</td>\n",
+       "      <td>11/15/2019 8:55:22 AM</td>\n",
+       "      <td>N12246 N128820 N119226 N4065 N67770 N33446 N10...</td>\n",
+       "      <td>N91737-0 N30206-0 N54368-0 N117802-0 N18190-0 ...</td>\n",
+       "      <td>cb6630a1-0150-4ef1-b944-de32af2ac598</td>\n",
+       "      <td>cb6630a1-0150-4ef1-b944-de32af2ac598</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   impression_id     user                   time  \\\n",
+       "0              1  U134050  11/15/2019 8:55:22 AM   \n",
+       "\n",
+       "                                        clicked_news  \\\n",
+       "0  N12246 N128820 N119226 N4065 N67770 N33446 N10...   \n",
+       "\n",
+       "                                         impressions  \\\n",
+       "0  N91737-0 N30206-0 N54368-0 N117802-0 N18190-0 ...   \n",
+       "\n",
+       "                                   uuid                              str_uuid  \n",
+       "0  cb6630a1-0150-4ef1-b944-de32af2ac598  cb6630a1-0150-4ef1-b944-de32af2ac598  "
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "val_behavior_df.head(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "a3b5507a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 保存一些数据\n",
+    "ID_title = dict(zip(val_news_df.id, val_news_df.title))\n",
+    "ID_newsuuid = dict(zip(val_news_df.id, val_news_df.uuid))\n",
+    "\n",
+    "news_struuid_ID = dict(zip(val_news_df.str_uuid, val_news_df.id)) # uuid - news id\n",
+    "behavior_struuid_ID = dict(zip(val_behavior_df.str_uuid, val_behavior_df.impression_id)) # uuid - impression id\n",
+    "\n",
+    "with open('./news_uuid_ID.json', 'w') as file:\n",
+    "    json.dump(news_struuid_ID , file, indent=4)\n",
+    "with open('./behavior_uuid_ID.json', 'w') as file:\n",
+    "    json.dump(behavior_struuid_ID , file, indent=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "0110d928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Article(BaseModel):\n",
+    "    article_id: UUID\n",
+    "    title: str\n",
+    "    content: str = \"\"\n",
+    "    url: str\n",
+    "    published_at: datetime = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)\n",
+    "\n",
+    "class ClickHistory(BaseModel):\n",
+    "    account_id: UUID4 = None\n",
+    "    article_id: List[UUID4]\n",
+    "        \n",
+    "def convert_to_Article(data: dict) -> Article:\n",
+    "    if 'published_at' not in data:\n",
+    "        data['published_at'] = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)\n",
+    "    return Article(**data)\n",
+    "\n",
+    "def convert_to_ClickHistory(data):\n",
+    "    return ClickHistory(**data)\n",
+    "\n",
+    "\n",
+    "#print('---',article.model_dump())\n",
+    "#print('---',Article.parse_obj(article.model_dump()))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "21a12b03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_list = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "f0b6cc3c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████| 376471/376471 [03:42<00:00, 1691.49it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# todays_articles (candidates)\n",
+    "# ID_newsuuid \n",
+    "\n",
+    "for i in tqdm(range(val_behavior_df.shape[0])): \n",
+    "    test_json = {}\n",
+    "    test_json['past_articles'] = [] \n",
+    "    test_json['num_recs'] = 10 \n",
+    "    test_json['todays_articles'] = [] # list of json \n",
+    "\n",
+    "\n",
+    "    row = val_behavior_df.iloc[i]\n",
+    "    \n",
+    "    impression_uuid = row.str_uuid\n",
+    "\n",
+    "    for candidate_pair in row.impressions.split(' '): \n",
+    "        single_news = {}\n",
+    "        single_news['article_id'] = ID_newsuuid[candidate_pair.split('-')[0]]\n",
+    "        single_news['url'] = str(ID_newsuuid[candidate_pair.split('-')[0]])\n",
+    "        single_news['title'] = single_news['content'] = ID_title[candidate_pair.split('-')[0]]\n",
+    "        \n",
+    "        single_news = convert_to_Article(single_news)\n",
+    "        single_news = single_news.model_dump()\n",
+    "        test_json['todays_articles'].append(single_news)\n",
+    "        \n",
+    "    \n",
+    "    for article in row.clicked_news.split(): \n",
+    "        single_news = {}\n",
+    "        single_news['article_id'] =  ID_newsuuid[article]\n",
+    "        single_news['url'] = str(ID_newsuuid[article])\n",
+    "        single_news['title'] = single_news['content'] = ID_title[article]\n",
+    "        \n",
+    "        single_news = convert_to_Article(single_news)\n",
+    "        single_news = single_news.model_dump()\n",
+    "        test_json['past_articles'].append(single_news)\n",
+    "    \n",
+    "    click_data = {'account_id': impression_uuid, 'article_id': [ID_newsuuid[id] for id in row.clicked_news.split()]}\n",
+    " \n",
+    "    click_data = convert_to_ClickHistory(click_data) \n",
+    "    \n",
+    "    click_data = click_data.model_dump()\n",
+    "    test_json['click_data'] = click_data\n",
+    "    \n",
+    "\n",
+    "    test_list.append(test_json)\n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "14db9c77",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "376471"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(test_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "a8bd7479",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "def custom_encoder(obj):\n",
+    "    if isinstance(obj, UUID):\n",
+    "        return str(obj)\n",
+    "    elif isinstance(obj, datetime):\n",
+    "        return obj.isoformat()\n",
+    "\n",
+    "with open('./mind_test.json', 'w') as file:\n",
+    "    json.dump(test_list, file, default=custom_encoder, indent=4)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "3de14d74",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "376471\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open('./mind_test.json', 'r') as json_file:\n",
+    "    data_loaded = json.load(json_file)\n",
+    "\n",
+    "print(len(data_loaded))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f5448df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# val_behavior_df[val_behavior_df['impressions'] == 'N29160-0 N25621-0 N122640-1 N46894-0 N54368-0 N18190-0 N55801-0']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5362ba9d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "POPROX",
+   "language": "python",
+   "name": "poprox"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Changes included in this PR:
1. Added `test/test_data.py` to convert MIND test data into the json format utilizing UUIDs, Article and ClickHistory classes.
2. Created `test_json.py` to evaluate the new MIND test data format using the model with tokenizer integration.
3. Fixed the MMR_diversification function.

WIP:
1. Uploading MIND test data and the UUID-ID mapping (generating UUIDs for original user and news IDs) via DVC.