### PR TITLE
Refactor Conda dependency specifications

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+# override default shell for mamba activation
+defaults:
+  run:
+    shell: bash -el {0}
+
 jobs:
   test-docker:
     name: Build and test Docker image
@@ -17,11 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install DVC
-        # to fetch things, all we need is DVC, so just use pipx
-        # saves the time of installing a whole environment
-        run: |
-          pipx install "dvc[s3]==3.*"
+      - name: Install tooling
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: conda-lock.yml
+          environment-name: poprox
+          # we *don't* need --category main — only dev deps are needed
+          create-args: --category dev
 
       - name: Cache model data
         uses: actions/cache@v4
@@ -46,7 +53,7 @@ jobs:
 
       - name: Submit test request
         run: |
-          pipx run ./tests/test-docker-lambda.py
+          python ./tests/test-docker-lambda.py
 
       - name: Dump Docker logs
         if: always()

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Install tooling
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: conda-lock.yml
+          # directly use the environment because we only need tooling
+          environment-file: dev/environment.yml
           environment-name: poprox
-          # we *don't* need --category main — only dev deps are needed
-          create-args: --category dev
 
       - name: Cache model data
         uses: actions/cache@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           environment-file: conda-lock.yml
           environment-name: poprox
-          create-args: --category main --category dev --category test
+          create-args: --category main --category dev
 
       - name: Install Node dependencies
         run: |

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -11,13 +11,13 @@
 # To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock  --lockfile conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
-#     conda-lock -f pyproject.toml --lockfile conda-lock.yml
+#     conda-lock -f pyproject.toml -f dev/constraints.yml -f dev/environment.yml --lockfile conda-lock.yml
 version: 1
 metadata:
   content_hash:
-    win-64: ba6c7ce3da6dc2f431e12f9d793b070097df37fc3750830389f00cb53ca70d03
-    linux-64: 0ea25337871378e8b2e55111b2770e0a6e6ddfbbddb3ea9d45915bf059a4516a
-    osx-arm64: 3359e9440e37a2121c57091d0226d1eaf5b95eaf7886aee24a060cb3108bf265
+    win-64: 6c39a44d5438e1d79a4ac8a3e8c23955965213027b7de274e4a3396f9c549f2d
+    linux-64: 1d9d1e71aad10c004459c5d8d5fb9bd9122069605cdd1b2a6051985b0cc81d1b
+    osx-arm64: 3abb80be54e0525ff04b6ec2344661ed714e6733003e259d9851727a0d8e222c
   channels:
   - url: pytorch
     used_env_vars: []
@@ -29,6 +29,8 @@ metadata:
   - win-64
   sources:
   - pyproject.toml
+  - dev/constraints.yml
+  - dev/environment.yml
 package:
 - name: _libgcc_mutex
   version: '0.1'
@@ -47,11 +49,11 @@ package:
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-    llvm-openmp: '>=9.0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
-    md5: 562b26ba2e19059551a811e72ab7f793
-    sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
+    md5: 73aaf86a425cc6e73fcf236a5a46396d
+    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   category: main
   optional: false
 - name: aiobotocore
@@ -68,8 +70,8 @@ package:
   hash:
     md5: c1ba7be2b8a71c6a9de23402a5810ea2
     sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aiobotocore
   version: 2.13.0
   manager: conda
@@ -84,8 +86,8 @@ package:
   hash:
     md5: c1ba7be2b8a71c6a9de23402a5810ea2
     sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aiobotocore
   version: 2.13.0
   manager: conda
@@ -100,8 +102,8 @@ package:
   hash:
     md5: c1ba7be2b8a71c6a9de23402a5810ea2
     sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aiohttp
   version: 3.9.5
   manager: conda
@@ -171,8 +173,8 @@ package:
   hash:
     md5: 63075586964c3e0d53e1a8d804d89090
     sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aiohttp-retry
   version: 2.8.3
   manager: conda
@@ -184,8 +186,8 @@ package:
   hash:
     md5: 63075586964c3e0d53e1a8d804d89090
     sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aiohttp-retry
   version: 2.8.3
   manager: conda
@@ -197,8 +199,8 @@ package:
   hash:
     md5: 63075586964c3e0d53e1a8d804d89090
     sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aioitertools
   version: 0.11.0
   manager: conda
@@ -210,8 +212,8 @@ package:
   hash:
     md5: 59c40397276a286241c65faec5e1be3c
     sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aioitertools
   version: 0.11.0
   manager: conda
@@ -223,8 +225,8 @@ package:
   hash:
     md5: 59c40397276a286241c65faec5e1be3c
     sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aioitertools
   version: 0.11.0
   manager: conda
@@ -236,8 +238,8 @@ package:
   hash:
     md5: 59c40397276a286241c65faec5e1be3c
     sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: aiosignal
   version: 1.3.1
   manager: conda
@@ -288,8 +290,8 @@ package:
   hash:
     md5: 23e198e6df09c2c441640f1bcd1c7822
     sha256: d445abfa5580fc4978eae39dd9268379cc6cffdb630108b38b03f0032899bc63
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: amqp
   version: 5.2.0
   manager: conda
@@ -301,8 +303,8 @@ package:
   hash:
     md5: 23e198e6df09c2c441640f1bcd1c7822
     sha256: d445abfa5580fc4978eae39dd9268379cc6cffdb630108b38b03f0032899bc63
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: amqp
   version: 5.2.0
   manager: conda
@@ -314,8 +316,8 @@ package:
   hash:
     md5: 23e198e6df09c2c441640f1bcd1c7822
     sha256: d445abfa5580fc4978eae39dd9268379cc6cffdb630108b38b03f0032899bc63
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -327,8 +329,8 @@ package:
   hash:
     md5: 7e9f4612544c8edbfd6afad17f1bd045
     sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -340,8 +342,8 @@ package:
   hash:
     md5: 7e9f4612544c8edbfd6afad17f1bd045
     sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -353,8 +355,8 @@ package:
   hash:
     md5: 7e9f4612544c8edbfd6afad17f1bd045
     sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: antlr-python-runtime
   version: 4.9.3
   manager: conda
@@ -365,8 +367,8 @@ package:
   hash:
     md5: c88eaec8de9ae1fa161205aa18e7a5b1
     sha256: b91f8ab4ac2b48972fbee1fc8e092cc452fdf59156e4ff2322c94bbf73650f94
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: antlr-python-runtime
   version: 4.9.3
   manager: conda
@@ -377,8 +379,8 @@ package:
   hash:
     md5: c88eaec8de9ae1fa161205aa18e7a5b1
     sha256: b91f8ab4ac2b48972fbee1fc8e092cc452fdf59156e4ff2322c94bbf73650f94
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: antlr-python-runtime
   version: 4.9.3
   manager: conda
@@ -389,8 +391,8 @@ package:
   hash:
     md5: c88eaec8de9ae1fa161205aa18e7a5b1
     sha256: b91f8ab4ac2b48972fbee1fc8e092cc452fdf59156e4ff2322c94bbf73650f94
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: anyconfig
   version: 0.14.0
   manager: conda
@@ -430,6 +432,54 @@ package:
     sha256: ae29de72b8e0b8fefb8d2778b29f7cee0a01ba99691c5e353f0843274365008b
   category: main
   optional: false
+- name: anyio
+  version: 4.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  category: dev
+  optional: true
+- name: anyio
+  version: 4.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+    idna: '>=2.8'
+    exceptiongroup: '>=1.0.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  category: dev
+  optional: true
+- name: anyio
+  version: 4.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+    idna: '>=2.8'
+    exceptiongroup: '>=1.0.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  category: dev
+  optional: true
 - name: appdirs
   version: 1.4.4
   manager: conda
@@ -440,8 +490,8 @@ package:
   hash:
     md5: 5f095bc6454094e96f146491fd03633b
     sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: appdirs
   version: 1.4.4
   manager: conda
@@ -452,8 +502,8 @@ package:
   hash:
     md5: 5f095bc6454094e96f146491fd03633b
     sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: appdirs
   version: 1.4.4
   manager: conda
@@ -464,8 +514,8 @@ package:
   hash:
     md5: 5f095bc6454094e96f146491fd03633b
     sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: asyncssh
   version: 2.14.1
   manager: conda
@@ -480,8 +530,8 @@ package:
   hash:
     md5: a88675dc80fa5b2d082fca1cc2a804c5
     sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: asyncssh
   version: 2.14.1
   manager: conda
@@ -496,8 +546,8 @@ package:
   hash:
     md5: a88675dc80fa5b2d082fca1cc2a804c5
     sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: asyncssh
   version: 2.14.1
   manager: conda
@@ -512,8 +562,8 @@ package:
   hash:
     md5: a88675dc80fa5b2d082fca1cc2a804c5
     sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: atk-1.0
   version: 2.38.0
   manager: conda
@@ -526,8 +576,8 @@ package:
   hash:
     md5: f730d54ba9cd543666d7220c9f7ed563
     sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: atk-1.0
   version: 2.38.0
   manager: conda
@@ -541,8 +591,8 @@ package:
   hash:
     md5: 57301986d02d30d6805fdce6c99074ee
     sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: atpublic
   version: 3.0.1
   manager: conda
@@ -553,8 +603,8 @@ package:
   hash:
     md5: 39904aaf8de88f03fe9c27286dc35681
     sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: atpublic
   version: 3.0.1
   manager: conda
@@ -565,8 +615,8 @@ package:
   hash:
     md5: 39904aaf8de88f03fe9c27286dc35681
     sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: atpublic
   version: 3.0.1
   manager: conda
@@ -577,8 +627,8 @@ package:
   hash:
     md5: 39904aaf8de88f03fe9c27286dc35681
     sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: attrs
   version: 23.2.0
   manager: conda
@@ -1255,8 +1305,8 @@ package:
   hash:
     md5: 54ca2e08b3220c148a1d8329c2678e02
     sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports
   version: '1.0'
   manager: conda
@@ -1267,8 +1317,8 @@ package:
   hash:
     md5: 54ca2e08b3220c148a1d8329c2678e02
     sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports
   version: '1.0'
   manager: conda
@@ -1279,8 +1329,8 @@ package:
   hash:
     md5: 54ca2e08b3220c148a1d8329c2678e02
     sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports.tarfile
   version: 1.0.0
   manager: conda
@@ -1292,8 +1342,8 @@ package:
   hash:
     md5: c747b1d79f136013c3b7ebcba876afa6
     sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports.tarfile
   version: 1.0.0
   manager: conda
@@ -1305,8 +1355,8 @@ package:
   hash:
     md5: c747b1d79f136013c3b7ebcba876afa6
     sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports.tarfile
   version: 1.0.0
   manager: conda
@@ -1318,8 +1368,8 @@ package:
   hash:
     md5: c747b1d79f136013c3b7ebcba876afa6
     sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports.zoneinfo
   version: 0.2.1
   manager: conda
@@ -1331,8 +1381,8 @@ package:
   hash:
     md5: 5384590f14dfe6ccd02811236afc9f8e
     sha256: 1708c5e6729567f30ccde7761492cb43ee72fa2f7d5065b9102785278718505b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports.zoneinfo
   version: 0.2.1
   manager: conda
@@ -1344,8 +1394,8 @@ package:
   hash:
     md5: acbef984789bc78fc49cca2e736b8006
     sha256: a1cdbc446ff4db99e9e39b73b1611932dc9c5111ecd90dd131fa6fdf62de904d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: backports.zoneinfo
   version: 0.2.1
   manager: conda
@@ -1357,8 +1407,8 @@ package:
   hash:
     md5: 6784cf61285ebc6d3772d9a51d9982eb
     sha256: 30d71fe787342045a7a1896835627c0ed0a1a8b796a497d63b0d36b31a84b7e7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: billiard
   version: 4.2.0
   manager: conda
@@ -1371,8 +1421,8 @@ package:
   hash:
     md5: d408435aabfb23b364dcca868386cf0b
     sha256: fc947afbd0eb61ac2e98195ae26a1b43b89ffb91b71c43cb0db7b52f131bc60c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: billiard
   version: 4.2.0
   manager: conda
@@ -1384,8 +1434,8 @@ package:
   hash:
     md5: d2100bf5626206fdfb56b2a92423bc53
     sha256: e70cbec50b46109f00fdd1b45cef33c4edb908ede67534fe6aaa0033d4f9217b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: billiard
   version: 4.2.0
   manager: conda
@@ -1400,8 +1450,8 @@ package:
   hash:
     md5: c2023bec2510422052ce8cfc484f0f62
     sha256: 8c3432023fe40cfa8c69d00855996403902dea0562cff298f28e2216c6be86f0
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: binpickle
   version: 0.3.4
   manager: conda
@@ -1445,18 +1495,6 @@ package:
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
     sha256: 409dd557027a01d3c1be325fa34b0104fb1a0842e9eea90bf03decc77d08b361
-  category: main
-  optional: false
-- name: blas
-  version: '1.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    mkl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-1.0-mkl.tar.bz2
-  hash:
-    md5: 349aef876b1d8c9dccae01de20d5b385
-    sha256: a9a9125029a66905fc9e932dfd4f595be3a59a30db37fd7bf4a675a5c6151d62
   category: main
   optional: false
 - name: blas
@@ -1576,8 +1614,8 @@ package:
     pyyaml: '>=3.10'
     pandas: '>=1.2'
     pillow: '>=7.1.0'
-    packaging: '>=16.8'
     jinja2: '>=2.9'
+    packaging: '>=16.8'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
     contourpy: '>=1.2'
@@ -1597,8 +1635,8 @@ package:
     pyyaml: '>=3.10'
     pandas: '>=1.2'
     pillow: '>=7.1.0'
-    packaging: '>=16.8'
     jinja2: '>=2.9'
+    packaging: '>=16.8'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
     contourpy: '>=1.2'
@@ -1621,8 +1659,8 @@ package:
   hash:
     md5: 190a8f3c28a2c6047dcca712eca663b1
     sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: boto3
   version: 1.34.106
   manager: conda
@@ -1636,8 +1674,8 @@ package:
   hash:
     md5: 190a8f3c28a2c6047dcca712eca663b1
     sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: boto3
   version: 1.34.106
   manager: conda
@@ -1651,8 +1689,8 @@ package:
   hash:
     md5: 190a8f3c28a2c6047dcca712eca663b1
     sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: botocore
   version: 1.34.106
   manager: conda
@@ -1666,8 +1704,8 @@ package:
   hash:
     md5: ff7f42537b4f054b10b4d02732e10ab8
     sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: botocore
   version: 1.34.106
   manager: conda
@@ -1681,8 +1719,8 @@ package:
   hash:
     md5: ff7f42537b4f054b10b4d02732e10ab8
     sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: botocore
   version: 1.34.106
   manager: conda
@@ -1696,8 +1734,8 @@ package:
   hash:
     md5: ff7f42537b4f054b10b4d02732e10ab8
     sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: brotli-python
   version: 1.1.0
   manager: conda
@@ -1862,8 +1900,8 @@ package:
   hash:
     md5: a661c39e223bf3038b38126b0bbf43d9
     sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachecontrol
   version: 0.14.0
   manager: conda
@@ -1876,8 +1914,8 @@ package:
   hash:
     md5: a661c39e223bf3038b38126b0bbf43d9
     sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachecontrol
   version: 0.14.0
   manager: conda
@@ -1890,8 +1928,8 @@ package:
   hash:
     md5: a661c39e223bf3038b38126b0bbf43d9
     sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachecontrol-with-filecache
   version: 0.14.0
   manager: conda
@@ -1904,8 +1942,8 @@ package:
   hash:
     md5: 4c08fa6e7d1d3f124ad815e21b2210e9
     sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachecontrol-with-filecache
   version: 0.14.0
   manager: conda
@@ -1918,8 +1956,8 @@ package:
   hash:
     md5: 4c08fa6e7d1d3f124ad815e21b2210e9
     sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachecontrol-with-filecache
   version: 0.14.0
   manager: conda
@@ -1932,8 +1970,8 @@ package:
   hash:
     md5: 4c08fa6e7d1d3f124ad815e21b2210e9
     sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachy
   version: 0.3.0
   manager: conda
@@ -1944,8 +1982,8 @@ package:
   hash:
     md5: 5dfee17f24e2dfd18d7392b48c9351e2
     sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachy
   version: 0.3.0
   manager: conda
@@ -1956,8 +1994,8 @@ package:
   hash:
     md5: 5dfee17f24e2dfd18d7392b48c9351e2
     sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cachy
   version: 0.3.0
   manager: conda
@@ -1968,8 +2006,8 @@ package:
   hash:
     md5: 5dfee17f24e2dfd18d7392b48c9351e2
     sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cairo
   version: 1.18.0
   manager: conda
@@ -1996,8 +2034,8 @@ package:
   hash:
     md5: f907bb958910dc404647326ca80c263e
     sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cairo
   version: 1.18.0
   manager: conda
@@ -2018,8 +2056,8 @@ package:
   hash:
     md5: 3fa6eebabb77f65e82f86b72b95482db
     sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cairo
   version: 1.18.0
   manager: conda
@@ -2041,8 +2079,8 @@ package:
   hash:
     md5: b3fe2c6381ec74afe8128e16a11eee02
     sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: celery
   version: 5.3.6
   manager: conda
@@ -2064,8 +2102,8 @@ package:
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
     sha256: bafedd098b75f9baf88167e9bbbbd687fbbc0b06b1a056bdb3bf16221e329def
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: celery
   version: 5.3.6
   manager: conda
@@ -2087,8 +2125,8 @@ package:
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
     sha256: bafedd098b75f9baf88167e9bbbbd687fbbc0b06b1a056bdb3bf16221e329def
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: celery
   version: 5.3.6
   manager: conda
@@ -2110,8 +2148,8 @@ package:
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
     sha256: bafedd098b75f9baf88167e9bbbbd687fbbc0b06b1a056bdb3bf16221e329def
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: certifi
   version: 2024.6.2
   manager: conda
@@ -2319,8 +2357,8 @@ package:
   hash:
     md5: 7c2b6931f9b3548ed78478332095c3e9
     sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-default-group
   version: 1.2.4
   manager: conda
@@ -2332,8 +2370,8 @@ package:
   hash:
     md5: 7c2b6931f9b3548ed78478332095c3e9
     sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-default-group
   version: 1.2.4
   manager: conda
@@ -2345,8 +2383,8 @@ package:
   hash:
     md5: 7c2b6931f9b3548ed78478332095c3e9
     sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-didyoumean
   version: 0.3.1
   manager: conda
@@ -2358,8 +2396,8 @@ package:
   hash:
     md5: ab1b094a8471e571b95c208bde719a4a
     sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-didyoumean
   version: 0.3.1
   manager: conda
@@ -2371,8 +2409,8 @@ package:
   hash:
     md5: ab1b094a8471e571b95c208bde719a4a
     sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-didyoumean
   version: 0.3.1
   manager: conda
@@ -2384,8 +2422,8 @@ package:
   hash:
     md5: ab1b094a8471e571b95c208bde719a4a
     sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-plugins
   version: 1.1.1
   manager: conda
