### PR TITLE
Use `pathlib` for paths instead of strings for Windows compatibility

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -46,7 +46,7 @@ def load_checkpoint(device_name=None):
         # device_name = "cuda" if th.cuda.is_available() else "cpu"
         device_name = "cpu"
 
-    load_path = f"{src_dir()}/models/model.safetensors"
+    load_path = src_dir() / "models" / "model.safetensors"
 
     checkpoint = load_file(load_path)
     return checkpoint, device_name

--- a/src/poprox_recommender/test_offline.py
+++ b/src/poprox_recommender/test_offline.py
@@ -20,7 +20,7 @@ def load_model(device_name=None):
     if device_name is None:
         device_name = "cuda" if th.cuda.is_available() else "cpu"
 
-    load_path = f"{src_dir()}/models/model.safetensors"
+    load_path = src_dir() / "models" / "model.safetensors"
     checkpoint = load_file(load_path)
 
     return checkpoint, device_name
@@ -36,7 +36,7 @@ def recsys_metric(recommendations, row_index, news_struuid_ID):
     # use the url of Article
     impressions_truth = (
         pd.read_table(
-            f"{src_dir()}/data/test_mind_large/behaviors.tsv",
+            src_dir() / "data" / "test_mind_large" / "behaviors.tsv",
             header="infer",
             usecols=range(5),
             names=["impression_id", "user", "time", "clicked_news", "impressions"],
@@ -69,11 +69,11 @@ if __name__ == "__main__":
     MODEL, DEVICE = load_model()
     TOKEN_MAPPING = "distilbert-base-uncased"  # can be modified
 
-    with open(f"{src_dir()}/data/val_mind_large/news_uuid_ID.json") as json_file:
+    with open(src_dir() / "data" / "val_mind_large" / " news_uuid_ID.json") as json_file:
         news_struuid_ID = json.load(json_file)
 
     # load the mind test json file
-    with open(f"{src_dir()}/data/val_mind_large/mind_test.json") as json_file:
+    with open(src_dir() / "data" / "val_mind_large" / "mind_test.json") as json_file:
         mind_data = json.load(json_file)
 
     ndcg5 = []


### PR DESCRIPTION
Although this still looks like it uses forward slashes, that's just `pathlib`'s way of saying "path separator," and it will translate them to the appropriate backslashes on Windows.