### PR TITLE
Move model and tokenizer loading into initialization for performance

### DIFF
--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -1,27 +1,7 @@
 import json
 
-import torch as th
-from safetensors.torch import load_file
-
 from poprox_concepts import Article, ClickHistory
 from poprox_recommender.default import select_articles
-from poprox_recommender.paths import project_root
-
-
-def load_model(device_name=None):
-    checkpoint = None
-
-    if device_name is None:
-        device_name = "cuda" if th.cuda.is_available() else "cpu"
-
-    load_path = f"{project_root()}/models/model.safetensors"
-
-    checkpoint = load_file(load_path)
-    return checkpoint, device_name
-
-
-MODEL, DEVICE = load_model()
-TOKEN_MAPPING = "distilbert-base-uncased"  # can be modified
 
 
 def generate_recs(event, context):
@@ -42,9 +22,6 @@ def generate_recs(event, context):
         todays_articles,
         past_articles,
         click_data,
-        MODEL,
-        DEVICE,
-        TOKEN_MAPPING,
         num_recs,
     )
 


### PR DESCRIPTION
Since Lambdas stay "warm" for a while and hold things in memory after a request, this makes subsequent calls to generate more recs much faster because they don't have to repeat the work of loading the model and tokenizer.

This also removes model-related code from the handler, which should make it generic across different recommenders, and consolidates it into the recommender code, which limits the number of files experimenters will have to edit.