@@ -2397,8 +2435,8 @@ package:
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
     sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-plugins
   version: 1.1.1
   manager: conda
@@ -2410,8 +2448,8 @@ package:
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
     sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-plugins
   version: 1.1.1
   manager: conda
@@ -2423,8 +2461,8 @@ package:
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
     sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-repl
   version: 0.3.0
   manager: conda
@@ -2438,8 +2476,8 @@ package:
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
     sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-repl
   version: 0.3.0
   manager: conda
@@ -2453,8 +2491,8 @@ package:
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
     sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: click-repl
   version: 0.3.0
   manager: conda
@@ -2468,8 +2506,8 @@ package:
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
     sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: clikit
   version: 0.6.2
   manager: conda
@@ -2482,8 +2520,8 @@ package:
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
     sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: clikit
   version: 0.6.2
   manager: conda
@@ -2496,8 +2534,8 @@ package:
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
     sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: clikit
   version: 0.6.2
   manager: conda
@@ -2510,8 +2548,8 @@ package:
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
     sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cloudpickle
   version: 3.0.0
   manager: conda
@@ -2618,8 +2656,8 @@ package:
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
     sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: conda-lock
   version: 2.5.7
   manager: conda
@@ -2654,8 +2692,8 @@ package:
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
     sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: conda-lock
   version: 2.5.7
   manager: conda
@@ -2690,8 +2728,8 @@ package:
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
     sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: configobj
   version: 5.0.8
   manager: conda
@@ -2703,8 +2741,8 @@ package:
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
     sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: configobj
   version: 5.0.8
   manager: conda
@@ -2716,8 +2754,8 @@ package:
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
     sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: configobj
   version: 5.0.8
   manager: conda
@@ -2729,8 +2767,8 @@ package:
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
     sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: contourpy
   version: 1.2.1
   manager: conda
@@ -2792,8 +2830,8 @@ package:
   hash:
     md5: 543dd05fd661e4e9c9deb3b37093d6a2
     sha256: 88e0063cf333147890aafacc2f87360867991241af827a111d97433b7055691e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: coverage
   version: 7.5.3
   manager: conda
@@ -2807,8 +2845,8 @@ package:
   hash:
     md5: 402a8b40b9c9423f40a32be066b467be
     sha256: dcdfa3b24affe7399654f2e8429c15e05a54b8cce32583263a0731c37b62dcbc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: coverage
   version: 7.5.3
   manager: conda
@@ -2824,8 +2862,8 @@ package:
   hash:
     md5: eead686af955162027fb5825e83a3131
     sha256: 16b1692a5ea5254842267e3f66489ecc009ff0d63c0d02148d756e32495c0947
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: crashtest
   version: 0.4.1
   manager: conda
@@ -2836,8 +2874,8 @@ package:
   hash:
     md5: 709a2295dd907bb34afb57d54320642f
     sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: crashtest
   version: 0.4.1
   manager: conda
@@ -2848,8 +2886,8 @@ package:
   hash:
     md5: 709a2295dd907bb34afb57d54320642f
     sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: crashtest
   version: 0.4.1
   manager: conda
@@ -2860,8 +2898,8 @@ package:
   hash:
     md5: 709a2295dd907bb34afb57d54320642f
     sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cryptography
   version: 42.0.8
   manager: conda
@@ -2876,8 +2914,8 @@ package:
   hash:
     md5: 962bcc96f59a31b62c43ac2b306812af
     sha256: 887557c1cc5083f68e531ffe98bb95e0ea2e99fb36f9d12f7f66c4cad2de7502
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cryptography
   version: 42.0.8
   manager: conda
@@ -2892,8 +2930,8 @@ package:
   hash:
     md5: 167cc1ddd4e8afab3959811dabaa79d8
     sha256: 3dd780ec2a637e8fa1095111cbf0b4ff13e9d01c2d81aa1b5b8f8ad2186873c5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: cryptography
   version: 42.0.8
   manager: conda
@@ -2910,8 +2948,8 @@ package:
   hash:
     md5: df7b0031f07fe3a35892fbad84b62ea0
     sha256: c422f83400092c9764d28f8551787bb1e8c0a3077ff665da324e88e168d1eb18
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: csr
   version: 0.5.2
   manager: conda
@@ -3013,15 +3051,15 @@ package:
   category: main
   optional: false
 - name: dask
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: linux-64
   dependencies:
     bokeh: '>=2.4.2,!=3.0.*'
     cytoolz: '>=0.11.0'
-    dask-core: '>=2024.5.2,<2024.5.3.0a0'
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
     dask-expr: '>=1.1,<1.2'
-    distributed: '>=2024.5.2,<2024.5.3.0a0'
+    distributed: '>=2024.6.0,<2024.6.1.0a0'
     jinja2: '>=2.10.3'
     lz4: '>=4.3.2'
     numpy: '>=1.21'
@@ -3029,14 +3067,14 @@ package:
     pyarrow: '>=7.0'
     pyarrow-hotfix: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6bb2c18b838161e550a30de0fdff6993
-    sha256: d2aee458f58253629c23905342daab9317a74b51241f284fe80aedee19f4a01a
+    md5: 706801e668da4c74e7a06a911d5abdfd
+    sha256: 24b9c04fe195edb3cedeffa36f8f657a552cc1f1706374e57ed346a7916f8a39
   category: main
   optional: false
 - name: dask
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3050,16 +3088,16 @@ package:
     cytoolz: '>=0.11.0'
     bokeh: '>=2.4.2,!=3.0.*'
     dask-expr: '>=1.1,<1.2'
-    dask-core: '>=2024.5.2,<2024.5.3.0a0'
-    distributed: '>=2024.5.2,<2024.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.5.2-pyhd8ed1ab_0.conda
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
+    distributed: '>=2024.6.0,<2024.6.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6bb2c18b838161e550a30de0fdff6993
-    sha256: d2aee458f58253629c23905342daab9317a74b51241f284fe80aedee19f4a01a
+    md5: 706801e668da4c74e7a06a911d5abdfd
+    sha256: 24b9c04fe195edb3cedeffa36f8f657a552cc1f1706374e57ed346a7916f8a39
   category: main
   optional: false
 - name: dask
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: win-64
   dependencies:
@@ -3073,16 +3111,16 @@ package:
     cytoolz: '>=0.11.0'
     bokeh: '>=2.4.2,!=3.0.*'
     dask-expr: '>=1.1,<1.2'
-    dask-core: '>=2024.5.2,<2024.5.3.0a0'
-    distributed: '>=2024.5.2,<2024.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.5.2-pyhd8ed1ab_0.conda
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
+    distributed: '>=2024.6.0,<2024.6.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 6bb2c18b838161e550a30de0fdff6993
-    sha256: d2aee458f58253629c23905342daab9317a74b51241f284fe80aedee19f4a01a
+    md5: 706801e668da4c74e7a06a911d5abdfd
+    sha256: 24b9c04fe195edb3cedeffa36f8f657a552cc1f1706374e57ed346a7916f8a39
   category: main
   optional: false
 - name: dask-core
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3095,14 +3133,14 @@ package:
     python: '>=3.9'
     pyyaml: '>=5.3.1'
     toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1a57a819915e1c169b74933720b138f2
-    sha256: dfa55fbb760b668a01de676cc86f8d39c8ad31a0f89881596cd43880c327b411
+    md5: edf709967712b2953ab4189256266adc
+    sha256: c27668dc802b67588d32da4d2f19833ad815bd39457f375f228f2bfae08bc13d
   category: main
   optional: false
 - name: dask-core
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3115,14 +3153,14 @@ package:
     partd: '>=1.2.0'
     importlib_metadata: '>=4.13.0'
     fsspec: '>=2021.09.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1a57a819915e1c169b74933720b138f2
-    sha256: dfa55fbb760b668a01de676cc86f8d39c8ad31a0f89881596cd43880c327b411
+    md5: edf709967712b2953ab4189256266adc
+    sha256: c27668dc802b67588d32da4d2f19833ad815bd39457f375f228f2bfae08bc13d
   category: main
   optional: false
 - name: dask-core
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: win-64
   dependencies:
@@ -3135,92 +3173,91 @@ package:
     partd: '>=1.2.0'
     importlib_metadata: '>=4.13.0'
     fsspec: '>=2021.09.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1a57a819915e1c169b74933720b138f2
-    sha256: dfa55fbb760b668a01de676cc86f8d39c8ad31a0f89881596cd43880c327b411
+    md5: edf709967712b2953ab4189256266adc
+    sha256: c27668dc802b67588d32da4d2f19833ad815bd39457f375f228f2bfae08bc13d
   category: main
   optional: false
 - name: dask-expr
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: linux-64
   dependencies:
-    dask-core: 2024.5.2
+    dask-core: 2024.6.0
     pandas: '>=2'
     pyarrow: ''
     python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 34db694d2afc672094f1a74af51cb44e
-    sha256: 10a66058440dc54a07c8f00d45259487acf24013ca48387e6680b0a9cc198f70
+    md5: 2b2b28ff641f91527fac96dfb0a8ea9a
+    sha256: 9c40027b6ca711c7b310e609f1cac503e8034cc7ce0ae502c9238b95a9e2ae8b
   category: main
   optional: false
 - name: dask-expr
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: osx-arm64
   dependencies:
     pyarrow: ''
     python: '>=3.9'
     pandas: '>=2'
-    dask-core: 2024.5.2
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.2-pyhd8ed1ab_0.conda
+    dask-core: 2024.6.0
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 34db694d2afc672094f1a74af51cb44e
-    sha256: 10a66058440dc54a07c8f00d45259487acf24013ca48387e6680b0a9cc198f70
+    md5: 2b2b28ff641f91527fac96dfb0a8ea9a
+    sha256: 9c40027b6ca711c7b310e609f1cac503e8034cc7ce0ae502c9238b95a9e2ae8b
   category: main
   optional: false
 - name: dask-expr
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: win-64
   dependencies:
     pyarrow: ''
     python: '>=3.9'
     pandas: '>=2'
-    dask-core: 2024.5.2
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.2-pyhd8ed1ab_0.conda
+    dask-core: 2024.6.0
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 34db694d2afc672094f1a74af51cb44e
-    sha256: 10a66058440dc54a07c8f00d45259487acf24013ca48387e6680b0a9cc198f70
+    md5: 2b2b28ff641f91527fac96dfb0a8ea9a
+    sha256: 9c40027b6ca711c7b310e609f1cac503e8034cc7ce0ae502c9238b95a9e2ae8b
   category: main
   optional: false
 - name: datasets
-  version: 2.19.1
+  version: 2.20.0
   manager: conda
   platform: linux-64
   dependencies:
-    aiohttp: ''
+    aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
     filelock: ''
-    fsspec: '>=2023.1.0,<=2024.3.1'
+    fsspec: '>=2023.1.0,<=2024.5.0'
     huggingface_hub: '>=0.21.2'
     multiprocess: ''
     numpy: '>=1.17'
     packaging: ''
     pandas: ''
-    pyarrow: '>=12.0.0'
+    pyarrow: '>=15.0.0'
     pyarrow-hotfix: ''
     python: '>=3.8.0'
     python-xxhash: ''
     pyyaml: '>=5.1'
-    requests: '>=2.19.0'
-    tqdm: '>=4.62.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.19.1-pyhd8ed1ab_0.conda
+    requests: '>=2.32.2'
+    tqdm: '>=4.66.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f37f26b93f1c157f3e461ae686e1f2b3
-    sha256: 49bce70bb683bd23f908b3c356b042391154296dd9f2e4453e3de2d4aab79aa9
+    md5: 7e2c046cd09a2498bac484413771a9df
+    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
   category: main
   optional: false
 - name: datasets
-  version: 2.19.1
+  version: 2.20.0
   manager: conda
   platform: osx-arm64
   dependencies:
     pandas: ''
     packaging: ''
-    aiohttp: ''
     filelock: ''
     python-xxhash: ''
     multiprocess: ''
@@ -3228,26 +3265,26 @@ package:
     pyyaml: '>=5.1'
     numpy: '>=1.17'
     python: '>=3.8.0'
-    requests: '>=2.19.0'
-    tqdm: '>=4.62.1'
-    pyarrow: '>=12.0.0'
+    aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
     huggingface_hub: '>=0.21.2'
-    fsspec: '>=2023.1.0,<=2024.3.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.19.1-pyhd8ed1ab_0.conda
+    requests: '>=2.32.2'
+    tqdm: '>=4.66.3'
+    fsspec: '>=2023.1.0,<=2024.5.0'
+    pyarrow: '>=15.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f37f26b93f1c157f3e461ae686e1f2b3
-    sha256: 49bce70bb683bd23f908b3c356b042391154296dd9f2e4453e3de2d4aab79aa9
+    md5: 7e2c046cd09a2498bac484413771a9df
+    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
   category: main
   optional: false
 - name: datasets
-  version: 2.19.1
+  version: 2.20.0
   manager: conda
   platform: win-64
   dependencies:
     pandas: ''
     packaging: ''
-    aiohttp: ''
     filelock: ''
     python-xxhash: ''
     multiprocess: ''
@@ -3255,16 +3292,17 @@ package:
     pyyaml: '>=5.1'
     numpy: '>=1.17'
     python: '>=3.8.0'
-    requests: '>=2.19.0'
-    tqdm: '>=4.62.1'
-    pyarrow: '>=12.0.0'
+    aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
     huggingface_hub: '>=0.21.2'
-    fsspec: '>=2023.1.0,<=2024.3.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.19.1-pyhd8ed1ab_0.conda
+    requests: '>=2.32.2'
+    tqdm: '>=4.66.3'
+    fsspec: '>=2023.1.0,<=2024.5.0'
+    pyarrow: '>=15.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f37f26b93f1c157f3e461ae686e1f2b3
-    sha256: 49bce70bb683bd23f908b3c356b042391154296dd9f2e4453e3de2d4aab79aa9
+    md5: 7e2c046cd09a2498bac484413771a9df
+    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
   category: main
   optional: false
 - name: dbus
@@ -3279,8 +3317,8 @@ package:
   hash:
     md5: ecfff944ba3960ecb334b9a2663d708d
     sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: decorator
   version: 5.1.1
   manager: conda
@@ -3291,8 +3329,8 @@ package:
   hash:
     md5: 43afe5ab04e35e17ba28649471dd7364
     sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: decorator
   version: 5.1.1
   manager: conda
@@ -3303,8 +3341,8 @@ package:
   hash:
     md5: 43afe5ab04e35e17ba28649471dd7364
     sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: decorator
   version: 5.1.1
   manager: conda
@@ -3315,8 +3353,8 @@ package:
   hash:
     md5: 43afe5ab04e35e17ba28649471dd7364
     sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dictdiffer
   version: 0.9.0
   manager: conda
@@ -3327,8 +3365,8 @@ package:
   hash:
     md5: 3cb49199274e7f4d457d8fa2b84dea52
     sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dictdiffer
   version: 0.9.0
   manager: conda
@@ -3339,8 +3377,8 @@ package:
   hash:
     md5: 3cb49199274e7f4d457d8fa2b84dea52
     sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dictdiffer
   version: 0.9.0
   manager: conda
@@ -3351,8 +3389,8 @@ package:
   hash:
     md5: 3cb49199274e7f4d457d8fa2b84dea52
     sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dill
   version: 0.3.8
   manager: conda
@@ -3399,8 +3437,8 @@ package:
   hash:
     md5: 4c33109f652b5d8c995ab243436c9370
     sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: diskcache
   version: 5.6.3
   manager: conda
@@ -3411,8 +3449,8 @@ package:
   hash:
     md5: 4c33109f652b5d8c995ab243436c9370
     sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: diskcache
   version: 5.6.3
   manager: conda
@@ -3423,8 +3461,8 @@ package:
   hash:
     md5: 4c33109f652b5d8c995ab243436c9370
     sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: distlib
   version: 0.3.8
   manager: conda
@@ -3435,8 +3473,8 @@ package:
   hash:
     md5: db16c66b759a64dc5183d69cc3745a52
     sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: distlib
   version: 0.3.8
   manager: conda
@@ -3447,8 +3485,8 @@ package:
   hash:
     md5: db16c66b759a64dc5183d69cc3745a52
     sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: distlib
   version: 0.3.8
   manager: conda
@@ -3459,17 +3497,17 @@ package:
   hash:
     md5: db16c66b759a64dc5183d69cc3745a52
     sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: distributed
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0'
     cloudpickle: '>=1.5.0'
     cytoolz: '>=0.10.1'
-    dask-core: '>=2024.5.2,<2024.5.3.0a0'
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
     jinja2: '>=2.10.3'
     locket: '>=1.0.0'
     msgpack-python: '>=1.0.0'
@@ -3483,44 +3521,16 @@ package:
     tornado: '>=6.0.4'
     urllib3: '>=1.24.3'
     zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.5.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2fa6807bd19e5cdc77fe1b6a42c86228
-    sha256: 1cd3946f4476d592e2f925a5bd998d5609c3da643e7ac6bcb13f14adb517a456
+    md5: fc8c9391ef25c481d768967db027dfc0
+    sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
   category: main
   optional: false
 - name: distributed
-  version: 2024.5.2
+  version: 2024.6.0
   manager: conda
   platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    packaging: '>=20.0'
-    pyyaml: '>=5.3.1'
-    cloudpickle: '>=1.5.0'
-    click: '>=8.0'
-    msgpack-python: '>=1.0.0'
-    urllib3: '>=1.24.3'
-    toolz: '>=0.10.0'
-    jinja2: '>=2.10.3'
-    tblib: '>=1.6.0'
-    locket: '>=1.0.0'
-    tornado: '>=6.0.4'
-    sortedcontainers: '>=2.0.5'
-    cytoolz: '>=0.10.1'
-    psutil: '>=5.7.2'
-    zict: '>=3.0.0'
-    dask-core: '>=2024.5.2,<2024.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.5.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2fa6807bd19e5cdc77fe1b6a42c86228
-    sha256: 1cd3946f4476d592e2f925a5bd998d5609c3da643e7ac6bcb13f14adb517a456
-  category: main
-  optional: false
-- name: distributed
-  version: 2024.5.2
-  manager: conda
-  platform: win-64
   dependencies:
     python: '>=3.9'
     packaging: '>=20.0'
@@ -3538,11 +3548,39 @@ package:
     cytoolz: '>=0.10.1'
     psutil: '>=5.7.2'
     zict: '>=3.0.0'
