### PR TITLE
Add CI test to ensure recommender runs directly and with serverless offline

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: docker-dvc-cache-${{ hashFiles('models/**.dvc') }}
+          key: docker-dvc-cache-${{ hashFiles('src/models/**.dvc') }}
 
       - name: Fetch model data
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: docker-dvc-cache-${{ hashFiles('models/**/*.dvc') }}
+          key: docker-dvc-cache-${{ hashFiles('models/**.dvc') }}
 
       - name: Fetch model data
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,6 +23,12 @@ jobs:
         run: |
           pipx install "dvc[s3]==3.*"
 
+      - name: Cache model data
+        uses: actions/cache@v4
+        with:
+          path: .dvc/cache
+          key: dvc-cache-${{ hashFiles('models/**.dvc') }}
+
       - name: Fetch model data
         run: |
           dvc pull -R src/models

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: dvc-cache-${{ hashFiles('models/**.dvc') }}
+          key: docker-dvc-cache-${{ hashFiles('models/**/*.dvc') }}
 
       - name: Fetch model data
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,8 @@ defaults:
     shell: bash -el {0}
 
 jobs:
-  serverless-smoketest:
-    name: Smoke-test the recommender with Serverless Offline
+  run-tests:
+    name: Run the PyTest tests
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +27,7 @@ jobs:
         with:
           environment-file: conda-lock.yml
           environment-name: poprox
-          create-args: --category main --category dev
+          create-args: --category main --category dev --category test
 
       - name: Install Node dependencies
         run: |
@@ -40,8 +40,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
 
-      - name: Start and test Serverless container
+      - name: Run tests
         run: |
-          npx serverless offline start &
-          sleep 2
-          curl -vf -XPOST http://localhost:3000 --data @tests/basic-request.json
+          python -m pytest -v

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           environment-file: conda-lock.yml
           environment-name: poprox
-          create-args: --category dev
+          create-args: --cateogry main --category dev
 
       - name: Install Node dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,12 @@ jobs:
         run: |
           npm ci
 
+      - name: Cache model data
+        uses: actions/cache@v4
+        with:
+          path: .dvc/cache
+          key: dvc-cache-${{ hashFiles('models/**.dvc') }}
+
       - name: Fetch model data
         run: |
           dvc pull -R src/models

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Source Tests
+name: Tests
 
 on:
   push:
@@ -43,4 +43,5 @@ jobs:
       - name: Start and test Serverless container
         run: |
           npx serverless offline start &
+          sleep 2
           curl -vf -XPOST http://localhost:3000 --data @tests/basic-request.json

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           npm ci
 
+      - name: Install recommender package
+        run: |
+          pip install --no-deps -e .
+
       - name: Cache model data
         uses: actions/cache@v4
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: test-dvc-cache-${{ hashFiles('models/**/*.dvc') }}
+          key: test-dvc-cache-${{ hashFiles('models/*.dvc') }}
 
       - name: Fetch model data
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: test-dvc-cache-${{ hashFiles('models/*.dvc') }}
+          key: test-dvc-cache-${{ hashFiles('src/models/**.dvc') }}
 
       - name: Fetch model data
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: dvc-cache-${{ hashFiles('models/**.dvc') }}
+          key: test-dvc-cache-${{ hashFiles('models/**/*.dvc') }}
 
       - name: Fetch model data
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           environment-file: conda-lock.yml
           environment-name: poprox
-          create-args: --cateogry main --category dev
+          create-args: --category main --category dev
 
       - name: Install Node dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,46 @@
+name: Source Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# override default shell for mamba activation
+defaults:
+  run:
+    shell: bash -el {0}
+
+jobs:
+  serverless-smoketest:
+    name: Smoke-test the recommender with Serverless Offline
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: conda-lock.yml
+          environment-name: poprox
+          create-args: --category dev
+
+      - name: Install Node dependencies
+        run: |
+          npm ci
+
+      - name: Fetch model data
+        run: |
+          dvc pull -R src/models
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+
+      - name: Start and test Serverless container
+        run: |
+          npx serverless offline start &
+          curl -vf -XPOST http://localhost:3000 --data @tests/basic-request.json

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ conda activate poprox-recsys
 If you use `micromamba` instead of a full Conda installation, it can directly use the lockfile:
 
 ```console
-micromamba create -n poprox-recs -f conda-lock.yml --category dev
+micromamba create -n poprox-recs -f conda-lock.yml --category main --category dev
 ```
 
 Set up `pre-commit` to make sure that code formatting rules are applied as you make changes:

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -15,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    win-64: 3fff14af7a2b604d3f5af87c368a50ac073bba5244ee1c8d0465059732f81340
-    linux-64: 56ca3ab160eaac85dedc8711256b4c6a362dfe72a7e507f7478cad02d2c5f27a
-    osx-arm64: 8cd1a138f0524cc67c6d7bd1f206766f51e275fec14c179459cec48104691f57
+    win-64: ba6c7ce3da6dc2f431e12f9d793b070097df37fc3750830389f00cb53ca70d03
+    linux-64: 0ea25337871378e8b2e55111b2770e0a6e6ddfbbddb3ea9d45915bf059a4516a
+    osx-arm64: 3359e9440e37a2121c57091d0226d1eaf5b95eaf7886aee24a060cb3108bf265
   channels:
   - url: pytorch
     used_env_vars: []
