### PR TITLE
Switch to yamlfmt for YAML formatting in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.12.1
+    hooks:
+      - id: yamlfmt
+        name: format yaml files
+        exclude: conda-lock.yml
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.4.8
@@ -30,12 +36,3 @@ repos:
         language: node
         additional_dependencies:
           - "@taplo/cli"
-      - id: format-yaml-files
-        name: yaml-format
-        files: \.ya?ml$
-        exclude: conda-lock.yml
-        entry: prettier
-        args: [-w]
-        language: node
-        additional_dependencies:
-          - prettier

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,3 @@
+formatter:
+  type: basic
+  retain_line_breaks_single: true

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,6 +49,5 @@ package:
     - "**.py"
     - "**.html"
 
-functions:
-  # if offline mode enabled filePrefix = 'offline.' else filePrefix = ''
-  ${file(./serverless/${self:custom.offline.filePrefix}functions.yaml):functions}
+# if offline mode enabled filePrefix = 'offline.' else filePrefix = ''
+functions: ${file(./serverless/${self:custom.offline.filePrefix}functions.yaml):functions}


### PR DESCRIPTION
This switches our pre-commit YAML formatting to use `yamlfmt` instead of writing our own hook around Prettier in the pre-commit config. Only one file has formatting changes.