-    dask-core: '>=2024.5.2,<2024.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.5.2-pyhd8ed1ab_0.conda
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2fa6807bd19e5cdc77fe1b6a42c86228
-    sha256: 1cd3946f4476d592e2f925a5bd998d5609c3da643e7ac6bcb13f14adb517a456
+    md5: fc8c9391ef25c481d768967db027dfc0
+    sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
+  category: main
+  optional: false
+- name: distributed
+  version: 2024.6.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.9'
+    packaging: '>=20.0'
+    pyyaml: '>=5.3.1'
+    cloudpickle: '>=1.5.0'
+    click: '>=8.0'
+    msgpack-python: '>=1.0.0'
+    urllib3: '>=1.24.3'
+    toolz: '>=0.10.0'
+    jinja2: '>=2.10.3'
+    tblib: '>=1.6.0'
+    locket: '>=1.0.0'
+    tornado: '>=6.0.4'
+    sortedcontainers: '>=2.0.5'
+    cytoolz: '>=0.10.1'
+    psutil: '>=5.7.2'
+    zict: '>=3.0.0'
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: fc8c9391ef25c481d768967db027dfc0
+    sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
   category: main
   optional: false
 - name: distro
@@ -3555,8 +3593,8 @@ package:
   hash:
     md5: bbdb409974cd6cb30071b1d978302726
     sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: distro
   version: 1.9.0
   manager: conda
@@ -3567,8 +3605,8 @@ package:
   hash:
     md5: bbdb409974cd6cb30071b1d978302726
     sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: distro
   version: 1.9.0
   manager: conda
@@ -3579,8 +3617,8 @@ package:
   hash:
     md5: bbdb409974cd6cb30071b1d978302726
     sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: docopt
   version: 0.6.2
   manager: conda
@@ -3627,8 +3665,8 @@ package:
   hash:
     md5: b2681af65644be41a18d4b00b67938f1
     sha256: ab88f587a9b7dc3cbb636823423c2ecfd868d4719b491af37c09b0384214bacf
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dpath
   version: 2.2.0
   manager: conda
@@ -3639,8 +3677,8 @@ package:
   hash:
     md5: b2681af65644be41a18d4b00b67938f1
     sha256: ab88f587a9b7dc3cbb636823423c2ecfd868d4719b491af37c09b0384214bacf
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dpath
   version: 2.2.0
   manager: conda
@@ -3651,8 +3689,8 @@ package:
   hash:
     md5: b2681af65644be41a18d4b00b67938f1
     sha256: ab88f587a9b7dc3cbb636823423c2ecfd868d4719b491af37c09b0384214bacf
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dulwich
   version: 0.22.1
   manager: conda
@@ -3666,8 +3704,8 @@ package:
   hash:
     md5: 8addaf53957f6bd24229b7f9c03e7e2c
     sha256: f8fd18aacfca21a444806e464eb030d0715b49e1c6d867ddf6b5fb50f076a91c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dulwich
   version: 0.22.1
   manager: conda
@@ -3681,8 +3719,8 @@ package:
   hash:
     md5: baa9c921c2c997e52e7d19b552a3afb3
     sha256: 802d7d12e495167323cb7b47a87ff30b41fbb6b69d67d72c5056e39c12e74b3a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dulwich
   version: 0.22.1
   manager: conda
@@ -3698,8 +3736,8 @@ package:
   hash:
     md5: 9a89efc65178428e4c821e01d2d3ad42
     sha256: 83ab435b6ac17cca238611d2899365f17313343ba3ce090a97aac263a4bf6113
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc
   version: 3.51.2
   manager: conda
@@ -3881,8 +3919,8 @@ package:
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
     sha256: c9a13d4a2d075f5bef3ef833a811f2ac6db1c11bbebca6ff29dd7c931e426443
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-data
   version: 3.15.1
   manager: conda
@@ -3902,8 +3940,8 @@ package:
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
     sha256: c9a13d4a2d075f5bef3ef833a811f2ac6db1c11bbebca6ff29dd7c931e426443
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-data
   version: 3.15.1
   manager: conda
@@ -3923,8 +3961,8 @@ package:
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
     sha256: c9a13d4a2d075f5bef3ef833a811f2ac6db1c11bbebca6ff29dd7c931e426443
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-http
   version: 2.32.0
   manager: conda
@@ -3937,8 +3975,8 @@ package:
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
     sha256: e7f0594b6f4fc23bf2398029fa269b87f659efab266ea995de31a9b5edd7fbef
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-http
   version: 2.32.0
   manager: conda
@@ -3951,8 +3989,8 @@ package:
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
     sha256: e7f0594b6f4fc23bf2398029fa269b87f659efab266ea995de31a9b5edd7fbef
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-http
   version: 2.32.0
   manager: conda
@@ -3965,8 +4003,8 @@ package:
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
     sha256: e7f0594b6f4fc23bf2398029fa269b87f659efab266ea995de31a9b5edd7fbef
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-objects
   version: 5.1.0
   manager: conda
@@ -3979,8 +4017,8 @@ package:
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
     sha256: 658e29e9203ac7797a67d01bcd79ca48a4e920d3a70508cafc10fb761f5315b6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-objects
   version: 5.1.0
   manager: conda
@@ -3993,8 +4031,8 @@ package:
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
     sha256: 658e29e9203ac7797a67d01bcd79ca48a4e920d3a70508cafc10fb761f5315b6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-objects
   version: 5.1.0
   manager: conda
@@ -4007,8 +4045,8 @@ package:
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
     sha256: 658e29e9203ac7797a67d01bcd79ca48a4e920d3a70508cafc10fb761f5315b6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-render
   version: 1.0.2
   manager: conda
@@ -4022,8 +4060,8 @@ package:
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
     sha256: d52444f19cc12f2d2c4948a2a822a0ee9ed8a509c3fe5cbf52e86646befdbefd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-render
   version: 1.0.2
   manager: conda
@@ -4037,8 +4075,8 @@ package:
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
     sha256: d52444f19cc12f2d2c4948a2a822a0ee9ed8a509c3fe5cbf52e86646befdbefd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-render
   version: 1.0.2
   manager: conda
@@ -4052,8 +4090,8 @@ package:
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
     sha256: d52444f19cc12f2d2c4948a2a822a0ee9ed8a509c3fe5cbf52e86646befdbefd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-s3
   version: 3.2.0
   manager: conda
@@ -4067,8 +4105,8 @@ package:
   hash:
     md5: 5e6ae8f59d5c899960b9f33a2ae2a0a7
     sha256: 48632e1c5cb894822bba7fdf341fc320aebced6864eb071ce792293b3e5405ea
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-s3
   version: 3.2.0
   manager: conda
@@ -4082,8 +4120,8 @@ package:
   hash:
     md5: 5e6ae8f59d5c899960b9f33a2ae2a0a7
     sha256: 48632e1c5cb894822bba7fdf341fc320aebced6864eb071ce792293b3e5405ea
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-s3
   version: 3.2.0
   manager: conda
@@ -4097,8 +4135,8 @@ package:
   hash:
     md5: 5e6ae8f59d5c899960b9f33a2ae2a0a7
     sha256: 48632e1c5cb894822bba7fdf341fc320aebced6864eb071ce792293b3e5405ea
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-studio-client
   version: 0.20.0
   manager: conda
@@ -4112,8 +4150,8 @@ package:
   hash:
     md5: ebedafb4704c48d7ad274acb1d0b2475
     sha256: 136ddb343f5f77a28253f27d5b950f223823a6d5afaf1088b5ee9fa286451995
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-studio-client
   version: 0.20.0
   manager: conda
@@ -4127,8 +4165,8 @@ package:
   hash:
     md5: ebedafb4704c48d7ad274acb1d0b2475
     sha256: 136ddb343f5f77a28253f27d5b950f223823a6d5afaf1088b5ee9fa286451995
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-studio-client
   version: 0.20.0
   manager: conda
@@ -4142,8 +4180,8 @@ package:
   hash:
     md5: ebedafb4704c48d7ad274acb1d0b2475
     sha256: 136ddb343f5f77a28253f27d5b950f223823a6d5afaf1088b5ee9fa286451995
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-task
   version: 0.4.0
   manager: conda
@@ -4159,8 +4197,8 @@ package:
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
     sha256: d499d1495ab6d00a4c75510d4573749abed3a7f2b3b291fbe377f029eef7ff79
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-task
   version: 0.4.0
   manager: conda
@@ -4176,8 +4214,8 @@ package:
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
     sha256: d499d1495ab6d00a4c75510d4573749abed3a7f2b3b291fbe377f029eef7ff79
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: dvc-task
   version: 0.4.0
   manager: conda
@@ -4193,8 +4231,44 @@ package:
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
     sha256: d499d1495ab6d00a4c75510d4573749abed3a7f2b3b291fbe377f029eef7ff79
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: editables
+  version: '0.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9873878e2a069bc358b69e9a29c1ecd5
+    sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
+  category: dev
+  optional: true
+- name: editables
+  version: '0.5'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9873878e2a069bc358b69e9a29c1ecd5
+    sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
+  category: dev
+  optional: true
+- name: editables
+  version: '0.5'
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9873878e2a069bc358b69e9a29c1ecd5
+    sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
+  category: dev
+  optional: true
 - name: ensureconda
   version: 1.4.4
   manager: conda
@@ -4210,8 +4284,8 @@ package:
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
     sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ensureconda
   version: 1.4.4
   manager: conda
@@ -4227,8 +4301,8 @@ package:
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
     sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ensureconda
   version: 1.4.4
   manager: conda
@@ -4244,8 +4318,8 @@ package:
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
     sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: entrypoints
   version: '0.4'
   manager: conda
@@ -4256,8 +4330,8 @@ package:
   hash:
     md5: 3cf04868fee0a029769bd41f4b2fbf2d
     sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: entrypoints
   version: '0.4'
   manager: conda
@@ -4268,8 +4342,8 @@ package:
   hash:
     md5: 3cf04868fee0a029769bd41f4b2fbf2d
     sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: entrypoints
   version: '0.4'
   manager: conda
@@ -4280,8 +4354,8 @@ package:
   hash:
     md5: 3cf04868fee0a029769bd41f4b2fbf2d
     sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: exceptiongroup
   version: 1.2.0
   manager: conda
@@ -4292,8 +4366,8 @@ package:
   hash:
     md5: 8d652ea2ee8eaee02ed8dc820bc794aa
     sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: exceptiongroup
   version: 1.2.0
   manager: conda
@@ -4304,8 +4378,8 @@ package:
   hash:
     md5: 8d652ea2ee8eaee02ed8dc820bc794aa
     sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: exceptiongroup
   version: 1.2.0
   manager: conda
@@ -4316,8 +4390,8 @@ package:
   hash:
     md5: 8d652ea2ee8eaee02ed8dc820bc794aa
     sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: expat
   version: 2.6.2
   manager: conda
@@ -4329,8 +4403,8 @@ package:
   hash:
     md5: 53fb86322bdb89496d7579fe3f02fd61
     sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: expat
   version: 2.6.2
   manager: conda
@@ -4341,8 +4415,8 @@ package:
   hash:
     md5: de0cff0ec74f273c4b6aa281479906c3
     sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: expat
   version: 2.6.2
   manager: conda
@@ -4353,8 +4427,8 @@ package:
   hash:
     md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
     sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: filelock
   version: 3.15.1
   manager: conda
@@ -4404,8 +4478,8 @@ package:
   hash:
     md5: ccfb30b92adfeb283d4dcae3d0b6441b
     sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: flatten-dict
   version: 0.4.2
   manager: conda
@@ -4419,8 +4493,8 @@ package:
   hash:
     md5: ccfb30b92adfeb283d4dcae3d0b6441b
     sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: flatten-dict
   version: 0.4.2
   manager: conda
@@ -4434,8 +4508,8 @@ package:
   hash:
     md5: ccfb30b92adfeb283d4dcae3d0b6441b
     sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: flufl.lock
   version: '7.1'
   manager: conda
@@ -4448,8 +4522,8 @@ package:
   hash:
     md5: 9164819e1a375013c4fbcbaa9538f96c
     sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: flufl.lock
   version: '7.1'
   manager: conda
@@ -4462,8 +4536,8 @@ package:
   hash:
     md5: 9164819e1a375013c4fbcbaa9538f96c
     sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: flufl.lock
   version: '7.1'
   manager: conda
@@ -4476,8 +4550,8 @@ package:
   hash:
     md5: 9164819e1a375013c4fbcbaa9538f96c
     sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
@@ -4487,8 +4561,8 @@ package:
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
@@ -4498,8 +4572,8 @@ package:
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
@@ -4509,8 +4583,8 @@ package:
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-inconsolata
   version: '3.000'
   manager: conda
@@ -4520,8 +4594,8 @@ package:
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-inconsolata
   version: '3.000'
   manager: conda
@@ -4531,8 +4605,8 @@ package:
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-inconsolata
   version: '3.000'
   manager: conda
@@ -4542,8 +4616,8 @@ package:
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -4553,8 +4627,8 @@ package:
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -4564,8 +4638,8 @@ package:
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-source-code-pro
   version: '2.038'
   manager: conda
@@ -4575,8 +4649,8 @@ package:
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
@@ -4586,8 +4660,8 @@ package:
   hash:
     md5: cbbe59391138ea5ad3658c76912e147f
     sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
@@ -4597,8 +4671,8 @@ package:
   hash:
     md5: cbbe59391138ea5ad3658c76912e147f
     sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: font-ttf-ubuntu
   version: '0.83'
   manager: conda
@@ -4608,8 +4682,8 @@ package:
   hash:
     md5: cbbe59391138ea5ad3658c76912e147f
     sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fontconfig
   version: 2.14.2
   manager: conda
@@ -4624,8 +4698,8 @@ package:
   hash:
     md5: 0f69b688f52ff6da70bccb7ff7001d1d
     sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fontconfig
   version: 2.14.2
   manager: conda
@@ -4638,8 +4712,8 @@ package:
   hash:
     md5: f77d47ddb6d3cc5b39b9bdf65635afbb
     sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fontconfig
   version: 2.14.2
   manager: conda
@@ -4656,8 +4730,8 @@ package:
   hash:
     md5: 08767992f1a4f1336a257af1241034bd
     sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -4668,8 +4742,8 @@ package:
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -4680,8 +4754,8 @@ package:
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-ecosystem
   version: '1'
   manager: conda
@@ -4692,8 +4766,8 @@ package:
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-forge
   version: '1'
   manager: conda
@@ -4707,8 +4781,8 @@ package:
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-forge
   version: '1'
   manager: conda
@@ -4722,8 +4796,8 @@ package:
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fonts-conda-forge
   version: '1'
   manager: conda
@@ -4737,8 +4811,8 @@ package:
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: freetype
   version: 2.12.1
   manager: conda
@@ -4792,8 +4866,8 @@ package:
   hash:
     md5: ac7bc6a654f8f41b352b38f4051135f8
     sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fribidi
   version: 1.0.10
   manager: conda
@@ -4803,8 +4877,8 @@ package:
   hash:
     md5: c64443234ff91d70cb9c7dc926c58834
     sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fribidi
   version: 1.0.10
   manager: conda
@@ -4816,8 +4890,8 @@ package:
   hash:
     md5: 807e81d915f2bb2e49951648615241f6
     sha256: e0323e6d7b6047042970812ee810c6b1e1a11a3af4025db26d0965ae5d206104
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: frozenlist
   version: 1.4.1
   manager: conda
@@ -4862,39 +4936,39 @@ package:
   category: main
   optional: false
 - name: fsspec
-  version: 2024.3.1
+  version: 2024.5.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.5.0-pyhff2d567_0.conda
   hash:
-    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
-    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
+    md5: d73e9932511ef7670b2cc0ebd9dfbd30
+    sha256: 34149798edaf7f67251ee09612cd50b52ee8a69b45e63ddb79732085ae7423cd
   category: main
   optional: false
 - name: fsspec
-  version: 2024.3.1
+  version: 2024.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.5.0-pyhff2d567_0.conda
   hash:
-    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
-    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
+    md5: d73e9932511ef7670b2cc0ebd9dfbd30
+    sha256: 34149798edaf7f67251ee09612cd50b52ee8a69b45e63ddb79732085ae7423cd
   category: main
   optional: false
 - name: fsspec
-  version: 2024.3.1
+  version: 2024.5.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.3.1-pyhca7485f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.5.0-pyhff2d567_0.conda
   hash:
-    md5: b7f0662ef2c9d4404f0af9eef5ed2fde
-    sha256: b8621151939bb5ea4ea4aa84f010e6130a47b1453cd9178283f335816b72a895
+    md5: d73e9932511ef7670b2cc0ebd9dfbd30
+    sha256: 34149798edaf7f67251ee09612cd50b52ee8a69b45e63ddb79732085ae7423cd
   category: main
   optional: false
 - name: funcy
@@ -4907,8 +4981,8 @@ package:
   hash:
     md5: ecf68a50baba6d9151addcb69cecfb92
     sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: funcy
   version: '2.0'
   manager: conda
@@ -4919,8 +4993,8 @@ package:
   hash:
     md5: ecf68a50baba6d9151addcb69cecfb92
     sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: funcy
   version: '2.0'
   manager: conda
@@ -4931,8 +5005,8 @@ package:
   hash:
     md5: ecf68a50baba6d9151addcb69cecfb92
     sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: future
   version: 1.0.0
   manager: conda
@@ -4943,8 +5017,8 @@ package:
   hash:
     md5: 650a7807e689642dddd3590eb817beed
     sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: future
   version: 1.0.0
   manager: conda
@@ -4955,8 +5029,8 @@ package:
   hash:
     md5: 650a7807e689642dddd3590eb817beed
     sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: future
   version: 1.0.0
   manager: conda
@@ -4967,8 +5041,8 @@ package:
   hash:
     md5: 650a7807e689642dddd3590eb817beed
     sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gdk-pixbuf
   version: 2.42.12
   manager: conda
@@ -4983,8 +5057,8 @@ package:
   hash:
     md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
     sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gdk-pixbuf
   version: 2.42.12
   manager: conda
@@ -5000,8 +5074,8 @@ package:
   hash:
     md5: 151309a7e1eb57a3c2ab8088a1d74f3e
     sha256: 72bcf0a4d3f9aa6d99d7d1d224d19f76ccdb3a4fa85e60f77d17e17985c81bd2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: getopt-win32
   version: '0.1'
   manager: conda
@@ -5014,8 +5088,8 @@ package:
   hash:
     md5: 714d0882dc5e692ca4683d8e520f73c6
     sha256: f3b6e689724a62f36591f6f0e4657db5507feca78e7ef08690a6b2a384216a5c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gettext
   version: 0.22.5
   manager: conda
@@ -5034,8 +5108,8 @@ package:
   hash:
     md5: 404e2894e9cb2835246cef47317ff763
     sha256: 7188b466071698759b125aaed9b4d78940e72e6299b0c6dbad6f35c85cf3d27b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gettext-tools
   version: 0.22.5
   manager: conda
@@ -5047,8 +5121,8 @@ package:
   hash:
     md5: 31117a80d73f4fac856ab09fd9f3c6b5
     sha256: f60d1671e30ac60598396c11fcec4426f7ddb281bf9e37af2262016b4d812cce
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gflags
   version: 2.2.2
   manager: conda
@@ -5084,8 +5158,8 @@ package:
   hash:
     md5: 3bf7b9fd5a7136126e0234db4b87c8b6
     sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: giflib
   version: 5.2.2
   manager: conda