@@ -10527,6 +10527,45 @@ package:
     sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
   category: main
   optional: false
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ptyprocess: '>=0.5'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    ptyprocess: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+    ptyprocess: '>=0.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: dev
+  optional: true
 - name: pillow
   version: 10.3.0
   manager: conda
@@ -11005,6 +11044,42 @@ package:
     sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
   category: main
   optional: false
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: dev
+  optional: true
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: dev
+  optional: true
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: dev
+  optional: true
 - name: pyarrow
   version: 16.1.0
   manager: conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 # this is sub-optimal for various reasons, but it's the best way with conda-lock
 dev = ["dvc[s3]==3.*", "docopt>=0.6", "requests~=2.31", "pre-commit>=3.7,<4"]
+test = ["pexpect~=4.9"]
 
 [project.urls]
 Documentation = "https://github.com/CCRI-POPROX/poprox-recommender#readme"
@@ -42,7 +43,12 @@ allow-direct-references = true
 path = "src/poprox_recommender/__about__.py"
 
 [tool.hatch.envs.default]
-dependencies = ["coverage[toml]>=6.5", "pytest>=8"]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest>=8",
+  "pexpect~=4.9",
+  "requests~=2.13",
+]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"

--- a/tests/test_pfar.py
+++ b/tests/test_pfar.py
@@ -12,6 +12,13 @@ from poprox_concepts import Article, ClickHistory
 from poprox_recommender.default import select_articles, user_topic_preference
 from poprox_recommender.topics import extract_general_topic, general_topics, match_news_topics_to_general
 
+try:
+    import pytest
+
+    pytestmark = pytest.mark.skip("not a test module")
+except ImportError:
+    pass
+
 
 def load_test_articles():
     event_path = "/home/sun00587/research/POPROX/poprox-recommender/tests/request_body.json"  # update when the model path func is ready  # noqa: E501

--- a/tests/test_serverless_offline.py
+++ b/tests/test_serverless_offline.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from threading import Condition, Lock, Thread
 
 import requests
-from pexpect import EOF, mark, spawn
-from pytest import fail, fixture
+from pexpect import EOF, spawn
+from pytest import fail, fixture, mark
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_serverless_offline.py
+++ b/tests/test_serverless_offline.py
@@ -1,0 +1,64 @@
+"""
+Test the POPROX endpoint running under Serverless Offline.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from threading import Condition, Lock, Thread
+
+import requests
+from pexpect import EOF, mark, spawn
+from pytest import fail, fixture
+
+logger = logging.getLogger(__name__)
+
+
+@fixture(scope="module")
+def sl_listener():
+    """
+    Fixture that starts and stops serverless offline to test endpoint responses.
+    """
+
+    thread = ServerlessBackground()
+    thread.start()
+    try:
+        with thread.lock:
+            if thread.ready.wait(10):
+                logger.info("ready for tests")
+                yield
+            else:
+                fail("serverless timed out")
+    finally:
+        thread.proc.sendintr()
+
+
+class ServerlessBackground(Thread):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lock = Lock()
+        self.ready = Condition(self.lock)
+
+    def run(self):
+        logger.info("starting serverless")
+        self.proc = spawn("npx serverless offline start", logfile=sys.stdout.buffer)
+        self.proc.expect(r"Server ready:")
+        logger.info("server ready")
+        with self.lock:
+            self.ready.notify_all()
+        self.proc.expect(EOF)
+
+
+@mark.serverless
+def test_basic_request(sl_listener):
+    test_dir = Path(__file__)
+    req_f = test_dir.parent / "basic-request.json"
+    req_body = req_f.read_text()
+
+    logger.info("sending request")
+    res = requests.post("http://localhost:3000", req_body)
+    assert res.status_code == 200
+    logger.info("response: %s", res.text)
+    body = res.json()
+    assert "recommendations" in body
+    assert len(body["recommendations"]) > 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,27 @@
+"""
+Test the POPROX API through direct call.
+"""
+
+import logging
+from pathlib import Path
+
+from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_recommender.default import select_articles
+
+logger = logging.getLogger(__name__)
+
+
+def test_direct_basic_request():
+    test_dir = Path(__file__)
+    req_f = test_dir.parent / "basic-request.json"
+    req = RecommendationRequest.model_validate_json(req_f.read_text())
+
+    logger.info("generating recommendations")
+    recs = select_articles(
+        req.todays_articles,
+        req.past_articles,
+        req.click_histories,
+        req.num_recs,
+    )
+    # do we get recommendations?
+    assert len(recs) > 0


### PR DESCRIPTION
Adds PyTest tests to CI, and uses pytest to implement a version of the smoketest with both direct Python API calls and using `serverless offline start` to make sure that we don't break the local dev workflow in addition to the Docker image workflow.

It also uses the `actions/cache` action to cache the model data so we don't hit our S3 bucket so often.