### PR TITLE
Allow passing algorithm params in as query string parameters

### DIFF
--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from poprox_concepts.api.recommendations import (
     RecommendationRequest,
@@ -6,15 +7,26 @@ from poprox_concepts.api.recommendations import (
 )
 from poprox_recommender.default import select_articles
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
 
 def generate_recs(event, context):
     req = RecommendationRequest.model_validate_json(event["body"])
+
+    algo_params = event.get("queryStringParameters", {})
+
+    if algo_params:
+        logger.info(f"Generating recommendations with parameters: {algo_params}")
+    else:
+        logger.info("Generating recommendations with default parameters")
 
     recommendations = select_articles(
         req.todays_articles,
         req.past_articles,
         req.click_histories,
         req.num_recs,
+        algo_params,
     )
 
     resp_body = RecommendationResponse.model_validate(


### PR DESCRIPTION
This provides a generic way to supply algorithm parameters as part of the request URL across a variety of algorithms. The code in `handler.py` knows nothing about the actual recommender, but still hands off an algorithm specific parameter (theta) that tunes the amount of diversification. (The code in `default.py` is the algorithm-specific part that knows which parameters to look for.)