@@ -5095,8 +5169,8 @@ package:
   hash:
     md5: 95fa1486c77505330c20f7202492b913
     sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gitdb
   version: 4.0.11
   manager: conda
@@ -5108,8 +5182,8 @@ package:
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gitdb
   version: 4.0.11
   manager: conda
@@ -5121,8 +5195,8 @@ package:
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gitdb
   version: 4.0.11
   manager: conda
@@ -5134,8 +5208,8 @@ package:
   hash:
     md5: 623b19f616f2ca0c261441067e18ae40
     sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gitpython
   version: 3.1.43
   manager: conda
@@ -5148,8 +5222,8 @@ package:
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
     sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gitpython
   version: 3.1.43
   manager: conda
@@ -5162,8 +5236,8 @@ package:
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
     sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gitpython
   version: 3.1.43
   manager: conda
@@ -5176,8 +5250,8 @@ package:
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
     sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: glog
   version: 0.7.1
   manager: conda
@@ -5277,8 +5351,8 @@ package:
   hash:
     md5: 5d632e0f82bfaad59fe060f4b442fd11
     sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: grandalf
   version: '0.7'
   manager: conda
@@ -5291,8 +5365,8 @@ package:
   hash:
     md5: 5d632e0f82bfaad59fe060f4b442fd11
     sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: grandalf
   version: '0.7'
   manager: conda
@@ -5305,8 +5379,8 @@ package:
   hash:
     md5: 5d632e0f82bfaad59fe060f4b442fd11
     sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: graphite2
   version: 1.3.13
   manager: conda
@@ -5318,8 +5392,8 @@ package:
   hash:
     md5: f87c7b7c2cb45f323ffbce941c78ab7c
     sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: graphite2
   version: 1.3.13
   manager: conda
@@ -5330,8 +5404,8 @@ package:
   hash:
     md5: 339991336eeddb70076d8ca826dac625
     sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: graphite2
   version: 1.3.13
   manager: conda
@@ -5344,8 +5418,8 @@ package:
   hash:
     md5: 3194499ee7d1a67404a87d0eefdd92c6
     sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: graphviz
   version: 11.0.0
   manager: conda
@@ -5369,8 +5443,8 @@ package:
   hash:
     md5: 52a531ef95358086a56086c45d97ab75
     sha256: 7e7ca0901c0d2de455718ec7a0974e2091c38e608f90a4ba98084e4902d93c17
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: graphviz
   version: 11.0.0
   manager: conda
@@ -5394,8 +5468,8 @@ package:
   hash:
     md5: c004a0e5dfbe0ce38af9ab4684abd236
     sha256: ced49a72b8f3c92a76d3f07bb75be2a64d3572d433f2711d36003e1b565d1d4e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: graphviz
   version: 11.0.0
   manager: conda
@@ -5417,8 +5491,8 @@ package:
   hash:
     md5: c6c2ec410aa5e77e09948bf7a4367c00
     sha256: 9a41d852f32f5654980492934cc547776b94b3910e5c86beff3cb58eeddd08a5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gtk2
   version: 2.24.33
   manager: conda
@@ -5441,8 +5515,8 @@ package:
   hash:
     md5: 410f86e58e880dcc7b0e910a8e89c05c
     sha256: b946ba60d177d72157cad8af51723f1d081a4794741d35debe53f8b2c807f3af
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gtk2
   version: 2.24.33
   manager: conda
@@ -5458,8 +5532,8 @@ package:
   hash:
     md5: 9c1ba062d59f3f49a2d32d9611d72686
     sha256: fab8403a67273f69780b1e9b5f1db1aff74ff9472acc9f6df6d9b50fc252bd50
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gto
   version: 1.7.1
   manager: conda
@@ -5479,8 +5553,8 @@ package:
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
     sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gto
   version: 1.7.1
   manager: conda
@@ -5500,8 +5574,8 @@ package:
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
     sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gto
   version: 1.7.1
   manager: conda
@@ -5521,8 +5595,8 @@ package:
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
     sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gts
   version: 0.7.6
   manager: conda
@@ -5535,8 +5609,8 @@ package:
   hash:
     md5: 4d8df0b0db060d33c9a702ada998a8fe
     sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gts
   version: 0.7.6
   manager: conda
@@ -5548,8 +5622,8 @@ package:
   hash:
     md5: 21b4dd3098f63a74cf2aa9159cbef57d
     sha256: e0f8c7bc1b9ea62ded78ffa848e37771eeaaaf55b3146580513c7266862043ba
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: gts
   version: 0.7.6
   manager: conda
@@ -5563,8 +5637,89 @@ package:
   hash:
     md5: a41f14768d5e377426ad60c613f2923b
     sha256: b79755d2f9fc2113b6949bfc170c067902bc776e2c20da26e746e780f4f5a2d4
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: h11
+  version: 0.14.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: dev
+  optional: true
+- name: h11
+  version: 0.14.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    typing_extensions: ''
+    python: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: dev
+  optional: true
+- name: h11
+  version: 0.14.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    typing_extensions: ''
+    python: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: dev
+  optional: true
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b748fbf7060927a6e82df7cb5ee8f097
+    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  category: dev
+  optional: true
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6.1'
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b748fbf7060927a6e82df7cb5ee8f097
+    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  category: dev
+  optional: true
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6.1'
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b748fbf7060927a6e82df7cb5ee8f097
+    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  category: dev
+  optional: true
 - name: harfbuzz
   version: 8.5.0
   manager: conda
@@ -5581,8 +5736,8 @@ package:
   hash:
     md5: f5126317dd0ce0ba26945e411ecc6960
     sha256: a141fc55f8bfdab7db03fe9d8e61cb0f8c8b5970ed6540eda2db7186223f4444
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: harfbuzz
   version: 8.5.0
   manager: conda
@@ -5599,8 +5754,8 @@ package:
   hash:
     md5: aa22b942b980c17612d344adcd0f8798
     sha256: 91121ed30fa7d775f1cf7ae5de2f7852d66a604269509c4bb108b143315d8321
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: harfbuzz
   version: 8.5.0
   manager: conda
@@ -5618,8 +5773,185 @@ package:
   hash:
     md5: 2ff854071c04998038c0e1db4c9232f7
     sha256: f633a33dfe5c799a571af41e3515fc706a6f4988701d39e7b5d37811a1745bb9
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: hatch
+  version: 1.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
+    httpx: '>=0.22.0'
+    hyperlink: '>=21.0.0'
+    keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
+    shellingham: '>=1.4.0'
+    tomli-w: '>=1.0'
+    tomlkit: '>=0.11.1'
+    userpath: '>=1.7,<2'
+    uv: '>=0.1.35'
+    virtualenv: '>=20.26.1'
+    zstandard: <1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
+    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
+  category: dev
+  optional: true
+- name: hatch
+  version: 1.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    rich: '>=11.2.0'
+    tomlkit: '>=0.11.1'
+    httpx: '>=0.22.0'
+    hyperlink: '>=21.0.0'
+    platformdirs: '>=2.5.0'
+    keyring: '>=23.5.0'
+    shellingham: '>=1.4.0'
+    tomli-w: '>=1.0'
+    packaging: '>=23.2'
+    click: '>=8.0.6'
+    zstandard: <1.0
+    hatchling: '>=1.24.2'
+    pexpect: '>=4.8,<5'
+    userpath: '>=1.7,<2'
+    uv: '>=0.1.35'
+    virtualenv: '>=20.26.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
+    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
+  category: dev
+  optional: true
+- name: hatch
+  version: 1.12.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+    rich: '>=11.2.0'
+    tomlkit: '>=0.11.1'
+    httpx: '>=0.22.0'
+    hyperlink: '>=21.0.0'
+    platformdirs: '>=2.5.0'
+    keyring: '>=23.5.0'
+    shellingham: '>=1.4.0'
+    tomli-w: '>=1.0'
+    packaging: '>=23.2'
+    click: '>=8.0.6'
+    zstandard: <1.0
+    hatchling: '>=1.24.2'
+    pexpect: '>=4.8,<5'
+    userpath: '>=1.7,<2'
+    uv: '>=0.1.35'
+    virtualenv: '>=20.26.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
+    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
+  category: dev
+  optional: true
+- name: hatchling
+  version: 1.24.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28cef29029f6da70e7a987a76a3599a4
+    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+  category: dev
+  optional: true
+- name: hatchling
+  version: 1.24.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    importlib-metadata: ''
+    trove-classifiers: ''
+    python: '>=3.7'
+    packaging: '>=21.3'
+    pluggy: '>=1.0.0'
+    pathspec: '>=0.10.1'
+    tomli: '>=1.2.2'
+    editables: '>=0.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28cef29029f6da70e7a987a76a3599a4
+    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+  category: dev
+  optional: true
+- name: hatchling
+  version: 1.24.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    importlib-metadata: ''
+    trove-classifiers: ''
+    python: '>=3.7'
+    packaging: '>=21.3'
+    pluggy: '>=1.0.0'
+    pathspec: '>=0.10.1'
+    tomli: '>=1.2.2'
+    editables: '>=0.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28cef29029f6da70e7a987a76a3599a4
+    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+  category: dev
+  optional: true
+- name: hpack
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: dev
+  optional: true
+- name: hpack
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: dev
+  optional: true
+- name: hpack
+  version: 4.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: dev
+  optional: true
 - name: html5lib
   version: '1.1'
   manager: conda
@@ -5632,8 +5964,8 @@ package:
   hash:
     md5: b2355343d6315c892543200231d7154a
     sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: html5lib
   version: '1.1'
   manager: conda
@@ -5646,8 +5978,8 @@ package:
   hash:
     md5: b2355343d6315c892543200231d7154a
     sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: html5lib
   version: '1.1'
   manager: conda
@@ -5660,8 +5992,110 @@ package:
   hash:
     md5: b2355343d6315c892543200231d7154a
     sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: '>=3.0,<5.0'
+    certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
+    python: '>=3.8'
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: dev
+  optional: true
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    certifi: ''
+    python: '>=3.8'
+    sniffio: 1.*
+    h2: '>=3,<5'
+    anyio: '>=3.0,<5.0'
+    h11: '>=0.13,<0.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: dev
+  optional: true
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: win-64
+  dependencies:
+    certifi: ''
+    python: '>=3.8'
+    sniffio: 1.*
+    h2: '>=3,<5'
+    anyio: '>=3.0,<5.0'
+    h11: '>=0.13,<0.15'
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: dev
+  optional: true
+- name: httpx
+  version: 0.27.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: dev
+  optional: true
+- name: httpx
+  version: 0.27.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    certifi: ''
+    idna: ''
+    anyio: ''
+    sniffio: ''
+    python: '>=3.8'
+    httpcore: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: dev
+  optional: true
+- name: httpx
+  version: 0.27.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    certifi: ''
+    idna: ''
+    anyio: ''
+    sniffio: ''
+    python: '>=3.8'
+    httpcore: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: dev
+  optional: true
 - name: huggingface_hub
   version: 0.23.3
   manager: conda
@@ -5733,8 +6167,8 @@ package:
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
     sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: hydra-core
   version: 1.3.2
   manager: conda
@@ -5749,8 +6183,8 @@ package:
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
     sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: hydra-core
   version: 1.3.2
   manager: conda
@@ -5765,8 +6199,83 @@ package:
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
     sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: dev
+  optional: true
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: dev
+  optional: true
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: dev
+  optional: true
+- name: hyperlink
+  version: 21.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    idna: '>=2.6'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
+    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
+  category: dev
+  optional: true
+- name: hyperlink
+  version: 21.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+    idna: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
+    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
+  category: dev
+  optional: true
+- name: hyperlink
+  version: 21.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+    idna: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
+    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
+  category: dev
+  optional: true
 - name: icu
   version: '73.2'
   manager: conda
@@ -5778,8 +6287,8 @@ package:
   hash:
     md5: cc47e1facc155f91abd89b11e48e72ff
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: icu
   version: '73.2'
   manager: conda
@@ -5789,8 +6298,8 @@ package:
   hash:
     md5: 8521bd47c0e11c5902535bb1a17c565f
     sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: icu
   version: '73.2'
   manager: conda
@@ -5803,8 +6312,8 @@ package:
   hash:
     md5: 0f47d9e3192d9e09ae300da0d28e0f56
     sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: identify
   version: 2.5.36
   manager: conda
@@ -5966,8 +6475,8 @@ package:
   hash:
     md5: c5d3907ad8bd7bf557521a1833cf7e6d
     sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: importlib_resources
   version: 6.4.0
   manager: conda
@@ -5979,8 +6488,8 @@ package:
   hash:
     md5: c5d3907ad8bd7bf557521a1833cf7e6d
     sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: importlib_resources
   version: 6.4.0
   manager: conda
@@ -5992,8 +6501,8 @@ package:
   hash:
     md5: c5d3907ad8bd7bf557521a1833cf7e6d
     sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: iniconfig
   version: 2.0.0
   manager: conda
@@ -6004,8 +6513,8 @@ package:
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: iniconfig
   version: 2.0.0
   manager: conda
@@ -6016,8 +6525,8 @@ package:
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: iniconfig
   version: 2.0.0
   manager: conda
@@ -6028,8 +6537,8 @@ package:
   hash:
     md5: f800d2da156d08e289b14e87e43c1ae5
     sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: intel-openmp
   version: 2024.1.0
   manager: conda
@@ -6055,8 +6564,8 @@ package:
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
     sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: iterative-telemetry
   version: 0.0.8
   manager: conda
@@ -6071,8 +6580,8 @@ package:
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
     sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: iterative-telemetry
   version: 0.0.8
   manager: conda
@@ -6087,8 +6596,8 @@ package:
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
     sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.classes
   version: 3.4.0
   manager: conda
@@ -6100,8 +6609,8 @@ package:
   hash:
     md5: 7b756504d362cbad9b73a50a5455cafd
     sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.classes
   version: 3.4.0
   manager: conda
@@ -6113,8 +6622,8 @@ package:
   hash:
     md5: 7b756504d362cbad9b73a50a5455cafd
     sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.classes
   version: 3.4.0
   manager: conda
@@ -6126,8 +6635,8 @@ package:
   hash:
     md5: 7b756504d362cbad9b73a50a5455cafd
     sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.context
   version: 5.3.0
   manager: conda
@@ -6139,8 +6648,8 @@ package:
   hash:
     md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
     sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.context
   version: 5.3.0
   manager: conda
@@ -6152,8 +6661,8 @@ package:
   hash:
     md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
     sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.context
   version: 5.3.0
   manager: conda
@@ -6165,8 +6674,8 @@ package:
   hash:
     md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
     sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.functools
   version: 4.0.0
   manager: conda
@@ -6178,8 +6687,8 @@ package:
   hash:
     md5: 547670a612fd335eaa5ffbf0fa75cb64
     sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.functools
   version: 4.0.0
   manager: conda
@@ -6191,8 +6700,8 @@ package:
   hash:
     md5: 547670a612fd335eaa5ffbf0fa75cb64
     sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jaraco.functools
   version: 4.0.0
   manager: conda
@@ -6204,8 +6713,8 @@ package:
   hash:
     md5: 547670a612fd335eaa5ffbf0fa75cb64
     sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jeepney
   version: 0.8.0
   manager: conda
@@ -6216,8 +6725,8 @@ package:
   hash:
     md5: 9800ad1699b42612478755a2d26c722d
     sha256: 16639759b811866d63315fe1391f6fb45f5478b823972f4d3d9f0392b7dd80b8
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jinja2
   version: 3.1.4
   manager: conda
@@ -6267,8 +6776,8 @@ package:
   hash:
     md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
     sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jmespath
   version: 1.0.1
   manager: conda
@@ -6279,8 +6788,8 @@ package:
   hash:
     md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
     sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: jmespath
   version: 1.0.1
   manager: conda
@@ -6291,8 +6800,8 @@ package:
   hash:
     md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
     sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: joblib
   version: 1.4.2
   manager: conda
@@ -6350,8 +6859,8 @@ package:
   hash:
     md5: 8508b734287ac18dd1caa72a0d8127ee
     sha256: a9608fa7d3ec6a58f01a8901773a28bbe08f2e799476cd2b9aae7f578dff8fab
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: keyring
   version: 25.2.1
   manager: conda
@@ -6368,8 +6877,8 @@ package:
   hash:
     md5: 8c071c544a2fc27cbc75dfa0d7362f0c
     sha256: 25c638602ef3854a8f1785004124ac3acba2b1ceaa7a2f23f51dfa09b5cd6d3f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: keyring
   version: 25.2.1
   manager: conda
@@ -6387,8 +6896,8 @@ package:
   hash:
     md5: 70fb816c1b6ab81e048e4c6227ec922c
     sha256: 3c7402db93f974fee3ef88f1208c8d9ab4009f33392a6b6d340516c96b3ae5b5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: keyutils
   version: 1.6.1
   manager: conda
@@ -6415,8 +6924,8 @@ package:
   hash:
     md5: 256ce94762bf2e25822232253c029b5b
     sha256: 5e5edf48bb1910dc851c997ea990d8d960b333044fae11d10ca93cfdc1f72a4c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: kombu
   version: 5.3.7
   manager: conda
@@ -6431,8 +6940,8 @@ package:
   hash:
     md5: 1e42e45f351207e0571782c2d08ed983
     sha256: c0810b295a185b4bb7d586b432ee12140efcf08745d322cff2e2d28dff8750ee
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: kombu
   version: 5.3.7
   manager: conda
@@ -6447,8 +6956,8 @@ package:
   hash:
     md5: 6f3bce35fa4b4612fc1f2413a9b4033e
     sha256: e1338942952ecc2bcff542443a6f0c329b3448d5432772dffbc6ea1480f24211
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: krb5
   version: 1.21.2
   manager: conda
@@ -6542,10 +7051,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
   hash:
-    md5: 02d936b69ab683fc6755c236996f8b51
-    sha256: 5f1638202f19cac8ede2800c31eb0b2b206f0c4a2c4ff12ab6592115ad128748
+    md5: b80f2f396ca2c28b8c14c437a4ed1e74
+    sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
   category: main
   optional: false
 - name: lenskit
@@ -6937,8 +7446,8 @@ package:
   hash:
     md5: 1b27402397a76115679c4855ab2ece41
     sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libasprintf-devel
   version: 0.22.5
   manager: conda
@@ -6949,18 +7458,18 @@ package:
   hash:
     md5: 480c106e87d4c4791e6b55a6d1678866
     sha256: f5331486854a5fe80bb837891efb28a28623f762327372cb4cbc264c9c4bf9e2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    mkl: '>=2022.1.0,<2023.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_mkl.tar.bz2
+    libopenblas: '>=0.3.27,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
   hash:
-    md5: 85f61af03fd291dae33150ffe89dc09a
-    sha256: 24e656f13b402b6fceb88df386768445ab9beb657d451a8e5a88d4b3380cf7a4
+    md5: 1a2a0cd3153464fee6646f3dd6dad9b8
+    sha256: 082b8ac20d43a7bbcdc28b3b1cd40e4df3a8b5daf0a2d23d68953a44d2d12c1b
   category: main
   optional: false
 - name: libblas
@@ -7110,10 +7619,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_mkl.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
   hash:
-    md5: 361bf757b95488de76c4f123805742d3
-    sha256: 892ba10508f22310ccfe748df1fd3b6c7f20e7b6f6b79e69ed337863551c1bd8
+    md5: 4b31699e0ec5de64d5896e580389c9a1
+    sha256: da1b2faa017663c8f5555c1c5518e96ac4cd8e0be2a673c1c9e2cb8507c8fe46
   category: main
   optional: false
 - name: libcblas
@@ -7444,10 +7953,10 @@ package:
   dependencies:
     _libgcc_mutex: '0.1'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h77fa898_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h77fa898_10.conda
   hash:
-    md5: f23bc130bc3d2bbd9d9d6892609546ea
-    sha256: 99766cf453f4d5ed78b8446d81de99a5fe243dea0d73cf402454f81c136c7d7d
+    md5: bbb96c5e7a11ef8ca2b666fe9fe3d199
+    sha256: 78931358d83ff585d0cd448632366a5cbe6bcf41a66c07e8178200008127c2b5
   category: main
   optional: false
 - name: libgd
@@ -7473,8 +7982,8 @@ package:
   hash:
     md5: cfebc557e54905dadc355c0e9f003004
     sha256: b74f95a6e1f3b31a74741b39cba83ed99fc82d17243c0fd3b5ab16ddd48ab89d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libgd
   version: 2.3.3
   manager: conda
@@ -7498,8 +8007,8 @@ package:
   hash:
     md5: 0d847466f115fbdaaf2b6926f2e33278
     sha256: cfdecfaa27807abc2728bd8c60b923ce1b44020553e122e9a56fc3acb77acaec
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libgd
   version: 2.3.3
   manager: conda
@@ -7526,8 +8035,8 @@ package:
   hash:
     md5: 69c987e1f9268d9ade86497c4ab8cc45
     sha256: fa75f4206eb9cd8e5e24fe1b6381a7450cfcb507c42813fd028a924a4872bc76
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libgettextpo
   version: 0.22.5
   manager: conda
@@ -7539,8 +8048,8 @@ package:
   hash:
     md5: a66fad933e22d22599a6dd149d359d25
     sha256: c3f5580e172c3fc03d33e8994024f08b709a239bd599792e51435fa7a06beb64
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libgettextpo-devel
   version: 0.22.5
   manager: conda
@@ -7553,8 +8062,8 @@ package:
   hash:
     md5: 1113aa220b042b7ce8d077ea8f696f98
     sha256: b1be0bb8a726e2c47a025ff348e6ba8b51ef668f6ace06694657025d84ae66e2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libgfortran
   version: 5.0.0
   manager: conda
@@ -7573,10 +8082,10 @@ package:
   platform: linux-64
   dependencies:
     libgfortran5: 13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_10.conda
   hash:
-    md5: 90a8b0f4e0d4a333f54d0c33b882ee9a
-    sha256: 2e233e7b461749fcbc14b5e6ed5372a02e766924c1d73526ba9a46094c9499ba
+    md5: a78f7b3d951665c4c57578a8d3787993
+    sha256: de97f291cda4be906c9021c93a9d5d40eb65ab7bd5cba38dfa11f12597d7ef6a
   category: main
   optional: false
 - name: libgfortran5
@@ -7585,10 +8094,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=13.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-h3d2ce59_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-h3d2ce59_10.conda
   hash:
-    md5: 2f2a59af95aed6024368b8dbaf9591d8
-    sha256: 16042f9ee0b6303c85cac9c763dd32e8bdc82f3f7c24156560e603adfc31506a
+    md5: e3896e5c2dd1cbabaf4abb3254df47b0
+    sha256: be5f5873c392bc4c25bee25cef2d30a9dab69c0d82ff1ddf687f9ece6d36f56c
   category: main
   optional: false
 - name: libgfortran5
@@ -7612,15 +8121,15 @@ package:
     libgcc-ng: '>=12'
     libssh2: '>=1.11.0,<2.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.8.1-ha5f426f_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.8.1-he8d1d4c_1.conda
   hash:
-    md5: 1d135a1b8270eee9305a16bf89550aca
-    sha256: c41708ea655298ce65f123a696b22edd140fd45c4bcb18fcf06899402e78c09a
-  category: main
-  optional: false
+    md5: febd0520afc041dd938acdce0f26d71b
+    sha256: 7b59e6f31d9b4e877322ec1b9b7da61fc3f34950ca6a2b4576ba2de0de5718e6
+  category: dev
+  optional: true
 - name: libgit2
   version: 1.8.1
   manager: conda
@@ -7630,31 +8139,31 @@ package:
     libcxx: '>=16'
     libiconv: '>=1.17,<2.0a0'
     libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.3.0,<4.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgit2-1.8.1-h5a5d082_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgit2-1.8.1-h7d81828_1.conda
   hash:
-    md5: 0c09bedd4a035730b63448483df6441e
-    sha256: 131768815aca95a4a7ec572e0396aedf7ab032bb8647064051f32952aa814cfd
-  category: main
-  optional: false
+    md5: 4a7d5c262df8bc95a0509ce29881293e
+    sha256: 9dd6e511540298213bab05b1a640259d4f874c58137568fca5162305df0d3e73
+  category: dev
+  optional: true
 - name: libgit2
   version: 1.8.1
   manager: conda
   platform: win-64
   dependencies:
     libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgit2-1.8.1-hd33bead_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgit2-1.8.1-hc1607c6_1.conda
   hash:
-    md5: fe3bdd36df1b6f5e42acbdb9ee25d178
-    sha256: e2f180aebb795c1cbf602903fcd64dfd635581a66b982bd6d0fcc346ca14b66b
-  category: main
-  optional: false
+    md5: 96b2ee01e59abd5d8252b4da99f8ca7f
+    sha256: 68554180fe022e4cb7069e08906a3474732664763cea1594cc68b5671459ca57
+  category: dev
+  optional: true
 - name: libglib
   version: 2.80.2
   manager: conda
@@ -7663,14 +8172,14 @@ package:
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-hf974151_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-h8a4344b_1.conda
   hash:
-    md5: 72724f6a78ecb15559396966226d5838
-    sha256: 93e03b6cf4765bc06d64fa3dac65f22c53ae4a30247bb0e2dea0bd9c47a3fb26
-  category: main
-  optional: false
+    md5: 9c406bb3d4dac2b358873e6462496d09
+    sha256: 03dcc12fe937e32b1fbd7bd7cfe0f7a3e82ee4fe8d29c4d67afb657f13d04394
+  category: dev
+  optional: true
 - name: libglib
   version: 2.80.2
   manager: conda
@@ -7680,14 +8189,14 @@ package:
     libffi: '>=3.4,<4.0a0'
     libiconv: '>=1.17,<2.0a0'
     libintl: '>=0.22.5,<1.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h535f939_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h59d46d9_1.conda
   hash:
-    md5: 4ac7cb698ca919924e205af3ab3aacf3
-    sha256: 3f0c9f25748787ab5475c5ce8267184d6637e8a5b7ca55ef2f3a0d7bff2f537f
-  category: main
-  optional: false
+    md5: 104d740896163d3e5b4b5ca7bc8f5bbb
+    sha256: 630c10b41bad621c1b6c7cf7241bceca4a009fdc1db2a5b9125dc49059eab070
+  category: dev
+  optional: true
 - name: libglib
   version: 2.80.2
   manager: conda
@@ -7696,15 +8205,27 @@ package:
     libffi: '>=3.4,<4.0a0'
     libiconv: '>=1.17,<2.0a0'
     libintl: '>=0.22.5,<1.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pcre2: '>=10.43,<10.44.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h0df6a38_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h7025463_1.conda
   hash:
-    md5: ef9ae80bb2a15aee7a30180c057678ea
-    sha256: 941bbe089a7a87fbe88324bfc7970a1688c7a765490e25b829ff73c7abc3fc5a
+    md5: f9f0561c59e62d02f6d6d118ce8b5b63
+    sha256: 84dc3f80a2956a055c7aa3b5df9061756cf5d3eecb11bf656688e1ee6177bd7e
+  category: dev
+  optional: true
+- name: libgomp
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _libgcc_mutex: '0.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h77fa898_10.conda
+  hash:
+    md5: 9404d1686e63142d41acc72ef876a588
+    sha256: bcea6ddfea86f0e6a1a831d1d2c3f36f7613b5e447229e19f978ded0d184cf5a
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -7881,20 +8402,6 @@ package:
 - name: libhwloc
   version: 2.10.0
   manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.10.0-default_h5622ce7_1001.conda
-  hash:
-    md5: fc2d5b79c2d3f8568fbab31db7ae02f3
-    sha256: 6f19d26819d336cb76689861e20560404a3cd61cc9adf7cbc395b9a5e612e226
-  category: main
-  optional: false
-- name: libhwloc
-  version: 2.10.0
-  manager: conda
   platform: win-64
   dependencies:
     libxml2: '>=2.12.7,<3.0a0'
@@ -7918,8 +8425,8 @@ package:
   hash:
     md5: d66573916ffcf376178462f1b61c941e
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -7929,8 +8436,8 @@ package:
   hash:
     md5: 69bda57310071cf6d2b86caf11573d2d
     sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -7955,8 +8462,8 @@ package:
   hash:
     md5: 3d216d0add050129007de3342be7b8c5
     sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libintl
   version: 0.22.5
   manager: conda
@@ -7967,8 +8474,8 @@ package:
   hash:
     md5: aa622c938af057adc119f8b8eecada01
     sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libintl-devel
   version: 0.22.5
   manager: conda
@@ -7980,8 +8487,8 @@ package:
   hash:
     md5: 962b3348c68efd25da253e94590ea9a2
     sha256: e52b2d0c5711f64b523756ccd9b800ee6f10a6317432b20a417dc3792e0a794a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libjpeg-turbo
   version: 3.0.0
   manager: conda
@@ -8025,10 +8532,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_mkl.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
   hash:
-    md5: a2f166748917d6d6e4707841ca1f519e
-    sha256: d6201f860b2d76ed59027e69c2bbad6d1cb211a215ec9705cc487cde488fa1fa
+    md5: b083767b6c877e24ee597d93b87ab838
+    sha256: db246341d42f9100d45adeb1a7ba8b1ef5b51ceb9056fd643e98046a3259fde6
   category: main
   optional: false
 - name: liblapack
@@ -8140,6 +8647,20 @@ package:
   hash:
     md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  category: main
+  optional: false
+- name: libopenblas
+  version: 0.3.27
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libgfortran-ng: ''
+    libgfortran5: '>=12.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
+  hash:
+    md5: a356024784da6dfd4683dc5ecf45b155
+    sha256: 2ae7559aed0705deb3f716c7b247c74fd1b5e35b64e39834ce8b95f7564d4a3e
   category: main
   optional: false
 - name: libopenblas
@@ -8333,42 +8854,42 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.58.0
+  version: 2.58.1
   manager: conda
   platform: linux-64
   dependencies:
     cairo: '>=1.18.0,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    harfbuzz: '>=8.3.0,<9.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    harfbuzz: '>=8.5.0,<9.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.80.0,<3.0a0'
+    libglib: '>=2.80.2,<3.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-    libxml2: '>=2.12.6,<3.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
     pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.0-hadf69e7_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.1-hadf69e7_0.conda
   hash:
-    md5: 0e2b5bd9533043b41f9482ae9e2c16b5
-    sha256: eaba82901f01f3ede8b1307c64e0448df8c5e9af9c6b78600c5f63c91c122e45
-  category: main
-  optional: false
+    md5: 73fc255d740d23da4f554b58dc4909fd
+    sha256: c3b6c48e50a3ff8522d868215dcccfbd8f2720e512084b12f4bfcb6a668c5552
+  category: dev
+  optional: true
 - name: librsvg
-  version: 2.58.0
+  version: 2.58.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.0,<2.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    libglib: '>=2.80.0,<3.0a0'
-    libxml2: '>=2.12.6,<3.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
     pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.0-hb3d354b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.1-hbc281fb_0.conda
   hash:
-    md5: eefc587613e6097d9c0b14188c292b5d
-    sha256: c57a7fc7b24e5d036b0f2e5c871af0b636d46455cf73497fc2a6a5f873542b65
-  category: main
-  optional: false
+    md5: e642889ae7e977769f6d0328e2ec7497
+    sha256: 01fdd2c28b24d319f46cf8072147beda48e223757a8fb6bca95fb6c93bad918b
+  category: dev
+  optional: true
 - name: libsqlite
   version: 3.46.0
   manager: conda
@@ -8458,10 +8979,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: 13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-hc0a3c3a_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-hc0a3c3a_10.conda
   hash:
-    md5: 2075df518ef9d09f1ae209c83116e808
-    sha256: 642469fd890e890fd96db3d26e4fbd66b5d5d56142d8657b5c15450ab05dc6e1
+    md5: ea50441ab527f23ffa108ade07e2fde0
+    sha256: 9a5d43eed33fe8b2fd6adf71ef8f0253fd515e1440c9b7b7782db608e3085bea
   category: main
   optional: false
 - name: libthrift
@@ -8571,6 +9092,49 @@ package:
     sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
   category: main
   optional: false
+- name: libtorch
+  version: 2.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+    libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libstdcxx-ng: '>=12'
+    libuv: '>=1.48.0,<2.0a0'
+    sleef: '>=3.5.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.1.2-cpu_generic_h0ec3652_4.conda
+  hash:
+    md5: 14d76e1994a097c59c8822aed877f5f4
+    sha256: f5b02ad2accc3fe5670afeb4ad1671db171cb1a19ce8507547ab5e6195d0cc9e
+  category: main
+  optional: false
+- name: libtorch
+  version: 2.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=16'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libuv: '>=1.48.0,<2.0a0'
+    llvm-openmp: '>=16.0.6'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.3.1-cpu_generic_hac4f340_0.conda
+  hash:
+    md5: e925d1407b971d451e490fd4a46f3206
+    sha256: 2a4d926caed2cd6d51aeeae14685a8b1c57863a4ad8ca0b438eb7f896cb9b1c8
+  category: main
+  optional: false
 - name: libutf8proc
   version: 2.8.0
   manager: conda
@@ -8672,8 +9236,8 @@ package:
   hash:
     md5: 80030debaa84cfc31755d53742df3ca6
     sha256: bd45805b169e3e0ff166d360c3c4842d77107d28c8f9feba020a8e8b9c80f948
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libwebp
   version: 1.4.0
   manager: conda
@@ -8689,8 +9253,8 @@ package:
   hash:
     md5: 078abbcc54996b186b9144cf795bd30f
     sha256: e75e7a58793236fc8e92733c8bad168ce7bea40ca54c8c643e357511ba4a7b98
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libwebp
   version: 1.4.0
   manager: conda
@@ -8704,8 +9268,8 @@ package:
   hash:
     md5: 11334a8fb02041b453e2f89a4ae16f8d
     sha256: ebabb57084e85cd09d529dbb4fe0f4db6cd0d369ad8095342c37b98855fd87fd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libwebp-base
   version: 1.4.0
   manager: conda
@@ -8814,8 +9378,8 @@ package:
   hash:
     md5: 340278ded8b0dc3a73f3660bbb0adbc6
     sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libxml2
   version: 2.12.7
   manager: conda
@@ -8830,8 +9394,8 @@ package:
   hash:
     md5: 8ea71a74847498c793b0a8e9054a177a
     sha256: 0ea12032b53d3767564a058ccd5208c0a1724ed2f8074dd22257ff3859ea6a4e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libxml2
   version: 2.12.7
   manager: conda
@@ -8884,18 +9448,6 @@ package:
   hash:
     md5: d4483ca8afc57ddf1f6dded53b36c17f
     sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 15.0.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
-  hash:
-    md5: 589c9a3575a050b583241c3d688ad9aa
-    sha256: 7c67d383a8b1f3e7bf9e046e785325c481f6868194edcfb9d78d261da4ad65d4
   category: main
   optional: false
 - name: llvm-openmp
@@ -9159,8 +9711,8 @@ package:
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: markdown-it-py
   version: 3.0.0
   manager: conda
@@ -9172,8 +9724,8 @@ package:
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: markdown-it-py
   version: 3.0.0
   manager: conda
@@ -9185,8 +9737,8 @@ package:
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
     sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: markupsafe
   version: 2.1.5
   manager: conda
@@ -9240,8 +9792,8 @@ package:
   hash:
     md5: 776a8dd9e824f77abac30e6ef43a8f7a
     sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: mdurl
   version: 0.1.2
   manager: conda
@@ -9252,8 +9804,8 @@ package:
   hash:
     md5: 776a8dd9e824f77abac30e6ef43a8f7a
     sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: mdurl
   version: 0.1.2
   manager: conda
@@ -9264,22 +9816,8 @@ package:
   hash:
     md5: 776a8dd9e824f77abac30e6ef43a8f7a
     sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
-  category: main
-  optional: false
-- name: mkl
-  version: 2022.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _openmp_mutex: '>=4.5'
-    llvm-openmp: '>=15.0.6'
-    tbb: 2021.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2022.2.1-h84fe81f_16997.conda
-  hash:
-    md5: a7ce56d5757f5b57e7daabe703ade5bb
-    sha256: 5322750d5e96ff5d96b1457db5fb6b10300f2bc4030545e940e17b57c4e96d00
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: mkl
   version: 2021.4.0
   manager: conda
@@ -9327,8 +9865,8 @@ package:
   hash:
     md5: a57fb23d0260a962a67c7d990ec1c812
     sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: more-itertools
   version: 10.3.0
   manager: conda
@@ -9339,8 +9877,8 @@ package:
   hash:
     md5: a57fb23d0260a962a67c7d990ec1c812
     sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: more-itertools
   version: 10.3.0
   manager: conda
@@ -9351,8 +9889,8 @@ package:
   hash:
     md5: a57fb23d0260a962a67c7d990ec1c812
     sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: mpc
   version: 1.3.1
   manager: conda
@@ -9705,8 +10243,8 @@ package:
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
     sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: nodeenv
   version: 1.9.1
   manager: conda
@@ -9718,8 +10256,8 @@ package:
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
     sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: nodeenv
   version: 1.9.1
   manager: conda
@@ -9731,8 +10269,8 @@ package:
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
     sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: nodejs
   version: 20.12.2
   manager: conda
@@ -9750,8 +10288,8 @@ package:
   hash:
     md5: 1fd16ca757a195c4357a1fbb2cb553b5
     sha256: 2f5813d9718963861314c6d9f75fe4630c3e6d078ec1e792770daf9ce7ac5c4f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: nodejs
   version: 20.12.2
   manager: conda
@@ -9767,8 +10305,8 @@ package:
   hash:
     md5: 0ba66fae46df4a035db42e2230453604
     sha256: 81ea2a695b4b97ce6066220b9e54232e67b4a1e3eac3fc7016c08a463c588478
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: nodejs
   version: 20.12.2
   manager: conda
@@ -9778,6 +10316,28 @@ package:
   hash:
     md5: 28d4536e0beff7b51232a5b16f9c3444
     sha256: 31b275bf914d57941e818b31f7ee8367c6c6a8532a2918639c87816bad1323af
+  category: dev
+  optional: true
+- name: nomkl
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  hash:
+    md5: 9a66894dfd07c4510beb6b3f9672ccc0
+    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+  category: main
+  optional: false
+- name: nomkl
+  version: '1.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  hash:
+    md5: 9a66894dfd07c4510beb6b3f9672ccc0
+    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
   category: main
   optional: false
 - name: numba
@@ -9952,8 +10512,8 @@ package:
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
     sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: omegaconf
   version: 2.3.0
   manager: conda
@@ -9967,8 +10527,8 @@ package:
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
     sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: omegaconf
   version: 2.3.0
   manager: conda
@@ -9982,8 +10542,8 @@ package:
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
     sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: openjpeg
   version: 2.5.2
   manager: conda
@@ -10143,8 +10703,8 @@ package:
   hash:
     md5: e30a98410d7a1e9bb3fa713c1fd5c377
     sha256: e9fe499a21223169361bd2277a19bc9486df77a88a6b5d8ed73adb1aa14d025a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: orjson
   version: 3.10.4
   manager: conda
@@ -10157,8 +10717,8 @@ package:
   hash:
     md5: 6b3a5b6525c0dd048218c7505a81f0b5
     sha256: 7d1bec93320924e7a500e136887c00a978e8bfd907845cfe178b02b53a522f00
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: orjson
   version: 3.10.4
   manager: conda
@@ -10170,8 +10730,8 @@ package:
   hash:
     md5: 78665916419f610478a2e7922bcfdf3a
     sha256: 284d2c5ec290aa318a9e1425242faf4ca5874b61e20e7dc386b936addb8b951e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: packaging
   version: '24.1'
   manager: conda
@@ -10284,8 +10844,8 @@ package:
   hash:
     md5: 7c51e110b2f059c0843269d3324e4b22
     sha256: 3d0ef5a908f0429d7821d8a03a6f19ea7801245802c47f7c8c57163ea60e45c7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pango
   version: 1.54.0
   manager: conda
@@ -10304,8 +10864,8 @@ package:
   hash:
     md5: e490cbccf161da2220fd9be3463c0fac
     sha256: 45dd6dc3a5b737871f8bc6a5fd9857d37f6e411f33051ce8043af41c35c7fa02
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pango
   version: 1.54.0
   manager: conda
@@ -10326,8 +10886,8 @@ package:
   hash:
     md5: cef297f5eac752831efd6e680bf980bd
     sha256: f7910cc0ea1cff76adb2bcec81627e10d6b13f1956a47a69422b71cdc554bfe6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: partd
   version: 1.4.2
   manager: conda
@@ -10380,8 +10940,8 @@ package:
   hash:
     md5: a4eea5bff523f26442405bc5d1f52adb
     sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pastel
   version: 0.2.1
   manager: conda
@@ -10392,8 +10952,8 @@ package:
   hash:
     md5: a4eea5bff523f26442405bc5d1f52adb
     sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pastel
   version: 0.2.1
   manager: conda
@@ -10404,8 +10964,8 @@ package:
   hash:
     md5: a4eea5bff523f26442405bc5d1f52adb
     sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pathlib2
   version: 2.3.7.post1
   manager: conda
@@ -10418,8 +10978,8 @@ package:
   hash:
     md5: 972a2dff56a924aa01d2d90b3e6d0837
     sha256: cb0b39f14ec99b892fc25b2733adb8af5a2572786e8528a2dff7138640068177
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pathlib2
   version: 2.3.7.post1
   manager: conda
@@ -10432,8 +10992,8 @@ package:
   hash:
     md5: 1e5fd88aed9ddedbd5ed8f16ff8a7d52
     sha256: 14b02b2274b2882164f089c5cb3f125a103969450ff5674926e88a769febb28a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pathlib2
   version: 2.3.7.post1
   manager: conda
@@ -10446,8 +11006,8 @@ package:
   hash:
     md5: 9e85cb72eff51862c45a7f7c92a88272
     sha256: c930d9ac59ef2b4dcac8f9880028bac7ba78ee183499a5855ce4c85bf7214216
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pathspec
   version: 0.12.1
   manager: conda
@@ -10458,8 +11018,8 @@ package:
   hash:
     md5: 17064acba08d3686f1135b5ec1b32b12
     sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pathspec
   version: 0.12.1
   manager: conda
@@ -10470,8 +11030,8 @@ package:
   hash:
     md5: 17064acba08d3686f1135b5ec1b32b12
     sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pathspec
   version: 0.12.1
   manager: conda
@@ -10482,51 +11042,52 @@ package:
   hash:
     md5: 17064acba08d3686f1135b5ec1b32b12
     sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pcre2
-  version: '10.43'
+  version: '10.44'
   manager: conda
   platform: linux-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
   hash:
-    md5: 8292dea9e022d9610a11fce5e0896ed8
-    sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
-  category: main
-  optional: false
+    md5: 3914f7ac1761dce57102c72ca7c35d01
+    sha256: 90646ad0d8f9d0fd896170c4f3d754e88c4ba0eaf856c24d00842016f644baab
+  category: dev
+  optional: true
 - name: pcre2
-  version: '10.43'
+  version: '10.44'
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_0.conda
   hash:
-    md5: 1ddc87f00014612830f3235b5ad6d821
-    sha256: 4bf7b5fa091f5e7ab0b78778458be1e81c1ffa182b63795734861934945a63a7
-  category: main
-  optional: false
+    md5: 62f8d7e2ef03b0aae64185b0f38316eb
+    sha256: 23ddc5022a1025027ac1957dc1947c70d93a78414fbb183026457a537e8b3770
+  category: dev
+  optional: true
 - name: pcre2
-  version: '10.43'
+  version: '10.44'
   manager: conda
   platform: win-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
   hash:
-    md5: d0485b8aa2cedb141a7bd27b4efa4c9c
-    sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
-  category: main
-  optional: false
+    md5: 007d07ab5027e0bf49f6fa660a9f89a0
+    sha256: 44351611091ed72c4682ad23e53d7874334757298ff0ebb2acd769359ae82ab3
+  category: dev
+  optional: true
 - name: pexpect
   version: 4.9.0
   manager: conda
@@ -10689,8 +11250,8 @@ package:
   hash:
     md5: 71004cbf7924e19c02746ccde9fd7123
     sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pixman
   version: 0.43.4
   manager: conda
@@ -10701,8 +11262,8 @@ package:
   hash:
     md5: 0308c68e711cd295aaa026a4f8c4b1e5
     sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pixman
   version: 0.43.4
   manager: conda
@@ -10715,8 +11276,8 @@ package:
   hash:
     md5: b98135614135d5f458b75ab9ebb9558c
     sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pkginfo
   version: 1.11.1
   manager: conda
@@ -10727,8 +11288,8 @@ package:
   hash:
     md5: 6a3e4fb1396215d0d88b3cc2f09de412
     sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pkginfo
   version: 1.11.1
   manager: conda
@@ -10739,8 +11300,8 @@ package:
   hash:
     md5: 6a3e4fb1396215d0d88b3cc2f09de412
     sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pkginfo
   version: 1.11.1
   manager: conda
@@ -10751,8 +11312,8 @@ package:
   hash:
     md5: 6a3e4fb1396215d0d88b3cc2f09de412
     sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: platformdirs
   version: 3.11.0
   manager: conda
@@ -10764,8 +11325,8 @@ package:
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: platformdirs
   version: 3.11.0
   manager: conda
@@ -10777,8 +11338,8 @@ package:
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: platformdirs
   version: 3.11.0
   manager: conda
@@ -10790,8 +11351,8 @@ package:
   hash:
     md5: 8f567c0a74aa44cf732f15773b4083b0
     sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pluggy
   version: 1.5.0
   manager: conda
@@ -10802,8 +11363,8 @@ package:
   hash:
     md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
     sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pluggy
   version: 1.5.0
   manager: conda
@@ -10814,8 +11375,8 @@ package:
   hash:
     md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
     sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pluggy
   version: 1.5.0
   manager: conda
@@ -10826,8 +11387,8 @@ package:
   hash:
     md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
     sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pre-commit
   version: 3.7.1
   manager: conda
@@ -10890,8 +11451,8 @@ package:
   hash:
     md5: 1247c861065d227781231950e14fe817
     sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: prompt-toolkit
   version: 3.0.47
   manager: conda
@@ -10903,8 +11464,8 @@ package:
   hash:
     md5: 1247c861065d227781231950e14fe817
     sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: prompt-toolkit
   version: 3.0.47
   manager: conda
@@ -10916,8 +11477,8 @@ package:
   hash:
     md5: 1247c861065d227781231950e14fe817
     sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: prompt_toolkit
   version: 3.0.47
   manager: conda
@@ -10928,8 +11489,8 @@ package:
   hash:
     md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
     sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: prompt_toolkit
   version: 3.0.47
   manager: conda
@@ -10940,8 +11501,8 @@ package:
   hash:
     md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
     sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: prompt_toolkit
   version: 3.0.47
   manager: conda
@@ -10952,8 +11513,8 @@ package:
   hash:
     md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
     sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: psutil
   version: 5.9.8
   manager: conda
@@ -11328,8 +11889,8 @@ package:
   hash:
     md5: c4de9699f095e3049dc02bcf811497b7
     sha256: 2c34d272a1afe39afbf4713a7f96366a579cb628a0321159e3015695b1e54913
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pydantic-core
   version: 2.18.4
   manager: conda
@@ -11343,8 +11904,8 @@ package:
   hash:
     md5: d7a6b069772e61897ab8ade15d268dde
     sha256: ca8342ba184e1e9ce1367c7225cbd837516b3d69381a17fc53c434bb2a2a1f0f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pydantic-core
   version: 2.18.4
   manager: conda
@@ -11360,8 +11921,8 @@ package:
   hash:
     md5: e91b2e309604559af562f15b19e39917
     sha256: 675d5c219b68d82af3649564f12e882c49cfafc4a6cc394d3a3ee00f6d14a047
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pydot
   version: 2.0.0
   manager: conda
@@ -11375,8 +11936,8 @@ package:
   hash:
     md5: cdfd23a54a18f3c8d5320d7717f4ed52
     sha256: 091228a33041e667dd03f38684e5f04ef11ef316b8fb0ac21ed2f2ada546e633
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pydot
   version: 2.0.0
   manager: conda
@@ -11390,8 +11951,8 @@ package:
   hash:
     md5: 5ccaf6ac3d5cdb0b2c240f8fa4485d6e
     sha256: 68aaf6ea99daf8093e4f4b426831f51d9d79ff5ae0901f2bab0a47dfee9b5eab
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pydot
   version: 2.0.0
   manager: conda
@@ -11405,8 +11966,8 @@ package:
   hash:
     md5: acccbaf906c36b4c7b2986fffc5b908e
     sha256: f9ea84b56e988b31bd99b3e621d6d092a38f587f7ddecf619f767d9f8d75d735
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygit2
   version: 1.15.0
   manager: conda
@@ -11421,8 +11982,8 @@ package:
   hash:
     md5: 32ebdd6cfcdfa0c8bb9cd06fa2b85b3e
     sha256: 8229d452a19bce44c7f173023ff36827886cf63fbd9f1576f2fdfe12e92176f4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygit2
   version: 1.15.0
   manager: conda
@@ -11437,8 +11998,8 @@ package:
   hash:
     md5: 0b8128cf65ccf05bbcef1dd4f2ab4300
     sha256: 8f8172c83d555b2268112c05e3e22a6a9fcd06d113478b9e75d477d98d2356ca
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygit2
   version: 1.15.0
   manager: conda
@@ -11455,8 +12016,8 @@ package:
   hash:
     md5: e4071da277f4f734bdeca8c98043e96d
     sha256: f69cadd599f784579249606f41c476037768595dfc79f53a916334a6f9bdef2f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygments
   version: 2.18.0
   manager: conda
@@ -11467,8 +12028,8 @@ package:
   hash:
     md5: b7f5c092b8f9800150d998a71b76d5a1
     sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygments
   version: 2.18.0
   manager: conda
@@ -11479,8 +12040,8 @@ package:
   hash:
     md5: b7f5c092b8f9800150d998a71b76d5a1
     sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygments
   version: 2.18.0
   manager: conda
@@ -11491,8 +12052,8 @@ package:
   hash:
     md5: b7f5c092b8f9800150d998a71b76d5a1
     sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygtrie
   version: 2.5.0
   manager: conda
@@ -11503,8 +12064,8 @@ package:
   hash:
     md5: a041d1adf502fc6b3c6a0b0955e29fff
     sha256: c77c8bc76e98ce95e28962c93613472a23cc30d14f523ce5eea625f91cef1e1a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygtrie
   version: 2.5.0
   manager: conda
@@ -11515,8 +12076,8 @@ package:
   hash:
     md5: a041d1adf502fc6b3c6a0b0955e29fff
     sha256: c77c8bc76e98ce95e28962c93613472a23cc30d14f523ce5eea625f91cef1e1a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pygtrie
   version: 2.5.0
   manager: conda
@@ -11527,8 +12088,8 @@ package:
   hash:
     md5: a041d1adf502fc6b3c6a0b0955e29fff
     sha256: c77c8bc76e98ce95e28962c93613472a23cc30d14f523ce5eea625f91cef1e1a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pylev
   version: 1.4.0
   manager: conda
@@ -11539,8 +12100,8 @@ package:
   hash:
     md5: edf8651c4379d9d1495ad6229622d150
     sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pylev
   version: 1.4.0
   manager: conda
@@ -11551,8 +12112,8 @@ package:
   hash:
     md5: edf8651c4379d9d1495ad6229622d150
     sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pylev
   version: 1.4.0
   manager: conda
@@ -11563,8 +12124,8 @@ package:
   hash:
     md5: edf8651c4379d9d1495ad6229622d150
     sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyopenssl
   version: 24.0.0
   manager: conda
@@ -11576,8 +12137,8 @@ package:
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
     sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyopenssl
   version: 24.0.0
   manager: conda
@@ -11589,8 +12150,8 @@ package:
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
     sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyopenssl
   version: 24.0.0
   manager: conda
@@ -11602,8 +12163,8 @@ package:
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
     sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyparsing
   version: 3.1.2
   manager: conda
@@ -11614,8 +12175,8 @@ package:
   hash:
     md5: b9a4dacf97241704529131a0dfc0494f
     sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyparsing
   version: 3.1.2
   manager: conda
@@ -11626,8 +12187,8 @@ package:
   hash:
     md5: b9a4dacf97241704529131a0dfc0494f
     sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyparsing
   version: 3.1.2
   manager: conda
@@ -11638,8 +12199,8 @@ package:
   hash:
     md5: b9a4dacf97241704529131a0dfc0494f
     sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyright
   version: 1.1.367
   manager: conda
@@ -11655,8 +12216,8 @@ package:
   hash:
     md5: 74d20949d6fe2a207b2d9632d8e2a822
     sha256: 2dd3cab564c910200ce7482481e259bf5ab1d262e58d90d522bc9ab792bd55b9
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyright
   version: 1.1.367
   manager: conda
@@ -11671,8 +12232,8 @@ package:
   hash:
     md5: f041b08ae8b5c64bdddda8357496d5c8
     sha256: ce4be02303942a7a16d3a10d3bb8cf6da4adedf4da2f98eb3db676ec433be71e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyright
   version: 1.1.367
   manager: conda
@@ -11689,8 +12250,8 @@ package:
   hash:
     md5: 4c51e348d47dc9a5d0351d113ef32a60
     sha256: f02e99e4193ed742a3ceb8486dc6d398a0005a4f873e3a647eb6f3ddb9dae276
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pysocks
   version: 1.7.1
   manager: conda
@@ -11747,8 +12308,8 @@ package:
   hash:
     md5: 0f3f49c22c7ef3a1195fa61dad3c43be
     sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pytest
   version: 8.2.2
   manager: conda
@@ -11765,8 +12326,8 @@ package:
   hash:
     md5: 0f3f49c22c7ef3a1195fa61dad3c43be
     sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pytest
   version: 8.2.2
   manager: conda
@@ -11783,8 +12344,8 @@ package:
   hash:
     md5: 0f3f49c22c7ef3a1195fa61dad3c43be
     sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: python
   version: 3.11.9
   manager: conda
@@ -11959,8 +12520,8 @@ package:
   hash:
     md5: 84fe6d156520937fd9fc634a88e36a52
     sha256: eabe93b34fe0b53d3ab1163c2d6904bdd6be22f078c84dc4c5309154fd002763
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: python-gssapi
   version: 1.8.3
   manager: conda
@@ -11974,8 +12535,8 @@ package:
   hash:
     md5: 2e922095f5b48586cbb2c08808cb5b7f
     sha256: 29c7cf8578fb383366276427efbc2ae9f9bbb5da63b24b7bd56042386e6eb017
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: python-gssapi
   version: 1.8.3
   manager: conda
@@ -11992,8 +12553,8 @@ package:
   hash:
     md5: 384a5a0aee51e2d50e6da34fa9e8303a
     sha256: b55107429fd288611929d83ac8949d1026b942953303b2beb6b410d803a399e4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: python-tzdata
   version: '2024.1'
   manager: conda
@@ -12110,43 +12671,65 @@ package:
   category: main
   optional: false
 - name: pytorch
-  version: 2.3.1
+  version: 2.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    blas: '*'
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
     filelock: ''
+    fsspec: ''
     jinja2: ''
-    llvm-openmp: <16
-    mkl: '>=2018'
+    libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libstdcxx-ng: '>=12'
+    libtorch: 2.1.2.*
+    libuv: '>=1.48.0,<2.0a0'
     networkx: ''
+    nomkl: ''
+    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
-    pytorch-mutex: '1.0'
-    pyyaml: ''
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-2.3.1-py3.11_cpu_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.2-cpu_generic_py311h255d53b_4.conda
   hash:
-    md5: 1f7a250b13cfcd4f24562707187da2a1
-    sha256: e526af10fa35f9f39b5c356ee5060a29de132d2ccaea060da5d7b6c42c31f16d
+    md5: 740a2e20304b47db2c9a94f180d5be5d
+    sha256: 5822cc6f4cca0dd09899ef9f0e42ad9d1de4243f770d24b4389d545752ffec96
   category: main
   optional: false
 - name: pytorch
-  version: 2.2.2
+  version: 2.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     filelock: ''
+    fsspec: ''
     jinja2: ''
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=16'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libtorch: 2.3.1.*
+    libuv: '>=1.48.0,<2.0a0'
+    llvm-openmp: '>=16.0.6'
     networkx: ''
+    nomkl: ''
+    numpy: '>=1.19,<3'
     python: '>=3.11,<3.12.0a0'
-    pyyaml: ''
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/pytorch/osx-arm64/pytorch-2.2.2-py3.11_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.3.1-cpu_generic_py311h82099cb_0.conda
   hash:
-    md5: cc4d0ea852c3f0e452b97cdc8a6eecfe
-    sha256: 61c94a761abf75ff132943be5c9f812dcc8fa6209ac74754574d1beacf6ef33f
+    md5: 66234dc95e9ce2ec73f62256a9fd7cbd
+    sha256: d2f8e12fc7d7f42bce69a802735ca20286978e4c4350a3e8af060e338b68965e
   category: main
   optional: false
 - name: pytorch
@@ -12172,24 +12755,28 @@ package:
     sha256: bb24d176b407f69b2e6ebb10059697affa02a05746073cbaf8717559cd4ec1d4
   category: main
   optional: false
-- name: pytorch-mutex
-  version: '1.0'
+- name: pytorch-cpu
+  version: 2.1.2
   manager: conda
   platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
+  dependencies:
+    pytorch: 2.1.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-cpu-2.1.2-cpu_generic_py311h9d11763_4.conda
   hash:
-    md5: 49565ed726991fd28d08a39885caa88d
+    md5: 6b72d7c404e09696c7d5d2e393879019
+    sha256: 71663b22bbab86f02784f63d8d2e29706dee02901818bdb0c2f79caf9a48cc4d
   category: main
   optional: false
-- name: pytorch-mutex
-  version: '1.0'
+- name: pytorch-cpu
+  version: 2.3.1
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
+  dependencies:
+    pytorch: 2.3.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.3.1-cpu_generic_py311h7a66607_0.conda
   hash:
-    md5: 49565ed726991fd28d08a39885caa88d
+    md5: 62bfc974de77ce58645111e90ca1ebe1
+    sha256: fac6ca96f30d909916c45cfc2344af9a89ce0eef995cbb27c886302838fc4983
   category: main
   optional: false
 - name: pytorch-mutex
@@ -12252,8 +12839,8 @@ package:
   hash:
     md5: 25df0fc55722ea1a94494f41302e2d1c
     sha256: 79d942817bdaf384602113e5fcb9158dc45cae4044bed308918a5db97f141fdb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pywin32-ctypes
   version: 0.2.2
   manager: conda
@@ -12265,8 +12852,8 @@ package:
   hash:
     md5: e1270294a55b716f9b76900340e8fc82
     sha256: 75a80bda3a87ae9387e8860be7a5271a67846d8929fe8c99799ed40eb085130a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pywin32-on-windows
   version: 0.1.0
   manager: conda
@@ -12278,8 +12865,8 @@ package:
   hash:
     md5: 2807a0becd1d986fe1ef9b7f8135f215
     sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pywin32-on-windows
   version: 0.1.0
   manager: conda
@@ -12291,8 +12878,8 @@ package:
   hash:
     md5: 2807a0becd1d986fe1ef9b7f8135f215
     sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pywin32-on-windows
   version: 0.1.0
   manager: conda
@@ -12304,8 +12891,8 @@ package:
   hash:
     md5: 91733394059b880d9cc0d010c20abda0
     sha256: 09803b75cccc16d8586d2f41ea890658d165f4afc359973fa1c7904a2c140eae
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pyyaml
   version: 6.0.1
   manager: conda
@@ -12458,51 +13045,51 @@ package:
   category: main
   optional: false
 - name: requests
-  version: 2.31.0
+  version: 2.32.3
   manager: conda
   platform: linux-64
   dependencies:
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
     idna: '>=2.5,<4'
-    python: '>=3.7'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+    md5: 5ede4753180c7a550a443c430dc8ab52
+    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
   category: dev
   optional: true
 - name: requests
-  version: 2.31.0
+  version: 2.32.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
     idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
     urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+    md5: 5ede4753180c7a550a443c430dc8ab52
+    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
   category: dev
   optional: true
 - name: requests
-  version: 2.31.0
+  version: 2.32.3
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
     idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
     urllib3: '>=1.21.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+    md5: 5ede4753180c7a550a443c430dc8ab52
+    sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
   category: dev
   optional: true
 - name: rich
@@ -12518,8 +13105,8 @@ package:
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
     sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: rich
   version: 13.7.1
   manager: conda
@@ -12533,8 +13120,8 @@ package:
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
     sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: rich
   version: 13.7.1
   manager: conda
@@ -12548,8 +13135,8 @@ package:
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
     sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruamel.yaml
   version: 0.18.6
   manager: conda
@@ -12563,8 +13150,8 @@ package:
   hash:
     md5: 4dccc0bc3bb4d6e5c30bccbd053c4f90
     sha256: b7056cf0f680a70c24d0a9addea6e8b640bfeafda4c37887e276331757404da0
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruamel.yaml
   version: 0.18.6
   manager: conda
@@ -12577,8 +13164,8 @@ package:
   hash:
     md5: d2a62ffc98713af809060950a6c1d107
     sha256: 7ed21c406b18c0ae1c3f6815afe5d7dcfddc374a0ac212fd9f203767d0a18ad4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruamel.yaml
   version: 0.18.6
   manager: conda
@@ -12594,8 +13181,8 @@ package:
   hash:
     md5: d471ed4194d2e3aa016278223a8fa52c
     sha256: a6914bab1f8350c1c4d1b3cd09cf753d788b2e8bd496d78389390660e5be18cd
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruamel.yaml.clib
   version: 0.2.8
   manager: conda
@@ -12608,8 +13195,8 @@ package:
   hash:
     md5: 7865c897d89a39abc0056d89e37bd9e9
     sha256: b6a4b72ec2a59de0307fca0c699da6238391ee20deb2d121780d10559b5a61a3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruamel.yaml.clib
   version: 0.2.8
   manager: conda
@@ -12621,8 +13208,8 @@ package:
   hash:
     md5: 0fbb200e26cec1931d0337ee70422965
     sha256: 8b64d7ac6d544cdb1c5e3677c3a6ea10f1d87f818888b25df5f3b97f271ef14f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruamel.yaml.clib
   version: 0.2.8
   manager: conda
@@ -12637,10 +13224,10 @@ package:
   hash:
     md5: 4938101fc72fa2a9919c51f194a733cb
     sha256: 40896e9a78f24d108ee5cd4156042e2a71bd40fcf74167af0cca3e2551e02eda
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: ruff
-  version: 0.4.8
+  version: 0.4.9
   manager: conda
   platform: linux-64
   dependencies:
@@ -12648,14 +13235,14 @@ package:
     libstdcxx-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.4.8-py311hae69bc3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.4.9-py311hae69bc3_0.conda
   hash:
-    md5: bc378b1e199bfcc587d60a62cc40eb6c
-    sha256: a1b59b39866f72d542e2ea11fca30e63d3a9957cde2f48661c1246724537b51c
-  category: main
-  optional: false
+    md5: 97b1901b332439b6a3ba8c1ebee8e0ee
+    sha256: 45765e0262e9b9435b653467e7efc50831753e530db808468a95cfb5d211cd38
+  category: dev
+  optional: true
 - name: ruff
-  version: 0.4.8
+  version: 0.4.9
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12663,14 +13250,14 @@ package:
     libcxx: '>=16'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.4.8-py311hd374d79_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.4.9-py311hd374d79_0.conda
   hash:
-    md5: 9d18539bbfd1f729e436d45a5d1ff5ed
-    sha256: c547e2e224446cf020d7e7e7ba30239c7b56f7ebd08341a5761703b9325af630
-  category: main
-  optional: false
+    md5: 48cc00763083875f15a2cf4005ceefeb
+    sha256: edb688fcf874fda757e7034a55b21a7195a7b70fcddbbfb2acaeb3d0ca6446e4
+  category: dev
+  optional: true
 - name: ruff
-  version: 0.4.8
+  version: 0.4.9
   manager: conda
   platform: win-64
   dependencies:
@@ -12679,12 +13266,12 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.4.8-py311ha637bb9_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.4.9-py311ha637bb9_0.conda
   hash:
-    md5: 4a78b9d647d91d13ccce27e03122ea0f
-    sha256: 96711e0444fabbd962748d02a7a04b9d9b7ad78acca70bf1d3e2f19ed97b15b1
-  category: main
-  optional: false
+    md5: 4b660bf499ffff4ddf379b5c4fc443e7
+    sha256: 3b3cbe3f005f86a8e400c3ac1822a3bb82eaf3a61899015d2da40b47d8334cd0
+  category: dev
+  optional: true
 - name: s2n
   version: 1.4.16
   manager: conda
@@ -12699,50 +13286,50 @@ package:
   category: main
   optional: false
 - name: s3fs
-  version: 2024.3.1
+  version: 2024.5.0
   manager: conda
   platform: linux-64
   dependencies:
     aiobotocore: '>=2.5.4,<3.0.0'
     aiohttp: ''
-    fsspec: 2024.3.1
+    fsspec: 2024.5.0
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 09003467a61e115c4652f8b1ffa7ccbb
-    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
-  category: main
-  optional: false
+    md5: 69f9f792aa777125aa284263067d1e97
+    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
+  category: dev
+  optional: true
 - name: s3fs
-  version: 2024.3.1
+  version: 2024.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
     aiohttp: ''
     python: '>=3.8'
     aiobotocore: '>=2.5.4,<3.0.0'
-    fsspec: 2024.3.1
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
+    fsspec: 2024.5.0
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 09003467a61e115c4652f8b1ffa7ccbb
-    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
-  category: main
-  optional: false
+    md5: 69f9f792aa777125aa284263067d1e97
+    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
+  category: dev
+  optional: true
 - name: s3fs
-  version: 2024.3.1
+  version: 2024.5.0
   manager: conda
   platform: win-64
   dependencies:
     aiohttp: ''
     python: '>=3.8'
     aiobotocore: '>=2.5.4,<3.0.0'
-    fsspec: 2024.3.1
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.3.1-pyhd8ed1ab_0.conda
+    fsspec: 2024.5.0
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 09003467a61e115c4652f8b1ffa7ccbb
-    sha256: a893cf822ca952cacb89ffa3daf312a4c367056a94db942ad792dcd672940f42
-  category: main
-  optional: false
+    md5: 69f9f792aa777125aa284263067d1e97
+    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
+  category: dev
+  optional: true
 - name: s3transfer
   version: 0.10.1
   manager: conda
@@ -12754,8 +13341,8 @@ package:
   hash:
     md5: a41cafc1fb653ce0e48b9310226e90fd
     sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: s3transfer
   version: 0.10.1
   manager: conda
@@ -12767,8 +13354,8 @@ package:
   hash:
     md5: a41cafc1fb653ce0e48b9310226e90fd
     sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: s3transfer
   version: 0.10.1
   manager: conda
@@ -12780,8 +13367,8 @@ package:
   hash:
     md5: a41cafc1fb653ce0e48b9310226e90fd
     sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: safetensors
   version: 0.4.3
   manager: conda
@@ -12907,8 +13494,8 @@ package:
   hash:
     md5: 633f93803051c8eae944808e40c17976
     sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: scmrepo
   version: 3.3.5
   manager: conda
@@ -12929,8 +13516,8 @@ package:
   hash:
     md5: 633f93803051c8eae944808e40c17976
     sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: scmrepo
   version: 3.3.5
   manager: conda
@@ -12951,8 +13538,8 @@ package:
   hash:
     md5: 633f93803051c8eae944808e40c17976
     sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: secretstorage
   version: 3.3.3
   manager: conda
@@ -12967,8 +13554,8 @@ package:
   hash:
     md5: 30a57eaa8e72cb0c2c84d6d7db32010c
     sha256: 45e7d85a3663993e8bffdb7c6040561923c848e3262228b163042663caa4485e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: seedbank
   version: 0.1.3
   manager: conda
@@ -13021,8 +13608,8 @@ package:
   hash:
     md5: 5efb3fccda53974aed800b6d575f72ed
     sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: semver
   version: 3.0.2
   manager: conda
@@ -13033,8 +13620,8 @@ package:
   hash:
     md5: 5efb3fccda53974aed800b6d575f72ed
     sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: semver
   version: 3.0.2
   manager: conda
@@ -13045,8 +13632,8 @@ package:
   hash:
     md5: 5efb3fccda53974aed800b6d575f72ed
     sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: setuptools
   version: 70.0.0
   manager: conda
@@ -13093,8 +13680,8 @@ package:
   hash:
     md5: d08db09a552699ee9e7eec56b4eb3899
     sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shellingham
   version: 1.5.4
   manager: conda
@@ -13105,8 +13692,8 @@ package:
   hash:
     md5: d08db09a552699ee9e7eec56b4eb3899
     sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shellingham
   version: 1.5.4
   manager: conda
@@ -13117,8 +13704,8 @@ package:
   hash:
     md5: d08db09a552699ee9e7eec56b4eb3899
     sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shortuuid
   version: 1.0.13
   manager: conda
@@ -13129,8 +13716,8 @@ package:
   hash:
     md5: 241e47b9e59bd1689ba0c444306fe6b1
     sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shortuuid
   version: 1.0.13
   manager: conda
@@ -13141,8 +13728,8 @@ package:
   hash:
     md5: 241e47b9e59bd1689ba0c444306fe6b1
     sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shortuuid
   version: 1.0.13
   manager: conda
@@ -13153,8 +13740,8 @@ package:
   hash:
     md5: 241e47b9e59bd1689ba0c444306fe6b1
     sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shtab
   version: 1.7.1
   manager: conda
@@ -13165,8 +13752,8 @@ package:
   hash:
     md5: c5cf937409ac178717946edbfa82a5da
     sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shtab
   version: 1.7.1
   manager: conda
@@ -13177,8 +13764,8 @@ package:
   hash:
     md5: c5cf937409ac178717946edbfa82a5da
     sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: shtab
   version: 1.7.1
   manager: conda
@@ -13189,8 +13776,8 @@ package:
   hash:
     md5: c5cf937409ac178717946edbfa82a5da
     sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: six
   version: 1.16.0
   manager: conda
@@ -13225,6 +13812,31 @@ package:
   hash:
     md5: e5f25f8dbc060e9a8d912e432202afc2
     sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  category: main
+  optional: false
+- name: sleef
+  version: 3.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    libgcc-ng: '>=9.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h9b69904_2.tar.bz2
+  hash:
+    md5: 6e016cf4c525d04a7bd038cee53ad3fd
+    sha256: 77d644a16f682e6d01df63fe9d25315011393498b63cf08c0e548780e46b2170
+  category: main
+  optional: false
+- name: sleef
+  version: 3.5.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    llvm-openmp: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.5.1-h156473d_2.tar.bz2
+  hash:
+    md5: bd159e7f04dbf79b06ed2bd37e112458
+    sha256: a3d20bed697aaababfcb53ca2011486cf5e44e20855142c170fa0826df5f952c
   category: main
   optional: false
 - name: smart-open
@@ -13312,8 +13924,8 @@ package:
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: smmap
   version: 5.0.0
   manager: conda
@@ -13324,8 +13936,8 @@ package:
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: smmap
   version: 5.0.0
   manager: conda
@@ -13336,8 +13948,8 @@ package:
   hash:
     md5: 62f26a3d1387acee31322208f0cfa3e0
     sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: snappy
   version: 1.2.0
   manager: conda
@@ -13377,6 +13989,42 @@ package:
     sha256: de02a222071d6a832ad3b790c8c977725161ad430ec694fd7b35769b6e1104b4
   category: main
   optional: false
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: dev
+  optional: true
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: dev
+  optional: true
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: dev
+  optional: true
 - name: sortedcontainers
   version: 2.4.0
   manager: conda
@@ -13426,8 +14074,8 @@ package:
   hash:
     md5: b51fd2979cbda01f74ebaf7e4c2d632b
     sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: sqltrie
   version: 0.11.0
   manager: conda
@@ -13441,8 +14089,8 @@ package:
   hash:
     md5: b51fd2979cbda01f74ebaf7e4c2d632b
     sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: sqltrie
   version: 0.11.0
   manager: conda
@@ -13456,8 +14104,8 @@ package:
   hash:
     md5: b51fd2979cbda01f74ebaf7e4c2d632b
     sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: swifter
   version: 1.4.0
   manager: conda
@@ -13507,7 +14155,7 @@ package:
   category: main
   optional: false
 - name: sympy
-  version: '1.12'
+  version: 1.12.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -13515,14 +14163,14 @@ package:
     gmpy2: '>=2.0.8'
     mpmath: '>=0.19'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
   hash:
-    md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
-    sha256: 0025dd4e6411423903bf478d1b9fbff0cbbbe546f51c9375dfd6729ef2e1a1ac
+    md5: 4af9db19148140eb2ff3b2a93697063b
+    sha256: a365a6d6f47953cd1fe8be234c2d51b1ac6990a288865126cf32197b3f256a15
   category: main
   optional: false
 - name: sympy
-  version: '1.12'
+  version: 1.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13530,23 +14178,23 @@ package:
     python: '*'
     mpmath: '>=0.19'
     gmpy2: '>=2.0.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
   hash:
-    md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
-    sha256: 0025dd4e6411423903bf478d1b9fbff0cbbbe546f51c9375dfd6729ef2e1a1ac
+    md5: 4af9db19148140eb2ff3b2a93697063b
+    sha256: a365a6d6f47953cd1fe8be234c2d51b1ac6990a288865126cf32197b3f256a15
   category: main
   optional: false
 - name: sympy
-  version: '1.12'
+  version: 1.12.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
     mpmath: '>=0.19'
-  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pyh04b8f61_3.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pyh04b8f61_3.conda
   hash:
-    md5: 6af285473a6a49ea8068e0b5b28ed7de
-    sha256: 75b525ecb0948380796f519fe723470d52f9369e23c68f194c28f34df5e49b39
+    md5: 2a2ecb906ec4efabca7e40bd36b627c8
+    sha256: cd488f0c44dec1f1f5d0c65144d144ccb5f8325c63bfcc60ab81e557d8bfc2b2
   category: main
   optional: false
 - name: tabulate
@@ -13559,8 +14207,8 @@ package:
   hash:
     md5: 4759805cce2d914c38472f70bf4d8bcb
     sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tabulate
   version: 0.9.0
   manager: conda
@@ -13571,8 +14219,8 @@ package:
   hash:
     md5: 4759805cce2d914c38472f70bf4d8bcb
     sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tabulate
   version: 0.9.0
   manager: conda
@@ -13583,22 +14231,8 @@ package:
   hash:
     md5: 4759805cce2d914c38472f70bf4d8bcb
     sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: main
-  optional: false
-- name: tbb
-  version: 2021.12.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libhwloc: '>=2.10.0,<2.10.1.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h297d8ca_1.conda
-  hash:
-    md5: 3ff978d8994f591818a506640c6a7071
-    sha256: ab706931ba80e8117995fc838509f044ccd1388a4cd7cc4ff1a55ea904bac723
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tbb
   version: 2021.12.0
   manager: conda
@@ -13748,8 +14382,8 @@ package:
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tomli
   version: 2.0.1
   manager: conda
@@ -13760,8 +14394,8 @@ package:
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tomli
   version: 2.0.1
   manager: conda
@@ -13772,8 +14406,44 @@ package:
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: tomli-w
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 73506d1ab4202481841c68c169b7ef6c
+    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
+  category: dev
+  optional: true
+- name: tomli-w
+  version: 1.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 73506d1ab4202481841c68c169b7ef6c
+    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
+  category: dev
+  optional: true
+- name: tomli-w
+  version: 1.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 73506d1ab4202481841c68c169b7ef6c
+    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
+  category: dev
+  optional: true
 - name: tomlkit
   version: 0.12.5
   manager: conda
@@ -13784,8 +14454,8 @@ package:
   hash:
     md5: e5dde5caf905e9d95895e05f94967e14
     sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tomlkit
   version: 0.12.5
   manager: conda
@@ -13796,8 +14466,8 @@ package:
   hash:
     md5: e5dde5caf905e9d95895e05f94967e14
     sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tomlkit
   version: 0.12.5
   manager: conda
@@ -13808,8 +14478,8 @@ package:
   hash:
     md5: e5dde5caf905e9d95895e05f94967e14
     sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: toolz
   version: 0.12.1
   manager: conda
@@ -13998,6 +14668,42 @@ package:
     sha256: fd8921a42d1d94052c13a2365969a8598280b1986b117c8507abb39a50477711
   category: main
   optional: false
+- name: trove-classifiers
+  version: 2024.5.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: a887538e7f6697ed52a487dbaa0ebff5
+    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+  category: dev
+  optional: true
+- name: trove-classifiers
+  version: 2024.5.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: a887538e7f6697ed52a487dbaa0ebff5
+    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+  category: dev
+  optional: true
+- name: trove-classifiers
+  version: 2024.5.22
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: a887538e7f6697ed52a487dbaa0ebff5
+    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+  category: dev
+  optional: true
 - name: typer
   version: 0.12.3
   manager: conda
@@ -14009,8 +14715,8 @@ package:
   hash:
     md5: 10efd02b22c39c0a46312ef7cb16d237
     sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer
   version: 0.12.3
   manager: conda
@@ -14022,8 +14728,8 @@ package:
   hash:
     md5: 10efd02b22c39c0a46312ef7cb16d237
     sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer
   version: 0.12.3
   manager: conda
@@ -14035,8 +14741,8 @@ package:
   hash:
     md5: 10efd02b22c39c0a46312ef7cb16d237
     sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer-slim
   version: 0.12.3
   manager: conda
@@ -14049,8 +14755,8 @@ package:
   hash:
     md5: cf2c3a89f89644c53cadbfeb124914e9
     sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer-slim
   version: 0.12.3
   manager: conda
@@ -14063,8 +14769,8 @@ package:
   hash:
     md5: cf2c3a89f89644c53cadbfeb124914e9
     sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer-slim
   version: 0.12.3
   manager: conda
@@ -14077,8 +14783,8 @@ package:
   hash:
     md5: cf2c3a89f89644c53cadbfeb124914e9
     sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer-slim-standard
   version: 0.12.3
   manager: conda
@@ -14091,8 +14797,8 @@ package:
   hash:
     md5: 8e56b98837d17e6ace4dc455d905709a
     sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer-slim-standard
   version: 0.12.3
   manager: conda
@@ -14105,8 +14811,8 @@ package:
   hash:
     md5: 8e56b98837d17e6ace4dc455d905709a
     sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typer-slim-standard
   version: 0.12.3
   manager: conda
@@ -14119,8 +14825,8 @@ package:
   hash:
     md5: 8e56b98837d17e6ace4dc455d905709a
     sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: typing-extensions
   version: 4.12.2
   manager: conda
@@ -14327,6 +15033,85 @@ package:
     sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
   category: main
   optional: false
+- name: userpath
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5bf074c9253a3bf914becfc50757406f
+    sha256: c8cbddd625340e1b00b53bafabc764526ee85f7ddb91018424bab0eea057796d
+  category: dev
+  optional: true
+- name: userpath
+  version: 1.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5bf074c9253a3bf914becfc50757406f
+    sha256: c8cbddd625340e1b00b53bafabc764526ee85f7ddb91018424bab0eea057796d
+  category: dev
+  optional: true
+- name: userpath
+  version: 1.7.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5bf074c9253a3bf914becfc50757406f
+    sha256: c8cbddd625340e1b00b53bafabc764526ee85f7ddb91018424bab0eea057796d
+  category: dev
+  optional: true
+- name: uv
+  version: 0.2.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.6-h0ea3d13_0.conda
+  hash:
+    md5: 59b5b6fd31fe993afe844687c36f64b5
+    sha256: a3476e0af359a15fcc4e575b106cd4d44d9633de43f83687c82a2b3b657ecb54
+  category: dev
+  optional: true
+- name: uv
+  version: 0.2.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.6-hc069d6b_0.conda
+  hash:
+    md5: d02bbc69d6ddfbcd822f64643360ec81
+    sha256: be826015f52a30931940291ceafea4b57d8cb539bae21974fe252cf5b3dc8486
+  category: dev
+  optional: true
+- name: uv
+  version: 0.2.6
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.6-ha08ef0e_0.conda
+  hash:
+    md5: 434644f2e1bc03498baf906a4f318ee7
+    sha256: 7884ae5d1027c20d79242a633ba0e6578c28f628f0c6c8e4e56f95dcc8667c96
+  category: dev
+  optional: true
 - name: vc
   version: '14.3'
   manager: conda
@@ -14361,8 +15146,8 @@ package:
   hash:
     md5: af71debe5f1819b065c0ba2b062ae81c
     sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: vine
   version: 5.1.0
   manager: conda
@@ -14373,8 +15158,8 @@ package:
   hash:
     md5: af71debe5f1819b065c0ba2b062ae81c
     sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: vine
   version: 5.1.0
   manager: conda
@@ -14385,8 +15170,8 @@ package:
   hash:
     md5: af71debe5f1819b065c0ba2b062ae81c
     sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: virtualenv
   version: 20.26.2
   manager: conda
@@ -14400,8 +15185,8 @@ package:
   hash:
     md5: 7d36e7a485ea2f5829408813bdbbfb38
     sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: virtualenv
   version: 20.26.2
   manager: conda
@@ -14415,8 +15200,8 @@ package:
   hash:
     md5: 7d36e7a485ea2f5829408813bdbbfb38
     sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: virtualenv
   version: 20.26.2
   manager: conda
@@ -14430,8 +15215,8 @@ package:
   hash:
     md5: 7d36e7a485ea2f5829408813bdbbfb38
     sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: voluptuous
   version: 0.14.2
   manager: conda
@@ -14442,8 +15227,8 @@ package:
   hash:
     md5: d61310a459c334702a00a2b7f4fc534c
     sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: voluptuous
   version: 0.14.2
   manager: conda
@@ -14454,8 +15239,8 @@ package:
   hash:
     md5: d61310a459c334702a00a2b7f4fc534c
     sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: voluptuous
   version: 0.14.2
   manager: conda
@@ -14466,8 +15251,8 @@ package:
   hash:
     md5: d61310a459c334702a00a2b7f4fc534c
     sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: vs2015_runtime
   version: 14.40.33810
   manager: conda
@@ -14490,8 +15275,8 @@ package:
   hash:
     md5: 68f0738df502a14213624b288c60c9ad
     sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: wcwidth
   version: 0.2.13
   manager: conda
@@ -14502,8 +15287,8 @@ package:
   hash:
     md5: 68f0738df502a14213624b288c60c9ad
     sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: wcwidth
   version: 0.2.13
   manager: conda
@@ -14514,8 +15299,8 @@ package:
   hash:
     md5: 68f0738df502a14213624b288c60c9ad
     sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: webencodings
   version: 0.5.1
   manager: conda
@@ -14526,8 +15311,8 @@ package:
   hash:
     md5: daf5160ff9cde3a468556965329085b9
     sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: webencodings
   version: 0.5.1
   manager: conda
@@ -14538,8 +15323,8 @@ package:
   hash:
     md5: daf5160ff9cde3a468556965329085b9
     sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: webencodings
   version: 0.5.1
   manager: conda
@@ -14550,8 +15335,8 @@ package:
   hash:
     md5: daf5160ff9cde3a468556965329085b9
     sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: wheel
   version: 0.43.0
   manager: conda
@@ -14654,8 +15439,8 @@ package:
   hash:
     md5: 4b230e8381279d76131116660f5a241a
     sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-kbproto
   version: 1.0.7
   manager: conda
@@ -14666,8 +15451,8 @@ package:
   hash:
     md5: 8d11c1dac4756ca57e78c1bfe173bba4
     sha256: 5b16e1ca1ecc0d2907f236bc4d8e6ecfd8417db013c862a01afb7f9d78e48c09
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libice
   version: 1.1.1
   manager: conda
@@ -14678,8 +15463,8 @@ package:
   hash:
     md5: b462a33c0be1421532f28bfe8f4a7514
     sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libice
   version: 1.1.1
   manager: conda
@@ -14692,8 +15477,8 @@ package:
   hash:
     md5: 5271e3af4791170e2c55d02818366916
     sha256: 353e07e311eb10e934f03e0123d0f05d9b3770a70b0c3993e6d11cf74d85689f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libsm
   version: 1.2.4
   manager: conda
@@ -14706,8 +15491,8 @@ package:
   hash:
     md5: 93ee23f12bc2e684548181256edd2cf6
     sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libsm
   version: 1.2.4
   manager: conda
@@ -14720,8 +15505,8 @@ package:
   hash:
     md5: 25926681339df15918243d9a7cec25a1
     sha256: 3a8cc151142c379d3ec3ec4420395d3a273873d3a45a94cd3038d143f5a519e8
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libx11
   version: 1.8.9
   manager: conda
@@ -14736,8 +15521,8 @@ package:
   hash:
     md5: 077b6e8ad6a3ddb741fce2496dd01bec
     sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libx11
   version: 1.8.9
   manager: conda
@@ -14753,8 +15538,8 @@ package:
   hash:
     md5: 3672e991346895f332af1ebc60b8bca9
     sha256: 15217b9180ff7d6840762363647fabcb79636517454d2c05dd69cb3fc38a1001
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxau
   version: 1.0.11
   manager: conda
@@ -14838,8 +15623,8 @@ package:
   hash:
     md5: 82b6df12252e6f32402b96dacc656fec
     sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxext
   version: 1.3.4
   manager: conda
@@ -14852,8 +15637,8 @@ package:
   hash:
     md5: 2aa695ac3c56193fd8d526e3b511e021
     sha256: 829320f05866ea1cc51924828427f215f4d0db093e748a662e3bb68b764785a4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxpm
   version: 3.5.17
   manager: conda
@@ -14870,8 +15655,8 @@ package:
   hash:
     md5: 029be9b667bf3896fa28bc32adb1bfc3
     sha256: d5cc2f026658e8b85679813bff35c16c857f873ba02489e6eb6e30d5865dacc4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxrender
   version: 0.9.11
   manager: conda
@@ -14884,8 +15669,8 @@ package:
   hash:
     md5: ed67c36f215b310412b2af935bf3e530
     sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxt
   version: 1.3.0
   manager: conda
@@ -14902,8 +15687,8 @@ package:
   hash:
     md5: 511a29edd2ff3d973f63e54f19dcc06e
     sha256: d513e0c627f098ef6655ce188eca79a672eaf763b0bbf37b228cb46dc82a66ca
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-renderproto
   version: 0.11.1
   manager: conda
@@ -14914,8 +15699,8 @@ package:
   hash:
     md5: 06feff3d2634e3097ce2fe681474b534
     sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-xextproto
   version: 7.3.0
   manager: conda
@@ -14926,8 +15711,8 @@ package:
   hash:
     md5: bce9f945da8ad2ae9b1d7165a64d0f87
     sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-xextproto
   version: 7.3.0
   manager: conda
@@ -14938,8 +15723,8 @@ package:
   hash:
     md5: 6e6c2639620e436bddb7c040cd4f3adb
     sha256: 04c0a08fd34fa33406c20f729e8f9cc40e8fd898072b952a5c14280fcf26f2e6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-xproto
   version: 7.0.31
   manager: conda
@@ -14950,8 +15735,8 @@ package:
   hash:
     md5: b4a4381d54784606820704f7b5f05a15
     sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-xproto
   version: 7.0.31
   manager: conda
@@ -14962,8 +15747,8 @@ package:
   hash:
     md5: 88f3c65d2ad13826a9e0b162063be023
     sha256: b84cacba8479fa14199c9255fb62e005cacc619e90198c53b1653973709ec331
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xxhash
   version: 0.8.2
   manager: conda
@@ -15169,8 +15954,8 @@ package:
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
     sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zc.lockfile
   version: 3.0.post1
   manager: conda
@@ -15182,8 +15967,8 @@ package:
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
     sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zc.lockfile
   version: 3.0.post1
   manager: conda
@@ -15195,8 +15980,8 @@ package:
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
     sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zict
   version: 3.0.0
   manager: conda
@@ -15280,8 +16065,8 @@ package:
   hash:
     md5: 9653f1bf3766164d0e65fa723cabbc54
     sha256: cee16ab07a11303de721915f0a269e8c7a54a5c834aa52f74b1cc3a59000ade8
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zlib
   version: 1.3.1
   manager: conda
@@ -15293,8 +16078,8 @@ package:
   hash:
     md5: f27e021db7862b6ddbc1d3578f10d883
     sha256: 87360c2dc662916aac37cf01e53324b4f4f78db6f399220818076752b093ede5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zlib
   version: 1.3.1
   manager: conda
@@ -15308,8 +16093,54 @@ package:
   hash:
     md5: f8e0a35bf6df768ad87ed7bbbc36ab04
     sha256: 76409556e6c7cb91991cd94d7fc853c9272c2872bd7e3573ff35eb33d6fca5be
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: zstandard
+  version: 0.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cffi: '>=1.8'
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py311hd4cff14_0.tar.bz2
+  hash:
+    md5: 056b3271f46abaa4673c8c6783283a07
+    sha256: 8aac43cc4fbdcc420fe8a22c764b67f6ac9168b103bfd10d79a82b748304ddf6
+  category: dev
+  optional: true
+- name: zstandard
+  version: 0.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cffi: '>=1.8'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py311he2be06e_0.tar.bz2
+  hash:
+    md5: ece21cb47a93c985aa4b44219c4c8c8b
+    sha256: 43eaee70cd406468d96d1643b75d16e0da3955a9c1d37056767134b91b61d515
+  category: dev
+  optional: true
+- name: zstandard
+  version: 0.19.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    cffi: '>=1.8'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vs2015_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.19.0-py311ha68e1ae_0.tar.bz2
+  hash:
+    md5: 94114ffe0cad9e1e704e2c0015c8aa87
+    sha256: c687a7d884e98c69f4f1fee8cb9949157bba7c76a54176edeb3262c156e08e71
+  category: dev
+  optional: true
 - name: zstd
   version: 1.5.6
   manager: conda

--- a/dev/constraints.yml
+++ b/dev/constraints.yml
@@ -1,0 +1,7 @@
+# Mixin environment file for the conda-lock process to select appropriate
+# PyTorch and compute implementations for our environments.
+dependencies:
+  - pytorch-mutex =*=cpu # [win]
+  - pytorch-cpu # [linux]
+  - pytorch-cpu # [osx]
+  - nomkl # [linux]

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -1,0 +1,23 @@
+# Dependencies needed for working on the poprox-recommender code and repo.
+# This does *not* include the dependencies of poprox-recommender itself —
+# it is only the tooling and dependencies for development, image building,
+# etc.  It is included in the conda lockfile as the 'dev' category, and
+# can be directly installed in CI for repo manipulation.
+category: dev
+dependencies:
+  # tooling for environments and data
+  - dvc >=3.51,<4
+  - dvc-s3
+  - conda-lock >=2.5,<3
+  - hatch
+  # dependencies for development scripts
+  - docopt >=0.6
+  - requests >=2.31,<3
+  # dependencies for tests
+  - pytest >=7
+  - coverage >=6.5
+  - pexpect~=4.9
+  # tooling for code validation
+  - pre-commit >=3.7,<4
+  - ruff >=0.4
+  - pyright >=1.1,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,6 @@ dependencies = [
   "poprox-concepts@git+https://github.com/CCRI-POPROX/poprox-concepts.git@main",
 ]
 
-[project.optional-dependencies]
-# this is sub-optimal for various reasons, but it's the best way with conda-lock
-dev = ["dvc[s3]==3.*", "docopt>=0.6", "requests~=2.31", "pre-commit>=3.7,<4"]
-test = ["pexpect~=4.9"]
-
 [project.urls]
 Documentation = "https://github.com/CCRI-POPROX/poprox-recommender#readme"
 Issues = "https://github.com/CCRI-POPROX/poprox-recommender/issues"
@@ -40,13 +35,19 @@ allow-direct-references = true
 path = "src/poprox_recommender/__about__.py"
 
 [tool.hatch.envs.default]
+python = "3.11"
+# keep these dependencies in sync with dev/dev-environment.yml
 dependencies = [
+  "dvc[s3] ~=3.51",
+  "conda-lock ~=2.5",
+  "docopt~=0.6",
+  "requests~=2.13",
   "coverage[toml]>=6.5",
   "pytest>=8",
   "pexpect~=4.9",
-  "requests~=2.13",
 ]
 [tool.hatch.envs.default.scripts]
+lock-deps = "conda-lock -f pyproject.toml -f dev/constraints.yml -f dev/environment.yml"
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
@@ -121,23 +122,8 @@ channels = ["pytorch", "conda-forge", "nodefaults"]
 platforms = ["win-64", "linux-64", "osx-arm64"]
 # extra deps in the conda environment
 [tool.conda-lock.dependencies]
-# specify our Python version
+# specify our Python version & make sure we have pip
 python = "=3.11"
-# need pip in deployment too
 pip = ">=24"
-# conda doesn't support extras, so this pulls in the DVC S3 support
-dvc-s3 = "=3"
-# the end-to-end recommender is deployed without CUDA, so force CPU PyTorch.
-# this does not prevent us from using CUDA in the model repo to train models,
-# as it will get its own environments.
-pytorch-mutex = "=*=cpu"
-# conda-lock doesn't look in Hatch environments, so this pulls in dev deps
-ruff = ">=0.4"
-pyright = ">=1.1,<2"
-pytest = ">=7"
-coverage = ">=6.5"
 # poprox concepts comes from PyPI
 poprox-concepts = { source = "pypi" }
-# we want conda-lock to manage the lockfiles
-conda-lock = ">=2.5,<3"
-# TODO: find a way to force MKL BLAS, but only on X86-64.


### PR DESCRIPTION
This refactors the Conda dependency specifications into `dev/environment.yml`, defining the development tools, and `dev/constraints.yml` providing additional constraints for locking environments.

This provides better categorization of dependencies in the lock file, so we can install the recommenders without the dev dependencies using Conda, and allows easier use of Conda to install only the dev deps when just tooling but not the ability to run code is required (e.g. fetching data to build the Docker image).

Nothing changes from the developer perspective installing their environment from the lock file — all that changes is how we create it.