### PR TITLE
Integrate onboarding topic selections into PFAR diversification

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -6,8 +6,6 @@
 #
 # Install this environment as "YOURENV" with:
 #     conda-lock install -n YOURENV conda-lock.yml
-# This lock contains optional development dependencies. Include them in the installed environment with:
-#     conda-lock install --dev-dependencies -n YOURENV conda-lock.yml
 # To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock  --lockfile conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
@@ -15,9 +13,9 @@
 version: 1
 metadata:
   content_hash:
-    win-64: 6c39a44d5438e1d79a4ac8a3e8c23955965213027b7de274e4a3396f9c549f2d
-    linux-64: 1d9d1e71aad10c004459c5d8d5fb9bd9122069605cdd1b2a6051985b0cc81d1b
-    osx-arm64: 3abb80be54e0525ff04b6ec2344661ed714e6733003e259d9851727a0d8e222c
+    win-64: ca0278239d274fb711a3f3db52a9c0de176fc6210e9ffa2044f453810225b184
+    linux-64: ba1e15e3b55c4d042969abe92d23ac56586cc5220924c3a5020690fe4cb8d0f7
+    osx-arm64: ccce201a9f1383bc750905aba2c5ad998a4dbe9559d4510f0a2bac2f41a47016
   channels:
   - url: pytorch
     used_env_vars: []
@@ -49,61 +47,13 @@ package:
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+    llvm-openmp: '>=9.0.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
   hash:
-    md5: 73aaf86a425cc6e73fcf236a5a46396d
-    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+    md5: 562b26ba2e19059551a811e72ab7f793
+    sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
   category: main
   optional: false
-- name: aiobotocore
-  version: 2.13.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiohttp: '>=3.9.2,<4.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.107'
-    python: '>=3.8'
-    wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c1ba7be2b8a71c6a9de23402a5810ea2
-    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
-  category: dev
-  optional: true
-- name: aiobotocore
-  version: 2.13.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    botocore: '>=1.34.70,<1.34.107'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c1ba7be2b8a71c6a9de23402a5810ea2
-    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
-  category: dev
-  optional: true
-- name: aiobotocore
-  version: 2.13.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    botocore: '>=1.34.70,<1.34.107'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c1ba7be2b8a71c6a9de23402a5810ea2
-    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
-  category: dev
-  optional: true
 - name: aiohttp
   version: 3.9.5
   manager: conda
@@ -162,84 +112,6 @@ package:
     sha256: 03e161ef1e710089630276964921bb6de9c9852d0b04a59e3fe528c608327767
   category: main
   optional: false
-- name: aiohttp-retry
-  version: 2.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiohttp: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohttp-retry-2.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 63075586964c3e0d53e1a8d804d89090
-    sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
-  category: dev
-  optional: true
-- name: aiohttp-retry
-  version: 2.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aiohttp: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohttp-retry-2.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 63075586964c3e0d53e1a8d804d89090
-    sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
-  category: dev
-  optional: true
-- name: aiohttp-retry
-  version: 2.8.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    aiohttp: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohttp-retry-2.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 63075586964c3e0d53e1a8d804d89090
-    sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
-  category: dev
-  optional: true
-- name: aioitertools
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: dev
-  optional: true
-- name: aioitertools
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: dev
-  optional: true
-- name: aioitertools
-  version: 0.11.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-    typing_extensions: '>=4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 59c40397276a286241c65faec5e1be3c
-    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
-  category: dev
-  optional: true
 - name: aiosignal
   version: 1.3.1
   manager: conda
@@ -258,8 +130,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -271,128 +143,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
     sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
   category: main
   optional: false
-- name: amqp
-  version: 5.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    vine: '>=5.0.0,<6.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/amqp-5.2.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 23e198e6df09c2c441640f1bcd1c7822
-    sha256: d445abfa5580fc4978eae39dd9268379cc6cffdb630108b38b03f0032899bc63
-  category: dev
-  optional: true
-- name: amqp
-  version: 5.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-    vine: '>=5.0.0,<6.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/amqp-5.2.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 23e198e6df09c2c441640f1bcd1c7822
-    sha256: d445abfa5580fc4978eae39dd9268379cc6cffdb630108b38b03f0032899bc63
-  category: dev
-  optional: true
-- name: amqp
-  version: 5.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-    vine: '>=5.0.0,<6.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/amqp-5.2.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 23e198e6df09c2c441640f1bcd1c7822
-    sha256: d445abfa5580fc4978eae39dd9268379cc6cffdb630108b38b03f0032899bc63
-  category: dev
-  optional: true
-- name: annotated-types
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: dev
-  optional: true
-- name: annotated-types
-  version: 0.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: dev
-  optional: true
-- name: annotated-types
-  version: 0.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7e9f4612544c8edbfd6afad17f1bd045
-    sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: dev
-  optional: true
-- name: antlr-python-runtime
-  version: 4.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/antlr-python-runtime-4.9.3-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c88eaec8de9ae1fa161205aa18e7a5b1
-    sha256: b91f8ab4ac2b48972fbee1fc8e092cc452fdf59156e4ff2322c94bbf73650f94
-  category: dev
-  optional: true
-- name: antlr-python-runtime
-  version: 4.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/antlr-python-runtime-4.9.3-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c88eaec8de9ae1fa161205aa18e7a5b1
-    sha256: b91f8ab4ac2b48972fbee1fc8e092cc452fdf59156e4ff2322c94bbf73650f94
-  category: dev
-  optional: true
-- name: antlr-python-runtime
-  version: 4.9.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/antlr-python-runtime-4.9.3-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c88eaec8de9ae1fa161205aa18e7a5b1
-    sha256: b91f8ab4ac2b48972fbee1fc8e092cc452fdf59156e4ff2322c94bbf73650f94
-  category: dev
-  optional: true
 - name: anyconfig
   version: 0.14.0
   manager: conda
@@ -411,8 +169,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.6'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyconfig-0.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6db9c8d8592eeb6ee25a8a90f137fe25
@@ -424,211 +182,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.6'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyconfig-0.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6db9c8d8592eeb6ee25a8a90f137fe25
     sha256: ae29de72b8e0b8fefb8d2778b29f7cee0a01ba99691c5e353f0843274365008b
   category: main
   optional: false
-- name: anyio
-  version: 4.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    exceptiongroup: '>=1.0.2'
-    idna: '>=2.8'
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
-    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
-  category: dev
-  optional: true
-- name: anyio
-  version: 4.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
-    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
-  category: dev
-  optional: true
-- name: anyio
-  version: 4.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
-    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
-  category: dev
-  optional: true
-- name: appdirs
-  version: 1.4.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-  category: dev
-  optional: true
-- name: appdirs
-  version: 1.4.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-  category: dev
-  optional: true
-- name: appdirs
-  version: 1.4.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 5f095bc6454094e96f146491fd03633b
-    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-  category: dev
-  optional: true
-- name: asyncssh
-  version: 2.14.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: ''
-    pyopenssl: '>=17.0.0'
-    python: '>=3.4'
-    python-gssapi: '>=1.2.0'
-    typing_extensions: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a88675dc80fa5b2d082fca1cc2a804c5
-    sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
-  category: dev
-  optional: true
-- name: asyncssh
-  version: 2.14.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cryptography: ''
-    python: '>=3.4'
-    pyopenssl: '>=17.0.0'
-    python-gssapi: '>=1.2.0'
-    typing_extensions: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a88675dc80fa5b2d082fca1cc2a804c5
-    sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
-  category: dev
-  optional: true
-- name: asyncssh
-  version: 2.14.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    cryptography: ''
-    python: '>=3.4'
-    pyopenssl: '>=17.0.0'
-    python-gssapi: '>=1.2.0'
-    typing_extensions: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a88675dc80fa5b2d082fca1cc2a804c5
-    sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
-  category: dev
-  optional: true
-- name: atk-1.0
-  version: 2.38.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.0,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-  hash:
-    md5: f730d54ba9cd543666d7220c9f7ed563
-    sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
-  category: dev
-  optional: true
-- name: atk-1.0
-  version: 2.38.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-    libglib: '>=2.80.0,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-  hash:
-    md5: 57301986d02d30d6805fdce6c99074ee
-    sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
-  category: dev
-  optional: true
-- name: atpublic
-  version: 3.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/atpublic-3.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 39904aaf8de88f03fe9c27286dc35681
-    sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
-  category: dev
-  optional: true
-- name: atpublic
-  version: 3.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/atpublic-3.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 39904aaf8de88f03fe9c27286dc35681
-    sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
-  category: dev
-  optional: true
-- name: atpublic
-  version: 3.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/atpublic-3.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 39904aaf8de88f03fe9c27286dc35681
-    sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
-  category: dev
-  optional: true
 - name: attrs
   version: 23.2.0
   manager: conda
@@ -1295,163 +856,6 @@ package:
     sha256: b8aa3a1cce16c0cc11c4daaab8ee8c9e49f39380352f32d15bbc0253f99eba38
   category: main
   optional: false
-- name: backports
-  version: '1.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
-  hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: dev
-  optional: true
-- name: backports
-  version: '1.0'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
-  hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: dev
-  optional: true
-- name: backports
-  version: '1.0'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
-  hash:
-    md5: 54ca2e08b3220c148a1d8329c2678e02
-    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-  category: dev
-  optional: true
-- name: backports.tarfile
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    backports: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c747b1d79f136013c3b7ebcba876afa6
-    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
-  category: dev
-  optional: true
-- name: backports.tarfile
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    backports: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c747b1d79f136013c3b7ebcba876afa6
-    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
-  category: dev
-  optional: true
-- name: backports.tarfile
-  version: 1.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    backports: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c747b1d79f136013c3b7ebcba876afa6
-    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
-  category: dev
-  optional: true
-- name: backports.zoneinfo
-  version: 0.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zoneinfo-0.2.1-py311h38be061_8.conda
-  hash:
-    md5: 5384590f14dfe6ccd02811236afc9f8e
-    sha256: 1708c5e6729567f30ccde7761492cb43ee72fa2f7d5065b9102785278718505b
-  category: dev
-  optional: true
-- name: backports.zoneinfo
-  version: 0.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zoneinfo-0.2.1-py311h267d04e_8.conda
-  hash:
-    md5: acbef984789bc78fc49cca2e736b8006
-    sha256: a1cdbc446ff4db99e9e39b73b1611932dc9c5111ecd90dd131fa6fdf62de904d
-  category: dev
-  optional: true
-- name: backports.zoneinfo
-  version: 0.2.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/win-64/backports.zoneinfo-0.2.1-py311h1ea47a8_8.conda
-  hash:
-    md5: 6784cf61285ebc6d3772d9a51d9982eb
-    sha256: 30d71fe787342045a7a1896835627c0ed0a1a8b796a497d63b0d36b31a84b7e7
-  category: dev
-  optional: true
-- name: billiard
-  version: 4.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/billiard-4.2.0-py311h459d7ec_0.conda
-  hash:
-    md5: d408435aabfb23b364dcca868386cf0b
-    sha256: fc947afbd0eb61ac2e98195ae26a1b43b89ffb91b71c43cb0db7b52f131bc60c
-  category: dev
-  optional: true
-- name: billiard
-  version: 4.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/billiard-4.2.0-py311h05b510d_0.conda
-  hash:
-    md5: d2100bf5626206fdfb56b2a92423bc53
-    sha256: e70cbec50b46109f00fdd1b45cef33c4edb908ede67534fe6aaa0033d4f9217b
-  category: dev
-  optional: true
-- name: billiard
-  version: 4.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/billiard-4.2.0-py311ha68e1ae_0.conda
-  hash:
-    md5: c2023bec2510422052ce8cfc484f0f62
-    sha256: 8c3432023fe40cfa8c69d00855996403902dea0562cff298f28e2216c6be86f0
-  category: dev
-  optional: true
 - name: binpickle
   version: 0.3.4
   manager: conda
@@ -1472,10 +876,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    numcodecs: ''
-    python-blosc: ''
-    python: '>=3.8'
     msgpack-python: '>=1.0'
+    numcodecs: ''
+    python: '>=3.8'
+    python-blosc: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binpickle-0.3.4-pyhd8ed1ab_2.conda
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
@@ -1487,14 +891,26 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    numcodecs: ''
-    python-blosc: ''
-    python: '>=3.8'
     msgpack-python: '>=1.0'
+    numcodecs: ''
+    python: '>=3.8'
+    python-blosc: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binpickle-0.3.4-pyhd8ed1ab_2.conda
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
     sha256: 409dd557027a01d3c1be325fa34b0104fb1a0842e9eea90bf03decc77d08b361
+  category: main
+  optional: false
+- name: blas
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    mkl: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-1.0-mkl.tar.bz2
+  hash:
+    md5: 349aef876b1d8c9dccae01de20d5b385
+    sha256: a9a9125029a66905fc9e932dfd4f595be3a59a30db37fd7bf4a675a5c6151d62
   category: main
   optional: false
 - name: blas
@@ -1609,16 +1025,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
     numpy: '>=1.16'
-    pyyaml: '>=3.10'
+    packaging: '>=16.8'
     pandas: '>=1.2'
     pillow: '>=7.1.0'
-    jinja2: '>=2.9'
-    packaging: '>=16.8'
+    python: '>=3.9'
+    pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-    contourpy: '>=1.2'
   url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: 0f8e0831bbf38d83973438ce9af9af9a
@@ -1630,112 +1046,22 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
+    contourpy: '>=1.2'
+    jinja2: '>=2.9'
     numpy: '>=1.16'
-    pyyaml: '>=3.10'
+    packaging: '>=16.8'
     pandas: '>=1.2'
     pillow: '>=7.1.0'
-    jinja2: '>=2.9'
-    packaging: '>=16.8'
+    python: '>=3.9'
+    pyyaml: '>=3.10'
     tornado: '>=6.2'
     xyzservices: '>=2021.09.1'
-    contourpy: '>=1.2'
   url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: 0f8e0831bbf38d83973438ce9af9af9a
     sha256: 0289e61d7a30a693cf79d36484abd13f72ad785bd23cadc227c29dca89d95046
   category: main
   optional: false
-- name: boto3
-  version: 1.34.106
-  manager: conda
-  platform: linux-64
-  dependencies:
-    botocore: '>=1.34.106,<1.35.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.8'
-    s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
-  hash:
-    md5: 190a8f3c28a2c6047dcca712eca663b1
-    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
-  category: dev
-  optional: true
-- name: boto3
-  version: 1.34.106
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
-    botocore: '>=1.34.106,<1.35.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
-  hash:
-    md5: 190a8f3c28a2c6047dcca712eca663b1
-    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
-  category: dev
-  optional: true
-- name: boto3
-  version: 1.34.106
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
-    botocore: '>=1.34.106,<1.35.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
-  hash:
-    md5: 190a8f3c28a2c6047dcca712eca663b1
-    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
-  category: dev
-  optional: true
-- name: botocore
-  version: 1.34.106
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.10'
-    python-dateutil: '>=2.1,<3.0.0'
-    urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
-  hash:
-    md5: ff7f42537b4f054b10b4d02732e10ab8
-    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
-  category: dev
-  optional: true
-- name: botocore
-  version: 1.34.106
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python-dateutil: '>=2.1,<3.0.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.10'
-    urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
-  hash:
-    md5: ff7f42537b4f054b10b4d02732e10ab8
-    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
-  category: dev
-  optional: true
-- name: botocore
-  version: 1.34.106
-  manager: conda
-  platform: win-64
-  dependencies:
-    python-dateutil: '>=2.1,<3.0.0'
-    jmespath: '>=0.7.1,<2.0.0'
-    python: '>=3.10'
-    urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
-  hash:
-    md5: ff7f42537b4f054b10b4d02732e10ab8
-    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
-  category: dev
-  optional: true
 - name: brotli-python
   version: 1.1.0
   manager: conda
@@ -1888,268 +1214,6 @@ package:
     sha256: d872d11558ebeaeb87bcf9086e97c075a1a2dfffed2d0e97570cf197ab29e3d8
   category: main
   optional: false
-- name: cachecontrol
-  version: 0.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    msgpack-python: '>=0.5.2'
-    python: '>=3.7'
-    requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a661c39e223bf3038b38126b0bbf43d9
-    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
-  category: dev
-  optional: true
-- name: cachecontrol
-  version: 0.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    msgpack-python: '>=0.5.2'
-    requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a661c39e223bf3038b38126b0bbf43d9
-    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
-  category: dev
-  optional: true
-- name: cachecontrol
-  version: 0.14.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    msgpack-python: '>=0.5.2'
-    requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a661c39e223bf3038b38126b0bbf43d9
-    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
-  category: dev
-  optional: true
-- name: cachecontrol-with-filecache
-  version: 0.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cachecontrol: 0.14.0
-    filelock: '>=3.8.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
-    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
-  category: dev
-  optional: true
-- name: cachecontrol-with-filecache
-  version: 0.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
-    cachecontrol: 0.14.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
-    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
-  category: dev
-  optional: true
-- name: cachecontrol-with-filecache
-  version: 0.14.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
-    cachecontrol: 0.14.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
-    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
-  category: dev
-  optional: true
-- name: cachy
-  version: 0.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 5dfee17f24e2dfd18d7392b48c9351e2
-    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
-  category: dev
-  optional: true
-- name: cachy
-  version: 0.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 5dfee17f24e2dfd18d7392b48c9351e2
-    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
-  category: dev
-  optional: true
-- name: cachy
-  version: 0.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachy-0.3.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 5dfee17f24e2dfd18d7392b48c9351e2
-    sha256: 9b193a4e483c4d0004bc5b88fac7a02516b6311137ab61b8db85aa9741422e35
-  category: dev
-  optional: true
-- name: cairo
-  version: 1.18.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
-  hash:
-    md5: f907bb958910dc404647326ca80c263e
-    sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
-  category: dev
-  optional: true
-- name: cairo
-  version: 1.18.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=10.9'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16.0.6'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
-  hash:
-    md5: 3fa6eebabb77f65e82f86b72b95482db
-    sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
-  category: dev
-  optional: true
-- name: cairo
-  version: 1.18.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
-  hash:
-    md5: b3fe2c6381ec74afe8128e16a11eee02
-    sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
-  category: dev
-  optional: true
-- name: celery
-  version: 5.3.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    backports.zoneinfo: '>=0.2.1'
-    billiard: '>=4.2.0,<5.0'
-    click: '>=8.1.2,<9.0'
-    click-didyoumean: '>=0.3.0'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
-    importlib-metadata: '>=3.6'
-    kombu: '>=5.3.4,<6.0'
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    python-tzdata: '>=2022.7'
-    vine: '>=5.1.0,<6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: f3949418e3578d5cbea5df5d32c5b6ff
-    sha256: bafedd098b75f9baf88167e9bbbbd687fbbc0b06b1a056bdb3bf16221e329def
-  category: dev
-  optional: true
-- name: celery
-  version: 5.3.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
-    click: '>=8.1.2,<9.0'
-    click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
-    kombu: '>=5.3.4,<6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: f3949418e3578d5cbea5df5d32c5b6ff
-    sha256: bafedd098b75f9baf88167e9bbbbd687fbbc0b06b1a056bdb3bf16221e329def
-  category: dev
-  optional: true
-- name: celery
-  version: 5.3.6
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
-    click: '>=8.1.2,<9.0'
-    click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
-    kombu: '>=5.3.4,<6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: f3949418e3578d5cbea5df5d32c5b6ff
-    sha256: bafedd098b75f9baf88167e9bbbbd687fbbc0b06b1a056bdb3bf16221e329def
-  category: dev
-  optional: true
 - name: certifi
   version: 2024.6.2
   manager: conda
@@ -2234,42 +1298,6 @@ package:
     sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
   category: main
   optional: false
-- name: cfgv
-  version: 3.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
-    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
-  category: dev
-  optional: true
-- name: cfgv
-  version: 3.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
-    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
-  category: dev
-  optional: true
-- name: cfgv
-  version: 3.3.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
-    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
-  category: dev
-  optional: true
 - name: charset-normalizer
   version: 3.3.2
   manager: conda
@@ -2337,8 +1365,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    colorama: ''
     __win: ''
+    colorama: ''
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
   hash:
@@ -2346,210 +1374,6 @@ package:
     sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
   category: main
   optional: false
-- name: click-default-group
-  version: 1.2.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7c2b6931f9b3548ed78478332095c3e9
-    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
-  category: dev
-  optional: true
-- name: click-default-group
-  version: 1.2.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7c2b6931f9b3548ed78478332095c3e9
-    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
-  category: dev
-  optional: true
-- name: click-default-group
-  version: 1.2.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    click: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7c2b6931f9b3548ed78478332095c3e9
-    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
-  category: dev
-  optional: true
-- name: click-didyoumean
-  version: 0.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=7'
-    python: '>=3.6.2,<4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ab1b094a8471e571b95c208bde719a4a
-    sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
-  category: dev
-  optional: true
-- name: click-didyoumean
-  version: 0.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: '>=7'
-    python: '>=3.6.2,<4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ab1b094a8471e571b95c208bde719a4a
-    sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
-  category: dev
-  optional: true
-- name: click-didyoumean
-  version: 0.3.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    click: '>=7'
-    python: '>=3.6.2,<4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ab1b094a8471e571b95c208bde719a4a
-    sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
-  category: dev
-  optional: true
-- name: click-plugins
-  version: 1.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=3.0'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
-  hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
-  category: dev
-  optional: true
-- name: click-plugins
-  version: 1.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-    click: '>=3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
-  hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
-  category: dev
-  optional: true
-- name: click-plugins
-  version: 1.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-    click: '>=3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
-  hash:
-    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
-    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
-  category: dev
-  optional: true
-- name: click-repl
-  version: 0.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: ''
-    prompt_toolkit: ''
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27eb8f68250666c1a19d1b6ec9d12c4e
-    sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
-  category: dev
-  optional: true
-- name: click-repl
-  version: 0.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    six: ''
-    click: ''
-    prompt_toolkit: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27eb8f68250666c1a19d1b6ec9d12c4e
-    sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
-  category: dev
-  optional: true
-- name: click-repl
-  version: 0.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    six: ''
-    click: ''
-    prompt_toolkit: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27eb8f68250666c1a19d1b6ec9d12c4e
-    sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
-  category: dev
-  optional: true
-- name: clikit
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pastel: '>=0.2.0,<0.3.0'
-    pylev: '>=1.3,<2.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
-  hash:
-    md5: 02abb7b66b02e8b9f5a9b05454400087
-    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
-  category: dev
-  optional: true
-- name: clikit
-  version: 0.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    pylev: '>=1.3,<2.0'
-    pastel: '>=0.2.0,<0.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
-  hash:
-    md5: 02abb7b66b02e8b9f5a9b05454400087
-    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
-  category: dev
-  optional: true
-- name: clikit
-  version: 0.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    pylev: '>=1.3,<2.0'
-    pastel: '>=0.2.0,<0.3.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
-  hash:
-    md5: 02abb7b66b02e8b9f5a9b05454400087
-    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
-  category: dev
-  optional: true
 - name: cloudpickle
   version: 3.0.0
   manager: conda
@@ -2622,153 +1446,6 @@ package:
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   category: main
   optional: false
-- name: conda-lock
-  version: 2.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cachecontrol-with-filecache: '>=0.12.9'
-    cachy: '>=0.3.0'
-    click: '>=8.0'
-    click-default-group: ''
-    clikit: '>=0.6.2'
-    crashtest: '>=0.3.0'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    html5lib: '>=1.0'
-    jinja2: ''
-    keyring: '>=21.2.0'
-    packaging: '>=20.4'
-    pkginfo: '>=1.4'
-    pydantic: '>=1.10'
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    requests: '>=2.18'
-    ruamel.yaml: ''
-    setuptools: ''
-    tomli: ''
-    tomlkit: '>=0.7.0'
-    toolz: '>=0.12.0,<1.0.0'
-    typing_extensions: ''
-    urllib3: '>=1.26.5,<2.0'
-    virtualenv: '>=20.0.26'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 154d0c643be6a9ce6fbe655d007d8e4e
-    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
-  category: dev
-  optional: true
-- name: conda-lock
-  version: 2.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    setuptools: ''
-    typing_extensions: ''
-    jinja2: ''
-    ruamel.yaml: ''
-    tomli: ''
-    click-default-group: ''
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    click: '>=8.0'
-    packaging: '>=20.4'
-    requests: '>=2.18'
-    ensureconda: '>=1.3'
-    pydantic: '>=1.10'
-    gitpython: '>=3.1.30'
-    keyring: '>=21.2.0'
-    html5lib: '>=1.0'
-    cachy: '>=0.3.0'
-    clikit: '>=0.6.2'
-    crashtest: '>=0.3.0'
-    pkginfo: '>=1.4'
-    tomlkit: '>=0.7.0'
-    virtualenv: '>=20.0.26'
-    toolz: '>=0.12.0,<1.0.0'
-    cachecontrol-with-filecache: '>=0.12.9'
-    urllib3: '>=1.26.5,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 154d0c643be6a9ce6fbe655d007d8e4e
-    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
-  category: dev
-  optional: true
-- name: conda-lock
-  version: 2.5.7
-  manager: conda
-  platform: win-64
-  dependencies:
-    setuptools: ''
-    typing_extensions: ''
-    jinja2: ''
-    ruamel.yaml: ''
-    tomli: ''
-    click-default-group: ''
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    click: '>=8.0'
-    packaging: '>=20.4'
-    requests: '>=2.18'
-    ensureconda: '>=1.3'
-    pydantic: '>=1.10'
-    gitpython: '>=3.1.30'
-    keyring: '>=21.2.0'
-    html5lib: '>=1.0'
-    cachy: '>=0.3.0'
-    clikit: '>=0.6.2'
-    crashtest: '>=0.3.0'
-    pkginfo: '>=1.4'
-    tomlkit: '>=0.7.0'
-    virtualenv: '>=20.0.26'
-    toolz: '>=0.12.0,<1.0.0'
-    cachecontrol-with-filecache: '>=0.12.9'
-    urllib3: '>=1.26.5,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: 154d0c643be6a9ce6fbe655d007d8e4e
-    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
-  category: dev
-  optional: true
-- name: configobj
-  version: 5.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 04c71f400324538d4396407ea2ffb34f
-    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
-  category: dev
-  optional: true
-- name: configobj
-  version: 5.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    six: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 04c71f400324538d4396407ea2ffb34f
-    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
-  category: dev
-  optional: true
-- name: configobj
-  version: 5.0.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    six: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 04c71f400324538d4396407ea2ffb34f
-    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
-  category: dev
-  optional: true
 - name: contourpy
   version: 1.2.1
   manager: conda
@@ -2817,139 +1494,6 @@ package:
     sha256: f9c392ae4c746ac32c55b20d8c487cbc06a91d5dd650261089d90fb55cfcb8c2
   category: main
   optional: false
-- name: coverage
-  version: 7.5.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.5.3-py311h331c9d8_0.conda
-  hash:
-    md5: 543dd05fd661e4e9c9deb3b37093d6a2
-    sha256: 88e0063cf333147890aafacc2f87360867991241af827a111d97433b7055691e
-  category: dev
-  optional: true
-- name: coverage
-  version: 7.5.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    tomli: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.5.3-py311hd3f4193_0.conda
-  hash:
-    md5: 402a8b40b9c9423f40a32be066b467be
-    sha256: dcdfa3b24affe7399654f2e8429c15e05a54b8cce32583263a0731c37b62dcbc
-  category: dev
-  optional: true
-- name: coverage
-  version: 7.5.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    tomli: ''
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.5.3-py311he736701_0.conda
-  hash:
-    md5: eead686af955162027fb5825e83a3131
-    sha256: 16b1692a5ea5254842267e3f66489ecc009ff0d63c0d02148d756e32495c0947
-  category: dev
-  optional: true
-- name: crashtest
-  version: 0.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 709a2295dd907bb34afb57d54320642f
-    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
-  category: dev
-  optional: true
-- name: crashtest
-  version: 0.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 709a2295dd907bb34afb57d54320642f
-    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
-  category: dev
-  optional: true
-- name: crashtest
-  version: 0.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 709a2295dd907bb34afb57d54320642f
-    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
-  category: dev
-  optional: true
-- name: cryptography
-  version: 42.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cffi: '>=1.12'
-    libgcc-ng: '>=12'
-    openssl: '>=3.3.1,<4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.8-py311h4a61cc7_0.conda
-  hash:
-    md5: 962bcc96f59a31b62c43ac2b306812af
-    sha256: 887557c1cc5083f68e531ffe98bb95e0ea2e99fb36f9d12f7f66c4cad2de7502
-  category: dev
-  optional: true
-- name: cryptography
-  version: 42.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cffi: '>=1.12'
-    openssl: '>=3.3.1,<4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.8-py311hcaeb4ce_0.conda
-  hash:
-    md5: 167cc1ddd4e8afab3959811dabaa79d8
-    sha256: 3dd780ec2a637e8fa1095111cbf0b4ff13e9d01c2d81aa1b5b8f8ad2186873c5
-  category: dev
-  optional: true
-- name: cryptography
-  version: 42.0.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    cffi: '>=1.12'
-    openssl: '>=3.3.1,<4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/cryptography-42.0.8-py311hfd75b31_0.conda
-  hash:
-    md5: df7b0031f07fe3a35892fbad84b62ea0
-    sha256: c422f83400092c9764d28f8551787bb1e8c0a3077ff665da324e88e168d1eb18
-  category: dev
-  optional: true
 - name: csr
   version: 0.5.2
   manager: conda
@@ -3078,18 +1622,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pyarrow-hotfix: ''
-    python: '>=3.9'
+    bokeh: '>=2.4.2,!=3.0.*'
+    cytoolz: '>=0.11.0'
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
+    dask-expr: '>=1.1,<1.2'
+    distributed: '>=2024.6.0,<2024.6.1.0a0'
+    jinja2: '>=2.10.3'
+    lz4: '>=4.3.2'
     numpy: '>=1.21'
     pandas: '>=1.3'
-    jinja2: '>=2.10.3'
     pyarrow: '>=7.0'
-    lz4: '>=4.3.2'
-    cytoolz: '>=0.11.0'
-    bokeh: '>=2.4.2,!=3.0.*'
-    dask-expr: '>=1.1,<1.2'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    distributed: '>=2024.6.0,<2024.6.1.0a0'
+    pyarrow-hotfix: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: 706801e668da4c74e7a06a911d5abdfd
@@ -3101,18 +1645,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pyarrow-hotfix: ''
-    python: '>=3.9'
+    bokeh: '>=2.4.2,!=3.0.*'
+    cytoolz: '>=0.11.0'
+    dask-core: '>=2024.6.0,<2024.6.1.0a0'
+    dask-expr: '>=1.1,<1.2'
+    distributed: '>=2024.6.0,<2024.6.1.0a0'
+    jinja2: '>=2.10.3'
+    lz4: '>=4.3.2'
     numpy: '>=1.21'
     pandas: '>=1.3'
-    jinja2: '>=2.10.3'
     pyarrow: '>=7.0'
-    lz4: '>=4.3.2'
-    cytoolz: '>=0.11.0'
-    bokeh: '>=2.4.2,!=3.0.*'
-    dask-expr: '>=1.1,<1.2'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    distributed: '>=2024.6.0,<2024.6.1.0a0'
+    pyarrow-hotfix: ''
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: 706801e668da4c74e7a06a911d5abdfd
@@ -3144,15 +1688,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    packaging: '>=20.0'
-    pyyaml: '>=5.3.1'
-    cloudpickle: '>=1.5.0'
-    toolz: '>=0.10.0'
     click: '>=8.1'
-    partd: '>=1.2.0'
-    importlib_metadata: '>=4.13.0'
+    cloudpickle: '>=1.5.0'
     fsspec: '>=2021.09.0'
+    importlib_metadata: '>=4.13.0'
+    packaging: '>=20.0'
+    partd: '>=1.2.0'
+    python: '>=3.9'
+    pyyaml: '>=5.3.1'
+    toolz: '>=0.10.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: edf709967712b2953ab4189256266adc
@@ -3164,15 +1708,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    packaging: '>=20.0'
-    pyyaml: '>=5.3.1'
-    cloudpickle: '>=1.5.0'
-    toolz: '>=0.10.0'
     click: '>=8.1'
-    partd: '>=1.2.0'
-    importlib_metadata: '>=4.13.0'
+    cloudpickle: '>=1.5.0'
     fsspec: '>=2021.09.0'
+    importlib_metadata: '>=4.13.0'
+    packaging: '>=20.0'
+    partd: '>=1.2.0'
+    python: '>=3.9'
+    pyyaml: '>=5.3.1'
+    toolz: '>=0.10.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: edf709967712b2953ab4189256266adc
@@ -3199,10 +1743,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    dask-core: 2024.6.0
+    pandas: '>=2'
     pyarrow: ''
     python: '>=3.9'
-    pandas: '>=2'
-    dask-core: 2024.6.0
   url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 2b2b28ff641f91527fac96dfb0a8ea9a
@@ -3214,10 +1758,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    dask-core: 2024.6.0
+    pandas: '>=2'
     pyarrow: ''
     python: '>=3.9'
-    pandas: '>=2'
-    dask-core: 2024.6.0
   url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 2b2b28ff641f91527fac96dfb0a8ea9a
@@ -3256,22 +1800,22 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: ''
-    packaging: ''
-    filelock: ''
-    python-xxhash: ''
-    multiprocess: ''
-    pyarrow-hotfix: ''
-    pyyaml: '>=5.1'
-    numpy: '>=1.17'
-    python: '>=3.8.0'
     aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
+    filelock: ''
+    fsspec: '>=2023.1.0,<=2024.5.0'
     huggingface_hub: '>=0.21.2'
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=15.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    fsspec: '>=2023.1.0,<=2024.5.0'
-    pyarrow: '>=15.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3283,114 +1827,28 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pandas: ''
-    packaging: ''
-    filelock: ''
-    python-xxhash: ''
-    multiprocess: ''
-    pyarrow-hotfix: ''
-    pyyaml: '>=5.1'
-    numpy: '>=1.17'
-    python: '>=3.8.0'
     aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
+    filelock: ''
+    fsspec: '>=2023.1.0,<=2024.5.0'
     huggingface_hub: '>=0.21.2'
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=15.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    fsspec: '>=2023.1.0,<=2024.5.0'
-    pyarrow: '>=15.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
     sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
   category: main
   optional: false
-- name: dbus
-  version: 1.13.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    expat: '>=2.4.2,<3.0a0'
-    libgcc-ng: '>=9.4.0'
-    libglib: '>=2.70.2,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
-  hash:
-    md5: ecfff944ba3960ecb334b9a2663d708d
-    sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-  category: dev
-  optional: true
-- name: decorator
-  version: 5.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: dev
-  optional: true
-- name: decorator
-  version: 5.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: dev
-  optional: true
-- name: decorator
-  version: 5.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  category: dev
-  optional: true
-- name: dictdiffer
-  version: 0.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dictdiffer-0.9.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cb49199274e7f4d457d8fa2b84dea52
-    sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
-  category: dev
-  optional: true
-- name: dictdiffer
-  version: 0.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dictdiffer-0.9.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cb49199274e7f4d457d8fa2b84dea52
-    sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
-  category: dev
-  optional: true
-- name: dictdiffer
-  version: 0.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dictdiffer-0.9.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cb49199274e7f4d457d8fa2b84dea52
-    sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
-  category: dev
-  optional: true
 - name: dill
   version: 0.3.8
   manager: conda
@@ -3427,78 +1885,6 @@ package:
     sha256: 482b5b566ca559119b504c53df12b08f3962a5ef8e48061d62fd58a47f8f2ec4
   category: main
   optional: false
-- name: diskcache
-  version: 5.6.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4c33109f652b5d8c995ab243436c9370
-    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  category: dev
-  optional: true
-- name: diskcache
-  version: 5.6.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4c33109f652b5d8c995ab243436c9370
-    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  category: dev
-  optional: true
-- name: diskcache
-  version: 5.6.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4c33109f652b5d8c995ab243436c9370
-    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
-  category: dev
-  optional: true
-- name: distlib
-  version: 0.3.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: db16c66b759a64dc5183d69cc3745a52
-    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: dev
-  optional: true
-- name: distlib
-  version: 0.3.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: db16c66b759a64dc5183d69cc3745a52
-    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: dev
-  optional: true
-- name: distlib
-  version: 0.3.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: 2.7|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: db16c66b759a64dc5183d69cc3745a52
-    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
-  category: dev
-  optional: true
 - name: distributed
   version: 2024.6.0
   manager: conda
@@ -3532,23 +1918,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    packaging: '>=20.0'
-    pyyaml: '>=5.3.1'
-    cloudpickle: '>=1.5.0'
     click: '>=8.0'
-    msgpack-python: '>=1.0.0'
-    urllib3: '>=1.24.3'
-    toolz: '>=0.10.0'
-    jinja2: '>=2.10.3'
-    tblib: '>=1.6.0'
-    locket: '>=1.0.0'
-    tornado: '>=6.0.4'
-    sortedcontainers: '>=2.0.5'
+    cloudpickle: '>=1.5.0'
     cytoolz: '>=0.10.1'
-    psutil: '>=5.7.2'
-    zict: '>=3.0.0'
     dask-core: '>=2024.6.0,<2024.6.1.0a0'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack-python: '>=1.0.0'
+    packaging: '>=20.0'
+    psutil: '>=5.7.2'
+    python: '>=3.9'
+    pyyaml: '>=5.3.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0'
+    toolz: '>=0.10.0'
+    tornado: '>=6.0.4'
+    urllib3: '>=1.24.3'
+    zict: '>=3.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: fc8c9391ef25c481d768967db027dfc0
@@ -3560,875 +1946,29 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    packaging: '>=20.0'
-    pyyaml: '>=5.3.1'
-    cloudpickle: '>=1.5.0'
     click: '>=8.0'
-    msgpack-python: '>=1.0.0'
-    urllib3: '>=1.24.3'
-    toolz: '>=0.10.0'
-    jinja2: '>=2.10.3'
-    tblib: '>=1.6.0'
-    locket: '>=1.0.0'
-    tornado: '>=6.0.4'
-    sortedcontainers: '>=2.0.5'
+    cloudpickle: '>=1.5.0'
     cytoolz: '>=0.10.1'
-    psutil: '>=5.7.2'
-    zict: '>=3.0.0'
     dask-core: '>=2024.6.0,<2024.6.1.0a0'
+    jinja2: '>=2.10.3'
+    locket: '>=1.0.0'
+    msgpack-python: '>=1.0.0'
+    packaging: '>=20.0'
+    psutil: '>=5.7.2'
+    python: '>=3.9'
+    pyyaml: '>=5.3.1'
+    sortedcontainers: '>=2.0.5'
+    tblib: '>=1.6.0'
+    toolz: '>=0.10.0'
+    tornado: '>=6.0.4'
+    urllib3: '>=1.24.3'
+    zict: '>=3.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: fc8c9391ef25c481d768967db027dfc0
     sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
   category: main
   optional: false
-- name: distro
-  version: 1.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbdb409974cd6cb30071b1d978302726
-    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: dev
-  optional: true
-- name: distro
-  version: 1.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbdb409974cd6cb30071b1d978302726
-    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: dev
-  optional: true
-- name: distro
-  version: 1.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbdb409974cd6cb30071b1d978302726
-    sha256: ae1c13d709c8001331b5b9345e4bcd77e9ae712d25f7958b2ebcbe0b068731b7
-  category: dev
-  optional: true
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: dev
-  optional: true
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: dev
-  optional: true
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: dev
-  optional: true
-- name: dpath
-  version: 2.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_0.conda
-  hash:
-    md5: b2681af65644be41a18d4b00b67938f1
-    sha256: ab88f587a9b7dc3cbb636823423c2ecfd868d4719b491af37c09b0384214bacf
-  category: dev
-  optional: true
-- name: dpath
-  version: 2.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_0.conda
-  hash:
-    md5: b2681af65644be41a18d4b00b67938f1
-    sha256: ab88f587a9b7dc3cbb636823423c2ecfd868d4719b491af37c09b0384214bacf
-  category: dev
-  optional: true
-- name: dpath
-  version: 2.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_0.conda
-  hash:
-    md5: b2681af65644be41a18d4b00b67938f1
-    sha256: ab88f587a9b7dc3cbb636823423c2ecfd868d4719b491af37c09b0384214bacf
-  category: dev
-  optional: true
-- name: dulwich
-  version: 0.22.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    urllib3: '>=1.25'
-  url: https://conda.anaconda.org/conda-forge/linux-64/dulwich-0.22.1-py311h5ecf98a_0.conda
-  hash:
-    md5: 8addaf53957f6bd24229b7f9c03e7e2c
-    sha256: f8fd18aacfca21a444806e464eb030d0715b49e1c6d867ddf6b5fb50f076a91c
-  category: dev
-  optional: true
-- name: dulwich
-  version: 0.22.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    urllib3: '>=1.25'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dulwich-0.22.1-py311h5d190b6_0.conda
-  hash:
-    md5: baa9c921c2c997e52e7d19b552a3afb3
-    sha256: 802d7d12e495167323cb7b47a87ff30b41fbb6b69d67d72c5056e39c12e74b3a
-  category: dev
-  optional: true
-- name: dulwich
-  version: 0.22.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    urllib3: '>=1.25'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/dulwich-0.22.1-py311h533ab2d_0.conda
-  hash:
-    md5: 9a89efc65178428e4c821e01d2d3ad42
-    sha256: 83ab435b6ac17cca238611d2899365f17313343ba3ce090a97aac263a4bf6113
-  category: dev
-  optional: true
-- name: dvc
-  version: 3.51.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: '>=22.2.0'
-    celery: ''
-    colorama: '>=0.3.9'
-    configobj: '>=5.0.6'
-    distro: '>=1.3'
-    dpath: <3,>=2.1.0
-    dulwich: ''
-    dvc-data: '>=3.15,<3.16'
-    dvc-http: '>=2.29.0'
-    dvc-objects: ''
-    dvc-render: '>=1.0.1,<2'
-    dvc-studio-client: '>=0.20,<1'
-    dvc-task: '>=0.3.0,<1'
-    flatten-dict: <1,>=0.4.1
-    flufl.lock: '>=5,<8'
-    fsspec: ''
-    funcy: '>=1.14'
-    grandalf: <1,>=0.7
-    gto: '>=1.6.0,<2'
-    hydra-core: '>=1.1'
-    iterative-telemetry: '>=0.0.7'
-    kombu: ''
-    networkx: '>=2.5'
-    omegaconf: ''
-    packaging: '>=19'
-    pathspec: '>=0.10.3'
-    platformdirs: <4,>=3.1.1
-    psutil: '>=5.8'
-    pydot: '>=1.2.4'
-    pygtrie: '>=2.3.2'
-    pyparsing: '>=2.4.7'
-    python: '>=3.9'
-    requests: '>=2.22'
-    rich: '>=12'
-    ruamel.yaml: '>=0.17.11'
-    scmrepo: '>=3.3.4,<4'
-    shortuuid: '>=0.5'
-    shtab: <2,>=1.3.4
-    tabulate: '>=0.8.7'
-    tomlkit: '>=0.11.1'
-    tqdm: <5,>=4.63.1
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8d2488c8bbe93bcd4f6faa160656703
-    sha256: 93b17fe3cedb5eac30e159c7217a250c94c21257f9b9e8c749dd6b379bfd400a
-  category: dev
-  optional: true
-- name: dvc
-  version: 3.51.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fsspec: ''
-    dvc-objects: ''
-    omegaconf: ''
-    celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    configobj: '>=5.0.6'
-    requests: '>=2.22'
-    colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
-    packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
-    pydot: '>=1.2.4'
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
-    attrs: '>=22.2.0'
-    dvc-task: '>=0.3.0,<1'
-    flufl.lock: '>=5,<8'
-    gto: '>=1.6.0,<2'
-    dvc-render: '>=1.0.1,<2'
-    dvc-studio-client: '>=0.20,<1'
-    dvc-data: '>=3.15,<3.16'
-    scmrepo: '>=3.3.4,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8d2488c8bbe93bcd4f6faa160656703
-    sha256: 93b17fe3cedb5eac30e159c7217a250c94c21257f9b9e8c749dd6b379bfd400a
-  category: dev
-  optional: true
-- name: dvc
-  version: 3.51.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    fsspec: ''
-    dvc-objects: ''
-    omegaconf: ''
-    celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    configobj: '>=5.0.6'
-    requests: '>=2.22'
-    colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
-    packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
-    pydot: '>=1.2.4'
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
-    attrs: '>=22.2.0'
-    dvc-task: '>=0.3.0,<1'
-    flufl.lock: '>=5,<8'
-    gto: '>=1.6.0,<2'
-    dvc-render: '>=1.0.1,<2'
-    dvc-studio-client: '>=0.20,<1'
-    dvc-data: '>=3.15,<3.16'
-    scmrepo: '>=3.3.4,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8d2488c8bbe93bcd4f6faa160656703
-    sha256: 93b17fe3cedb5eac30e159c7217a250c94c21257f9b9e8c749dd6b379bfd400a
-  category: dev
-  optional: true
-- name: dvc-data
-  version: 3.15.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: '>=21.3.0'
-    dictdiffer: '>=0.8.1'
-    diskcache: '>=5.2.1'
-    dvc-objects: '>=4.0.1,<6'
-    fsspec: '>=2024.2.0'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    python: '>=3.9'
-    sqltrie: '>=0.11.0,<1'
-    tqdm: '>=4.63.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: e402fc3b728b926ce1ece0236a1f81bd
-    sha256: c9a13d4a2d075f5bef3ef833a811f2ac6db1c11bbebca6ff29dd7c931e426443
-  category: dev
-  optional: true
-- name: dvc-data
-  version: 3.15.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    diskcache: '>=5.2.1'
-    attrs: '>=21.3.0'
-    dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
-    sqltrie: '>=0.11.0,<1'
-    dvc-objects: '>=4.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: e402fc3b728b926ce1ece0236a1f81bd
-    sha256: c9a13d4a2d075f5bef3ef833a811f2ac6db1c11bbebca6ff29dd7c931e426443
-  category: dev
-  optional: true
-- name: dvc-data
-  version: 3.15.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    diskcache: '>=5.2.1'
-    attrs: '>=21.3.0'
-    dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
-    sqltrie: '>=0.11.0,<1'
-    dvc-objects: '>=4.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: e402fc3b728b926ce1ece0236a1f81bd
-    sha256: c9a13d4a2d075f5bef3ef833a811f2ac6db1c11bbebca6ff29dd7c931e426443
-  category: dev
-  optional: true
-- name: dvc-http
-  version: 2.32.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiohttp-retry: '>=2.5.0'
-    fsspec: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6915a9612a2aacf4df13cf87cb291576
-    sha256: e7f0594b6f4fc23bf2398029fa269b87f659efab266ea995de31a9b5edd7fbef
-  category: dev
-  optional: true
-- name: dvc-http
-  version: 2.32.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fsspec: ''
-    python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6915a9612a2aacf4df13cf87cb291576
-    sha256: e7f0594b6f4fc23bf2398029fa269b87f659efab266ea995de31a9b5edd7fbef
-  category: dev
-  optional: true
-- name: dvc-http
-  version: 2.32.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    fsspec: ''
-    python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6915a9612a2aacf4df13cf87cb291576
-    sha256: e7f0594b6f4fc23bf2398029fa269b87f659efab266ea995de31a9b5edd7fbef
-  category: dev
-  optional: true
-- name: dvc-objects
-  version: 5.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fsspec: '>=2024.2.0'
-    funcy: '>=1.14'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 1fcbd36b4bbe66ad5aec71220109148e
-    sha256: 658e29e9203ac7797a67d01bcd79ca48a4e920d3a70508cafc10fb761f5315b6
-  category: dev
-  optional: true
-- name: dvc-objects
-  version: 5.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    fsspec: '>=2024.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 1fcbd36b4bbe66ad5aec71220109148e
-    sha256: 658e29e9203ac7797a67d01bcd79ca48a4e920d3a70508cafc10fb761f5315b6
-  category: dev
-  optional: true
-- name: dvc-objects
-  version: 5.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    fsspec: '>=2024.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 1fcbd36b4bbe66ad5aec71220109148e
-    sha256: 658e29e9203ac7797a67d01bcd79ca48a4e920d3a70508cafc10fb761f5315b6
-  category: dev
-  optional: true
-- name: dvc-render
-  version: 1.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    flatten-dict: '>=0.4.1'
-    funcy: '>=1.17'
-    python: '>=3.7'
-    tabulate: '>=0.8.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 33300000fa304dba183023f1251d7a5e
-    sha256: d52444f19cc12f2d2c4948a2a822a0ee9ed8a509c3fe5cbf52e86646befdbefd
-  category: dev
-  optional: true
-- name: dvc-render
-  version: 1.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 33300000fa304dba183023f1251d7a5e
-    sha256: d52444f19cc12f2d2c4948a2a822a0ee9ed8a509c3fe5cbf52e86646befdbefd
-  category: dev
-  optional: true
-- name: dvc-render
-  version: 1.0.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 33300000fa304dba183023f1251d7a5e
-    sha256: d52444f19cc12f2d2c4948a2a822a0ee9ed8a509c3fe5cbf52e86646befdbefd
-  category: dev
-  optional: true
-- name: dvc-s3
-  version: 3.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    boto3: '>=1.9.201'
-    dvc: ''
-    python: '>=3.8'
-    s3fs: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5e6ae8f59d5c899960b9f33a2ae2a0a7
-    sha256: 48632e1c5cb894822bba7fdf341fc320aebced6864eb071ce792293b3e5405ea
-  category: dev
-  optional: true
-- name: dvc-s3
-  version: 3.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    dvc: ''
-    python: '>=3.8'
-    boto3: '>=1.9.201'
-    s3fs: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5e6ae8f59d5c899960b9f33a2ae2a0a7
-    sha256: 48632e1c5cb894822bba7fdf341fc320aebced6864eb071ce792293b3e5405ea
-  category: dev
-  optional: true
-- name: dvc-s3
-  version: 3.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    dvc: ''
-    python: '>=3.8'
-    boto3: '>=1.9.201'
-    s3fs: '>=2021.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5e6ae8f59d5c899960b9f33a2ae2a0a7
-    sha256: 48632e1c5cb894822bba7fdf341fc320aebced6864eb071ce792293b3e5405ea
-  category: dev
-  optional: true
-- name: dvc-studio-client
-  version: 0.20.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dulwich: ''
-    python: '>=3.8'
-    requests: ''
-    voluptuous: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.20.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ebedafb4704c48d7ad274acb1d0b2475
-    sha256: 136ddb343f5f77a28253f27d5b950f223823a6d5afaf1088b5ee9fa286451995
-  category: dev
-  optional: true
-- name: dvc-studio-client
-  version: 0.20.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    requests: ''
-    voluptuous: ''
-    dulwich: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.20.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ebedafb4704c48d7ad274acb1d0b2475
-    sha256: 136ddb343f5f77a28253f27d5b950f223823a6d5afaf1088b5ee9fa286451995
-  category: dev
-  optional: true
-- name: dvc-studio-client
-  version: 0.20.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    requests: ''
-    voluptuous: ''
-    dulwich: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.20.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ebedafb4704c48d7ad274acb1d0b2475
-    sha256: 136ddb343f5f77a28253f27d5b950f223823a6d5afaf1088b5ee9fa286451995
-  category: dev
-  optional: true
-- name: dvc-task
-  version: 0.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    celery: '>=5.3.0,<6'
-    funcy: '>=1.17'
-    kombu: ''
-    python: '>=3.7'
-    pywin32-on-windows: ''
-    shortuuid: '>=1.0.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 99dd2e9046ade98deadd415ad5b143fe
-    sha256: d499d1495ab6d00a4c75510d4573749abed3a7f2b3b291fbe377f029eef7ff79
-  category: dev
-  optional: true
-- name: dvc-task
-  version: 0.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pywin32-on-windows: ''
-    kombu: ''
-    python: '>=3.7'
-    shortuuid: '>=1.0.8'
-    funcy: '>=1.17'
-    celery: '>=5.3.0,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 99dd2e9046ade98deadd415ad5b143fe
-    sha256: d499d1495ab6d00a4c75510d4573749abed3a7f2b3b291fbe377f029eef7ff79
-  category: dev
-  optional: true
-- name: dvc-task
-  version: 0.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    pywin32-on-windows: ''
-    kombu: ''
-    python: '>=3.7'
-    shortuuid: '>=1.0.8'
-    funcy: '>=1.17'
-    celery: '>=5.3.0,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 99dd2e9046ade98deadd415ad5b143fe
-    sha256: d499d1495ab6d00a4c75510d4573749abed3a7f2b3b291fbe377f029eef7ff79
-  category: dev
-  optional: true
-- name: editables
-  version: '0.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9873878e2a069bc358b69e9a29c1ecd5
-    sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
-  category: dev
-  optional: true
-- name: editables
-  version: '0.5'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9873878e2a069bc358b69e9a29c1ecd5
-    sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
-  category: dev
-  optional: true
-- name: editables
-  version: '0.5'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9873878e2a069bc358b69e9a29c1ecd5
-    sha256: de160a7494e7bc72360eea6a29cbddf194d0a79f45ff417a4de20e6858cf79a9
-  category: dev
-  optional: true
-- name: ensureconda
-  version: 1.4.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    appdirs: ''
-    click: '>=5.1'
-    filelock: ''
-    packaging: ''
-    python: '>=3.7'
-    requests: '>=2'
-  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: e54a91c3a65491b13c68f7696425bac8
-    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: dev
-  optional: true
-- name: ensureconda
-  version: 1.4.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    appdirs: ''
-    filelock: ''
-    python: '>=3.7'
-    requests: '>=2'
-    click: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: e54a91c3a65491b13c68f7696425bac8
-    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: dev
-  optional: true
-- name: ensureconda
-  version: 1.4.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    appdirs: ''
-    filelock: ''
-    python: '>=3.7'
-    requests: '>=2'
-    click: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: e54a91c3a65491b13c68f7696425bac8
-    sha256: a115afdc676c95a17ab63bbda84b7b724bc8817ae54fa34f8991339252424959
-  category: dev
-  optional: true
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: dev
-  optional: true
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: dev
-  optional: true
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: dev
-  optional: true
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: dev
-  optional: true
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: dev
-  optional: true
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: dev
-  optional: true
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libexpat: 2.6.2
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
-  hash:
-    md5: 53fb86322bdb89496d7579fe3f02fd61
-    sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
-  category: dev
-  optional: true
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libexpat: 2.6.2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
-  hash:
-    md5: de0cff0ec74f273c4b6aa281479906c3
-    sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
-  category: dev
-  optional: true
-- name: expat
-  version: 2.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    libexpat: 2.6.2
-  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
-  hash:
-    md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
-    sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
-  category: dev
-  optional: true
 - name: filelock
   version: 3.15.1
   manager: conda
@@ -4465,354 +2005,6 @@ package:
     sha256: 4b32cbd6082db21d463250cbfaaaaf37bfaa84950deeb1298753cae8d45771e7
   category: main
   optional: false
-- name: flatten-dict
-  version: 0.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pathlib2: '>=2.3,<3.0'
-    python: '>=3.6'
-    setuptools: ''
-    six: '>=1.12,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: ccfb30b92adfeb283d4dcae3d0b6441b
-    sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
-  category: dev
-  optional: true
-- name: flatten-dict
-  version: 0.4.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    setuptools: ''
-    python: '>=3.6'
-    pathlib2: '>=2.3,<3.0'
-    six: '>=1.12,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: ccfb30b92adfeb283d4dcae3d0b6441b
-    sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
-  category: dev
-  optional: true
-- name: flatten-dict
-  version: 0.4.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    setuptools: ''
-    python: '>=3.6'
-    pathlib2: '>=2.3,<3.0'
-    six: '>=1.12,<2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: ccfb30b92adfeb283d4dcae3d0b6441b
-    sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
-  category: dev
-  optional: true
-- name: flufl.lock
-  version: '7.1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    atpublic: ''
-    psutil: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9164819e1a375013c4fbcbaa9538f96c
-    sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
-  category: dev
-  optional: true
-- name: flufl.lock
-  version: '7.1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    psutil: ''
-    atpublic: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9164819e1a375013c4fbcbaa9538f96c
-    sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
-  category: dev
-  optional: true
-- name: flufl.lock
-  version: '7.1'
-  manager: conda
-  platform: win-64
-  dependencies:
-    psutil: ''
-    atpublic: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9164819e1a375013c4fbcbaa9538f96c
-    sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
-  category: dev
-  optional: true
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: dev
-  optional: true
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: dev
-  optional: true
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: dev
-  optional: true
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: dev
-  optional: true
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: dev
-  optional: true
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: dev
-  optional: true
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: dev
-  optional: true
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: dev
-  optional: true
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: dev
-  optional: true
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
-  hash:
-    md5: cbbe59391138ea5ad3658c76912e147f
-    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: dev
-  optional: true
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
-  hash:
-    md5: cbbe59391138ea5ad3658c76912e147f
-    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: dev
-  optional: true
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
-  hash:
-    md5: cbbe59391138ea5ad3658c76912e147f
-    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
-  category: dev
-  optional: true
-- name: fontconfig
-  version: 2.14.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libgcc-ng: '>=12'
-    libuuid: '>=2.32.1,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
-  hash:
-    md5: 0f69b688f52ff6da70bccb7ff7001d1d
-    sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-  category: dev
-  optional: true
-- name: fontconfig
-  version: 2.14.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
-  hash:
-    md5: f77d47ddb6d3cc5b39b9bdf65635afbb
-    sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
-  category: dev
-  optional: true
-- name: fontconfig
-  version: 2.14.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
-  hash:
-    md5: 08767992f1a4f1336a257af1241034bd
-    sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
-  category: dev
-  optional: true
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: dev
-  optional: true
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: dev
-  optional: true
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: win-64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: dev
-  optional: true
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    font-ttf-dejavu-sans-mono: ''
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: dev
-  optional: true
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
-    font-ttf-dejavu-sans-mono: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: dev
-  optional: true
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: win-64
-  dependencies:
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
-    font-ttf-dejavu-sans-mono: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  category: dev
-  optional: true
 - name: freetype
   version: 2.12.1
   manager: conda
@@ -4856,42 +2048,6 @@ package:
     sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
   category: main
   optional: false
-- name: fribidi
-  version: 1.0.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-  hash:
-    md5: ac7bc6a654f8f41b352b38f4051135f8
-    sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
-  category: dev
-  optional: true
-- name: fribidi
-  version: 1.0.10
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-  hash:
-    md5: c64443234ff91d70cb9c7dc926c58834
-    sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
-  category: dev
-  optional: true
-- name: fribidi
-  version: 1.0.10
-  manager: conda
-  platform: win-64
-  dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
-  url: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
-  hash:
-    md5: 807e81d915f2bb2e49951648615241f6
-    sha256: e0323e6d7b6047042970812ee810c6b1e1a11a3af4025db26d0965ae5d206104
-  category: dev
-  optional: true
 - name: frozenlist
   version: 1.4.1
   manager: conda
@@ -4971,158 +2127,6 @@ package:
     sha256: 34149798edaf7f67251ee09612cd50b52ee8a69b45e63ddb79732085ae7423cd
   category: main
   optional: false
-- name: funcy
-  version: '2.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/funcy-2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ecf68a50baba6d9151addcb69cecfb92
-    sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
-  category: dev
-  optional: true
-- name: funcy
-  version: '2.0'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/funcy-2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ecf68a50baba6d9151addcb69cecfb92
-    sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
-  category: dev
-  optional: true
-- name: funcy
-  version: '2.0'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/funcy-2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ecf68a50baba6d9151addcb69cecfb92
-    sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
-  category: dev
-  optional: true
-- name: future
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 650a7807e689642dddd3590eb817beed
-    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
-  category: dev
-  optional: true
-- name: future
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 650a7807e689642dddd3590eb817beed
-    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
-  category: dev
-  optional: true
-- name: future
-  version: 1.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 650a7807e689642dddd3590eb817beed
-    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
-  category: dev
-  optional: true
-- name: gdk-pixbuf
-  version: 2.42.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
-  hash:
-    md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
-    sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
-  category: dev
-  optional: true
-- name: gdk-pixbuf
-  version: 2.42.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libglib: '>=2.80.2,<3.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
-  hash:
-    md5: 151309a7e1eb57a3c2ab8088a1d74f3e
-    sha256: 72bcf0a4d3f9aa6d99d7d1d224d19f76ccdb3a4fa85e60f77d17e17985c81bd2
-  category: dev
-  optional: true
-- name: getopt-win32
-  version: '0.1'
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-hcfcfb64_1.conda
-  hash:
-    md5: 714d0882dc5e692ca4683d8e520f73c6
-    sha256: f3b6e689724a62f36591f6f0e4657db5507feca78e7ef08690a6b2a384216a5c
-  category: dev
-  optional: true
-- name: gettext
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gettext-tools: 0.22.5
-    libasprintf: 0.22.5
-    libasprintf-devel: 0.22.5
-    libcxx: '>=16'
-    libgettextpo: 0.22.5
-    libgettextpo-devel: 0.22.5
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-    libintl-devel: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 404e2894e9cb2835246cef47317ff763
-    sha256: 7188b466071698759b125aaed9b4d78940e72e6299b0c6dbad6f35c85cf3d27b
-  category: dev
-  optional: true
-- name: gettext-tools
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 31117a80d73f4fac856ab09fd9f3c6b5
-    sha256: f60d1671e30ac60598396c11fcec4426f7ddb281bf9e37af2262016b4d812cce
-  category: dev
-  optional: true
 - name: gflags
   version: 2.2.2
   manager: conda
@@ -5148,110 +2152,6 @@ package:
     sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
   category: main
   optional: false
-- name: giflib
-  version: 5.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
-  hash:
-    md5: 3bf7b9fd5a7136126e0234db4b87c8b6
-    sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
-  category: dev
-  optional: true
-- name: giflib
-  version: 5.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
-  hash:
-    md5: 95fa1486c77505330c20f7202492b913
-    sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
-  category: dev
-  optional: true
-- name: gitdb
-  version: 4.0.11
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  category: dev
-  optional: true
-- name: gitdb
-  version: 4.0.11
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  category: dev
-  optional: true
-- name: gitdb
-  version: 4.0.11
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    smmap: '>=3.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
-  hash:
-    md5: 623b19f616f2ca0c261441067e18ae40
-    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
-  category: dev
-  optional: true
-- name: gitpython
-  version: 3.1.43
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gitdb: '>=4.0.1,<5'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
-  category: dev
-  optional: true
-- name: gitpython
-  version: 3.1.43
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
-    gitdb: '>=4.0.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
-  category: dev
-  optional: true
-- name: gitpython
-  version: 3.1.43
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
-    gitdb: '>=4.0.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0b2154c1818111e17381b1df5b4b0176
-    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
-  category: dev
-  optional: true
 - name: glog
   version: 0.7.1
   manager: conda
@@ -5339,765 +2239,8 @@ package:
     sha256: 047dd4dd8255fea1cf3c0629e5cfcb3a1602c18ab46fa0e16b615b669b9f8efe
   category: main
   optional: false
-- name: grandalf
-  version: '0.7'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    future: ''
-    pyparsing: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/grandalf-0.7-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5d632e0f82bfaad59fe060f4b442fd11
-    sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
-  category: dev
-  optional: true
-- name: grandalf
-  version: '0.7'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    future: ''
-    pyparsing: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/grandalf-0.7-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5d632e0f82bfaad59fe060f4b442fd11
-    sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
-  category: dev
-  optional: true
-- name: grandalf
-  version: '0.7'
-  manager: conda
-  platform: win-64
-  dependencies:
-    future: ''
-    pyparsing: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/grandalf-0.7-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5d632e0f82bfaad59fe060f4b442fd11
-    sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
-  category: dev
-  optional: true
-- name: graphite2
-  version: 1.3.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-  hash:
-    md5: f87c7b7c2cb45f323ffbce941c78ab7c
-    sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
-  category: dev
-  optional: true
-- name: graphite2
-  version: 1.3.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
-  hash:
-    md5: 339991336eeddb70076d8ca826dac625
-    sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
-  category: dev
-  optional: true
-- name: graphite2
-  version: 1.3.13
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
-  hash:
-    md5: 3194499ee7d1a67404a87d0eefdd92c6
-    sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
-  category: dev
-  optional: true
-- name: graphviz
-  version: 11.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    fonts-conda-ecosystem: ''
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk2: ''
-    gts: '>=0.7.6,<0.8.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgcc-ng: '>=12'
-    libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    librsvg: '>=2.58.0,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-11.0.0-hc68bbd7_0.conda
-  hash:
-    md5: 52a531ef95358086a56086c45d97ab75
-    sha256: 7e7ca0901c0d2de455718ec7a0974e2091c38e608f90a4ba98084e4902d93c17
-  category: dev
-  optional: true
-- name: graphviz
-  version: 11.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fonts-conda-ecosystem: ''
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    gtk2: ''
-    gts: '>=0.7.6,<0.8.0a0'
-    libcxx: '>=16'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    librsvg: '>=2.58.0,<3.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-11.0.0-h9bb9bc9_0.conda
-  hash:
-    md5: c004a0e5dfbe0ce38af9ab4684abd236
-    sha256: ced49a72b8f3c92a76d3f07bb75be2a64d3572d433f2711d36003e1b565d1d4e
-  category: dev
-  optional: true
-- name: graphviz
-  version: 11.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    getopt-win32: '>=0.1,<0.2.0a0'
-    gts: '>=0.7.6,<0.8.0a0'
-    libexpat: '>=2.6.2,<3.0a0'
-    libgd: '>=2.3.3,<2.4.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pango: '>=1.50.14,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/graphviz-11.0.0-h09e431a_0.conda
-  hash:
-    md5: c6c2ec410aa5e77e09948bf7a4367c00
-    sha256: 9a41d852f32f5654980492934cc547776b94b3910e5c86beff3cb58eeddd08a5
-  category: dev
-  optional: true
-- name: gtk2
-  version: 2.24.33
-  manager: conda
-  platform: linux-64
-  dependencies:
-    atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    harfbuzz: '>=8.3.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.4,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-    xorg-libx11: '>=1.8.7,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h280cfa0_4.conda
-  hash:
-    md5: 410f86e58e880dcc7b0e910a8e89c05c
-    sha256: b946ba60d177d72157cad8af51723f1d081a4794741d35debe53f8b2c807f3af
-  category: dev
-  optional: true
-- name: gtk2
-  version: 2.24.33
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    atk-1.0: '>=2.38.0'
-    cairo: '>=1.18.0,<2.0a0'
-    gdk-pixbuf: '>=2.42.10,<3.0a0'
-    gettext: '>=0.21.1,<1.0a0'
-    libglib: '>=2.78.4,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk2-2.24.33-h7895bb2_4.conda
-  hash:
-    md5: 9c1ba062d59f3f49a2d32d9611d72686
-    sha256: fab8403a67273f69780b1e9b5f1db1aff74ff9472acc9f6df6d9b50fc252bd50
-  category: dev
-  optional: true
-- name: gto
-  version: 1.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    entrypoints: ''
-    funcy: ''
-    pydantic: '>=1.9.0,<3,!=2.0.0'
-    python: '>=3.9'
-    rich: ''
-    ruamel.yaml: ''
-    scmrepo: '>=3,<4'
-    semver: '>=2.13.0'
-    tabulate: '>=0.8.10'
-    typer: '>=0.4.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: ed39fb2671c7beeb6e87f8471392da64
-    sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
-  category: dev
-  optional: true
-- name: gto
-  version: 1.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    rich: ''
-    ruamel.yaml: ''
-    entrypoints: ''
-    funcy: ''
-    python: '>=3.9'
-    typer: '>=0.4.1'
-    tabulate: '>=0.8.10'
-    scmrepo: '>=3,<4'
-    pydantic: '>=1.9.0,<3,!=2.0.0'
-    semver: '>=2.13.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: ed39fb2671c7beeb6e87f8471392da64
-    sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
-  category: dev
-  optional: true
-- name: gto
-  version: 1.7.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    rich: ''
-    ruamel.yaml: ''
-    entrypoints: ''
-    funcy: ''
-    python: '>=3.9'
-    typer: '>=0.4.1'
-    tabulate: '>=0.8.10'
-    scmrepo: '>=3,<4'
-    pydantic: '>=1.9.0,<3,!=2.0.0'
-    semver: '>=2.13.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
-  hash:
-    md5: ed39fb2671c7beeb6e87f8471392da64
-    sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
-  category: dev
-  optional: true
-- name: gts
-  version: 0.7.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libglib: '>=2.76.3,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
-  hash:
-    md5: 4d8df0b0db060d33c9a702ada998a8fe
-    sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
-  category: dev
-  optional: true
-- name: gts
-  version: 0.7.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=15.0.7'
-    libglib: '>=2.76.3,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
-  hash:
-    md5: 21b4dd3098f63a74cf2aa9159cbef57d
-    sha256: e0f8c7bc1b9ea62ded78ffa848e37771eeaaaf55b3146580513c7266862043ba
-  category: dev
-  optional: true
-- name: gts
-  version: 0.7.6
-  manager: conda
-  platform: win-64
-  dependencies:
-    libglib: '>=2.76.3,<3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
-  hash:
-    md5: a41f14768d5e377426ad60c613f2923b
-    sha256: b79755d2f9fc2113b6949bfc170c067902bc776e2c20da26e746e780f4f5a2d4
-  category: dev
-  optional: true
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: dev
-  optional: true
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: dev
-  optional: true
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: dev
-  optional: true
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: dev
-  optional: true
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6.1'
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: dev
-  optional: true
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6.1'
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: dev
-  optional: true
-- name: harfbuzz
-  version: 8.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: ''
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.5.0-hfac3d4d_0.conda
-  hash:
-    md5: f5126317dd0ce0ba26945e411ecc6960
-    sha256: a141fc55f8bfdab7db03fe9d8e61cb0f8c8b5970ed6540eda2db7186223f4444
-  category: dev
-  optional: true
-- name: harfbuzz
-  version: 8.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: ''
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16'
-    libglib: '>=2.80.2,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.5.0-h1836168_0.conda
-  hash:
-    md5: aa22b942b980c17612d344adcd0f8798
-    sha256: 91121ed30fa7d775f1cf7ae5de2f7852d66a604269509c4bb108b143315d8321
-  category: dev
-  optional: true
-- name: harfbuzz
-  version: 8.5.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: ''
-    icu: '>=73.2,<74.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.5.0-h81778c3_0.conda
-  hash:
-    md5: 2ff854071c04998038c0e1db4c9232f7
-    sha256: f633a33dfe5c799a571af41e3515fc706a6f4988701d39e7b5d37811a1745bb9
-  category: dev
-  optional: true
-- name: hatch
-  version: 1.12.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.0.6'
-    hatchling: '>=1.24.2'
-    httpx: '>=0.22.0'
-    hyperlink: '>=21.0.0'
-    keyring: '>=23.5.0'
-    packaging: '>=23.2'
-    pexpect: '>=4.8,<5'
-    platformdirs: '>=2.5.0'
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    shellingham: '>=1.4.0'
-    tomli-w: '>=1.0'
-    tomlkit: '>=0.11.1'
-    userpath: '>=1.7,<2'
-    uv: '>=0.1.35'
-    virtualenv: '>=20.26.1'
-    zstandard: <1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
-    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
-  category: dev
-  optional: true
-- name: hatch
-  version: 1.12.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    tomlkit: '>=0.11.1'
-    httpx: '>=0.22.0'
-    hyperlink: '>=21.0.0'
-    platformdirs: '>=2.5.0'
-    keyring: '>=23.5.0'
-    shellingham: '>=1.4.0'
-    tomli-w: '>=1.0'
-    packaging: '>=23.2'
-    click: '>=8.0.6'
-    zstandard: <1.0
-    hatchling: '>=1.24.2'
-    pexpect: '>=4.8,<5'
-    userpath: '>=1.7,<2'
-    uv: '>=0.1.35'
-    virtualenv: '>=20.26.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
-    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
-  category: dev
-  optional: true
-- name: hatch
-  version: 1.12.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    tomlkit: '>=0.11.1'
-    httpx: '>=0.22.0'
-    hyperlink: '>=21.0.0'
-    platformdirs: '>=2.5.0'
-    keyring: '>=23.5.0'
-    shellingham: '>=1.4.0'
-    tomli-w: '>=1.0'
-    packaging: '>=23.2'
-    click: '>=8.0.6'
-    zstandard: <1.0
-    hatchling: '>=1.24.2'
-    pexpect: '>=4.8,<5'
-    userpath: '>=1.7,<2'
-    uv: '>=0.1.35'
-    virtualenv: '>=20.26.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
-    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
-  category: dev
-  optional: true
-- name: hatchling
-  version: 1.24.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    editables: '>=0.3'
-    importlib-metadata: ''
-    packaging: '>=21.3'
-    pathspec: '>=0.10.1'
-    pluggy: '>=1.0.0'
-    python: '>=3.7'
-    tomli: '>=1.2.2'
-    trove-classifiers: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28cef29029f6da70e7a987a76a3599a4
-    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
-  category: dev
-  optional: true
-- name: hatchling
-  version: 1.24.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib-metadata: ''
-    trove-classifiers: ''
-    python: '>=3.7'
-    packaging: '>=21.3'
-    pluggy: '>=1.0.0'
-    pathspec: '>=0.10.1'
-    tomli: '>=1.2.2'
-    editables: '>=0.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28cef29029f6da70e7a987a76a3599a4
-    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
-  category: dev
-  optional: true
-- name: hatchling
-  version: 1.24.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    importlib-metadata: ''
-    trove-classifiers: ''
-    python: '>=3.7'
-    packaging: '>=21.3'
-    pluggy: '>=1.0.0'
-    pathspec: '>=0.10.1'
-    tomli: '>=1.2.2'
-    editables: '>=0.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28cef29029f6da70e7a987a76a3599a4
-    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
-  category: dev
-  optional: true
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: dev
-  optional: true
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: dev
-  optional: true
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: dev
-  optional: true
-- name: html5lib
-  version: '1.1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-    six: '>=1.9'
-    webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: b2355343d6315c892543200231d7154a
-    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
-  category: dev
-  optional: true
-- name: html5lib
-  version: '1.1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-    webencodings: ''
-    six: '>=1.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: b2355343d6315c892543200231d7154a
-    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
-  category: dev
-  optional: true
-- name: html5lib
-  version: '1.1'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-    webencodings: ''
-    six: '>=1.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: b2355343d6315c892543200231d7154a
-    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
-  category: dev
-  optional: true
-- name: httpcore
-  version: 1.0.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    anyio: '>=3.0,<5.0'
-    certifi: ''
-    h11: '>=0.13,<0.15'
-    h2: '>=3,<5'
-    python: '>=3.8'
-    sniffio: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: a6b9a0158301e697e4d0a36a3d60e133
-    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
-  category: dev
-  optional: true
-- name: httpcore
-  version: 1.0.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    certifi: ''
-    python: '>=3.8'
-    sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: a6b9a0158301e697e4d0a36a3d60e133
-    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
-  category: dev
-  optional: true
-- name: httpcore
-  version: 1.0.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    certifi: ''
-    python: '>=3.8'
-    sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: a6b9a0158301e697e4d0a36a3d60e133
-    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
-  category: dev
-  optional: true
-- name: httpx
-  version: 0.27.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    anyio: ''
-    certifi: ''
-    httpcore: 1.*
-    idna: ''
-    python: '>=3.8'
-    sniffio: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9f359af5a886fd6ca6b2b6ea02e58332
-    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
-  category: dev
-  optional: true
-- name: httpx
-  version: 0.27.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    certifi: ''
-    idna: ''
-    anyio: ''
-    sniffio: ''
-    python: '>=3.8'
-    httpcore: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9f359af5a886fd6ca6b2b6ea02e58332
-    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
-  category: dev
-  optional: true
-- name: httpx
-  version: 0.27.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    certifi: ''
-    idna: ''
-    anyio: ''
-    sniffio: ''
-    python: '>=3.8'
-    httpcore: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9f359af5a886fd6ca6b2b6ea02e58332
-    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
-  category: dev
-  optional: true
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -6109,173 +2252,50 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
     filelock: ''
+    fsspec: '>=2023.5.0'
+    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.9'
-    typing-extensions: '>=3.7.4.3'
-    fsspec: '>=2023.5.0'
+    requests: ''
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+    typing-extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
     filelock: ''
+    fsspec: '>=2023.5.0'
+    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.9'
-    typing-extensions: '>=3.7.4.3'
-    fsspec: '>=2023.5.0'
+    requests: ''
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+    typing-extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
-- name: hydra-core
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    antlr-python-runtime: 4.9.*
-    importlib_resources: ''
-    omegaconf: '>=2.2,<2.4'
-    packaging: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 297d09ccdcec5b347d44c88f2b61cf03
-    sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
-  category: dev
-  optional: true
-- name: hydra-core
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    importlib_resources: ''
-    python: '>=3.6'
-    antlr-python-runtime: 4.9.*
-    omegaconf: '>=2.2,<2.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 297d09ccdcec5b347d44c88f2b61cf03
-    sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
-  category: dev
-  optional: true
-- name: hydra-core
-  version: 1.3.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    importlib_resources: ''
-    python: '>=3.6'
-    antlr-python-runtime: 4.9.*
-    omegaconf: '>=2.2,<2.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 297d09ccdcec5b347d44c88f2b61cf03
-    sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
-  category: dev
-  optional: true
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: dev
-  optional: true
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: dev
-  optional: true
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: dev
-  optional: true
-- name: hyperlink
-  version: 21.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    idna: '>=2.6'
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
-    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
-  category: dev
-  optional: true
-- name: hyperlink
-  version: 21.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-    idna: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
-    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
-  category: dev
-  optional: true
-- name: hyperlink
-  version: 21.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-    idna: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
-    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
-  category: dev
-  optional: true
 - name: icu
   version: '73.2'
   manager: conda
@@ -6287,72 +2307,8 @@ package:
   hash:
     md5: cc47e1facc155f91abd89b11e48e72ff
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  category: dev
-  optional: true
-- name: icu
-  version: '73.2'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-  hash:
-    md5: 8521bd47c0e11c5902535bb1a17c565f
-    sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
-  category: dev
-  optional: true
-- name: icu
-  version: '73.2'
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
-  hash:
-    md5: 0f47d9e3192d9e09ae300da0d28e0f56
-    sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
-  category: dev
-  optional: true
-- name: identify
-  version: 2.5.36
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    ukkonen: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba68cb5105760379432cebc82b45af40
-    sha256: dc98ab2233d3ed3692499e2a06b027489ee317658cef9277ec23cab00236f31c
-  category: dev
-  optional: true
-- name: identify
-  version: 2.5.36
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    ukkonen: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba68cb5105760379432cebc82b45af40
-    sha256: dc98ab2233d3ed3692499e2a06b027489ee317658cef9277ec23cab00236f31c
-  category: dev
-  optional: true
-- name: identify
-  version: 2.5.36
-  manager: conda
-  platform: win-64
-  dependencies:
-    ukkonen: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba68cb5105760379432cebc82b45af40
-    sha256: dc98ab2233d3ed3692499e2a06b027489ee317658cef9277ec23cab00236f31c
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: idna
   version: '3.7'
   manager: conda
@@ -6464,81 +2420,6 @@ package:
     sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
   category: main
   optional: false
-- name: importlib_resources
-  version: 6.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  category: dev
-  optional: true
-- name: importlib_resources
-  version: 6.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  category: dev
-  optional: true
-- name: importlib_resources
-  version: 6.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  category: dev
-  optional: true
-- name: iniconfig
-  version: 2.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  category: dev
-  optional: true
-- name: iniconfig
-  version: 2.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  category: dev
-  optional: true
-- name: iniconfig
-  version: 2.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  category: dev
-  optional: true
 - name: intel-openmp
   version: 2024.1.0
   manager: conda
@@ -6550,183 +2431,6 @@ package:
     sha256: 77465396f2636c8b3b3a587f1636ee35c17a73e2a2c7e0ea0957b05f84704cf3
   category: main
   optional: false
-- name: iterative-telemetry
-  version: 0.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    appdirs: ''
-    distro: ''
-    filelock: ''
-    python: '>=3.7'
-    requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6eb5ad35a97da6f5efe7689ead4ab79f
-    sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
-  category: dev
-  optional: true
-- name: iterative-telemetry
-  version: 0.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    requests: ''
-    appdirs: ''
-    filelock: ''
-    distro: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6eb5ad35a97da6f5efe7689ead4ab79f
-    sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
-  category: dev
-  optional: true
-- name: iterative-telemetry
-  version: 0.0.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    requests: ''
-    appdirs: ''
-    filelock: ''
-    distro: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6eb5ad35a97da6f5efe7689ead4ab79f
-    sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
-  category: dev
-  optional: true
-- name: jaraco.classes
-  version: 3.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 7b756504d362cbad9b73a50a5455cafd
-    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
-  category: dev
-  optional: true
-- name: jaraco.classes
-  version: 3.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 7b756504d362cbad9b73a50a5455cafd
-    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
-  category: dev
-  optional: true
-- name: jaraco.classes
-  version: 3.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 7b756504d362cbad9b73a50a5455cafd
-    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
-  category: dev
-  optional: true
-- name: jaraco.context
-  version: 5.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    backports.tarfile: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
-    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
-  category: dev
-  optional: true
-- name: jaraco.context
-  version: 5.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    backports.tarfile: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
-    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
-  category: dev
-  optional: true
-- name: jaraco.context
-  version: 5.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    backports.tarfile: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
-    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
-  category: dev
-  optional: true
-- name: jaraco.functools
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 547670a612fd335eaa5ffbf0fa75cb64
-    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
-  category: dev
-  optional: true
-- name: jaraco.functools
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 547670a612fd335eaa5ffbf0fa75cb64
-    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
-  category: dev
-  optional: true
-- name: jaraco.functools
-  version: 4.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    more-itertools: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 547670a612fd335eaa5ffbf0fa75cb64
-    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
-  category: dev
-  optional: true
-- name: jeepney
-  version: 0.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9800ad1699b42612478755a2d26c722d
-    sha256: 16639759b811866d63315fe1391f6fb45f5478b823972f4d3d9f0392b7dd80b8
-  category: dev
-  optional: true
 - name: jinja2
   version: 3.1.4
   manager: conda
@@ -6745,8 +2449,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -6758,50 +2462,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
     sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
   category: main
   optional: false
-- name: jmespath
-  version: 1.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
-  category: dev
-  optional: true
-- name: jmespath
-  version: 1.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
-  category: dev
-  optional: true
-- name: jmespath
-  version: 1.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
-    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
-  category: dev
-  optional: true
 - name: joblib
   version: 1.4.2
   manager: conda
@@ -6820,8 +2488,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -6833,71 +2501,26 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
     sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
   category: main
   optional: false
-- name: keyring
-  version: 25.2.1
+- name: jpeg
+  version: 9e
   manager: conda
   platform: linux-64
   dependencies:
-    __linux: ''
-    importlib_metadata: '>=4.11.4'
-    importlib_resources: ''
-    jaraco.classes: ''
-    jaraco.context: ''
-    jaraco.functools: ''
-    jeepney: '>=0.4.2'
-    python: '>=3.8'
-    secretstorage: '>=3.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyha804496_0.conda
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
   hash:
-    md5: 8508b734287ac18dd1caa72a0d8127ee
-    sha256: a9608fa7d3ec6a58f01a8901773a28bbe08f2e799476cd2b9aae7f578dff8fab
-  category: dev
-  optional: true
-- name: keyring
-  version: 25.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib_resources: ''
-    __osx: ''
-    jaraco.classes: ''
-    jaraco.functools: ''
-    jaraco.context: ''
-    python: '>=3.8'
-    importlib_metadata: '>=4.11.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh534df25_0.conda
-  hash:
-    md5: 8c071c544a2fc27cbc75dfa0d7362f0c
-    sha256: 25c638602ef3854a8f1785004124ac3acba2b1ceaa7a2f23f51dfa09b5cd6d3f
-  category: dev
-  optional: true
-- name: keyring
-  version: 25.2.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    importlib_resources: ''
-    __win: ''
-    jaraco.classes: ''
-    jaraco.functools: ''
-    jaraco.context: ''
-    python: '>=3.8'
-    importlib_metadata: '>=4.11.4'
-    pywin32-ctypes: '>=0.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh7428d3b_0.conda
-  hash:
-    md5: 70fb816c1b6ab81e048e4c6227ec922c
-    sha256: 3c7402db93f974fee3ef88f1208c8d9ab4009f33392a6b6d340516c96b3ae5b5
-  category: dev
-  optional: true
+    md5: c7a069243e1fbe9a556ed2ec030e6407
+    sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
+  category: main
+  optional: false
 - name: keyutils
   version: 1.6.1
   manager: conda
@@ -6910,54 +2533,6 @@ package:
     sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   category: main
   optional: false
-- name: kombu
-  version: 5.3.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    amqp: '>=5.1.1,<6.0.0'
-    boto3: '>=1.26.143'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    vine: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/kombu-5.3.7-py311h38be061_0.conda
-  hash:
-    md5: 256ce94762bf2e25822232253c029b5b
-    sha256: 5e5edf48bb1910dc851c997ea990d8d960b333044fae11d10ca93cfdc1f72a4c
-  category: dev
-  optional: true
-- name: kombu
-  version: 5.3.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    amqp: '>=5.1.1,<6.0.0'
-    boto3: '>=1.26.143'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    vine: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kombu-5.3.7-py311h267d04e_0.conda
-  hash:
-    md5: 1e42e45f351207e0571782c2d08ed983
-    sha256: c0810b295a185b4bb7d586b432ee12140efcf08745d322cff2e2d28dff8750ee
-  category: dev
-  optional: true
-- name: kombu
-  version: 5.3.7
-  manager: conda
-  platform: win-64
-  dependencies:
-    amqp: '>=5.1.1,<6.0.0'
-    boto3: '>=1.26.143'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    vine: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/kombu-5.3.7-py311h1ea47a8_0.conda
-  hash:
-    md5: 6f3bce35fa4b4612fc1f2413a9b4033e
-    sha256: e1338942952ecc2bcff542443a6f0c329b3448d5432772dffbc6ea1480f24211
-  category: dev
-  optional: true
 - name: krb5
   version: 1.21.2
   manager: conda
@@ -7004,17 +2579,17 @@ package:
   category: main
   optional: false
 - name: lcms2
-  version: '2.16'
+  version: '2.15'
   manager: conda
   platform: linux-64
   dependencies:
+    jpeg: '>=9e,<10a'
     libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+    libtiff: '>=4.5.0,<4.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
   hash:
-    md5: 51bb7010fc86f70eee639b4bb7a894f5
-    sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
+    md5: aa8840cdf17ef0c6084d1e24abc7a28b
+    sha256: 443e926b585528112ec6aa4d85bf087722914ed8d85a2f75ae47c023c55c4238
   category: main
   optional: false
 - name: lcms2
@@ -7083,16 +2658,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: '>=1.0'
-    numpy: '>=1.19'
-    scipy: '>=1.2'
-    python: '>=3.7.0'
-    psutil: '>=5'
     binpickle: '>=0.3.2'
     cffi: '>=1.12.2'
     csr: '>=0.3.1'
-    seedbank: '>=0.1.0'
     numba: '>=0.51,<0.59'
+    numpy: '>=1.19'
+    pandas: '>=1.0'
+    psutil: '>=5'
+    python: '>=3.7.0'
+    scipy: '>=1.2'
+    seedbank: '>=0.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/lenskit-0.14.4-pyhd8ed1ab_0.conda
   hash:
     md5: d3f95eaf0ca981e4831d603f3eb87e2f
@@ -7104,16 +2679,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pandas: '>=1.0'
-    numpy: '>=1.19'
-    scipy: '>=1.2'
-    python: '>=3.7.0'
-    psutil: '>=5'
     binpickle: '>=0.3.2'
     cffi: '>=1.12.2'
     csr: '>=0.3.1'
-    seedbank: '>=0.1.0'
     numba: '>=0.51,<0.59'
+    numpy: '>=1.19'
+    pandas: '>=1.0'
+    psutil: '>=5'
+    python: '>=3.7.0'
+    scipy: '>=1.2'
+    seedbank: '>=0.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/lenskit-0.14.4-pyhd8ed1ab_0.conda
   hash:
     md5: d3f95eaf0ca981e4831d603f3eb87e2f
@@ -7437,39 +3012,16 @@ package:
     sha256: b8ff3db6459d10320708981c54241cf7ede3cd10e022f3b5c94f754fd5e0c95f
   category: main
   optional: false
-- name: libasprintf
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 1b27402397a76115679c4855ab2ece41
-    sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
-  category: dev
-  optional: true
-- name: libasprintf-devel
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libasprintf: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 480c106e87d4c4791e6b55a6d1678866
-    sha256: f5331486854a5fe80bb837891efb28a28623f762327372cb4cbc264c9c4bf9e2
-  category: dev
-  optional: true
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.27,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
+    mkl: '>=2022.1.0,<2023.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_mkl.tar.bz2
   hash:
-    md5: 1a2a0cd3153464fee6646f3dd6dad9b8
-    sha256: 082b8ac20d43a7bbcdc28b3b1cd40e4df3a8b5daf0a2d23d68953a44d2d12c1b
+    md5: 85f61af03fd291dae33150ffe89dc09a
+    sha256: 24e656f13b402b6fceb88df386768445ab9beb657d451a8e5a88d4b3380cf7a4
   category: main
   optional: false
 - name: libblas
@@ -7619,10 +3171,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_mkl.tar.bz2
   hash:
-    md5: 4b31699e0ec5de64d5896e580389c9a1
-    sha256: da1b2faa017663c8f5555c1c5518e96ac4cd8e0be2a673c1c9e2cb8507c8fe46
+    md5: 361bf757b95488de76c4f123805742d3
+    sha256: 892ba10508f22310ccfe748df1fd3b6c7f20e7b6f6b79e69ed337863551c1bd8
   category: main
   optional: false
 - name: libcblas
@@ -7752,15 +3304,15 @@ package:
   category: main
   optional: false
 - name: libdeflate
-  version: '1.20'
+  version: '1.17'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
   hash:
-    md5: 8e88f9389f1165d7c0936fe40d9a9a79
-    sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
+    md5: 5cc781fd91968b11a8a7fdbee0982676
+    sha256: f9983a8ea03531f2c14bce76c870ca325c0fddf0c4e872bff1f78bc52624179c
   category: main
   optional: false
 - name: libdeflate
@@ -7959,111 +3511,6 @@ package:
     sha256: 78931358d83ff585d0cd448632366a5cbe6bcf41a66c07e8178200008127c2b5
   category: main
   optional: false
-- name: libgd
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    expat: ''
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h119a65a_9.conda
-  hash:
-    md5: cfebc557e54905dadc355c0e9f003004
-    sha256: b74f95a6e1f3b31a74741b39cba83ed99fc82d17243c0fd3b5ab16ddd48ab89d
-  category: dev
-  optional: true
-- name: libgd
-  version: 2.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    expat: ''
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hfdf3952_9.conda
-  hash:
-    md5: 0d847466f115fbdaaf2b6926f2e33278
-    sha256: cfdecfaa27807abc2728bd8c60b923ce1b44020553e122e9a56fc3acb77acaec
-  category: dev
-  optional: true
-- name: libgd
-  version: 2.3.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    expat: ''
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp: ''
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    xorg-libxpm: '>=3.5.16,<4.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/libgd-2.3.3-h312136b_9.conda
-  hash:
-    md5: 69c987e1f9268d9ade86497c4ab8cc45
-    sha256: fa75f4206eb9cd8e5e24fe1b6381a7450cfcb507c42813fd028a924a4872bc76
-  category: dev
-  optional: true
-- name: libgettextpo
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: a66fad933e22d22599a6dd149d359d25
-    sha256: c3f5580e172c3fc03d33e8994024f08b709a239bd599792e51435fa7a06beb64
-  category: dev
-  optional: true
-- name: libgettextpo-devel
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libgettextpo: 0.22.5
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 1113aa220b042b7ce8d077ea8f696f98
-    sha256: b1be0bb8a726e2c47a025ff348e6ba8b51ef668f6ace06694657025d84ae66e2
-  category: dev
-  optional: true
 - name: libgfortran
   version: 5.0.0
   manager: conda
@@ -8110,122 +3557,6 @@ package:
   hash:
     md5: 66ac81d54e95c534ae488726c1f698ea
     sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
-  category: main
-  optional: false
-- name: libgit2
-  version: 1.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libssh2: '>=1.11.0,<2.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.8.1-he8d1d4c_1.conda
-  hash:
-    md5: febd0520afc041dd938acdce0f26d71b
-    sha256: 7b59e6f31d9b4e877322ec1b9b7da61fc3f34950ca6a2b4576ba2de0de5718e6
-  category: dev
-  optional: true
-- name: libgit2
-  version: 1.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-    libiconv: '>=1.17,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgit2-1.8.1-h7d81828_1.conda
-  hash:
-    md5: 4a7d5c262df8bc95a0509ce29881293e
-    sha256: 9dd6e511540298213bab05b1a640259d4f874c58137568fca5162305df0d3e73
-  category: dev
-  optional: true
-- name: libgit2
-  version: 1.8.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgit2-1.8.1-hc1607c6_1.conda
-  hash:
-    md5: 96b2ee01e59abd5d8252b4da99f8ca7f
-    sha256: 68554180fe022e4cb7069e08906a3474732664763cea1594cc68b5671459ca57
-  category: dev
-  optional: true
-- name: libglib
-  version: 2.80.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-h8a4344b_1.conda
-  hash:
-    md5: 9c406bb3d4dac2b358873e6462496d09
-    sha256: 03dcc12fe937e32b1fbd7bd7cfe0f7a3e82ee4fe8d29c4d67afb657f13d04394
-  category: dev
-  optional: true
-- name: libglib
-  version: 2.80.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h59d46d9_1.conda
-  hash:
-    md5: 104d740896163d3e5b4b5ca7bc8f5bbb
-    sha256: 630c10b41bad621c1b6c7cf7241bceca4a009fdc1db2a5b9125dc49059eab070
-  category: dev
-  optional: true
-- name: libglib
-  version: 2.80.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: '>=0.22.5,<1.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    pcre2: '>=10.44,<10.45.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h7025463_1.conda
-  hash:
-    md5: f9f0561c59e62d02f6d6d118ce8b5b63
-    sha256: 84dc3f80a2956a055c7aa3b5df9061756cf5d3eecb11bf656688e1ee6177bd7e
-  category: dev
-  optional: true
-- name: libgomp
-  version: 13.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _libgcc_mutex: '0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h77fa898_10.conda
-  hash:
-    md5: 9404d1686e63142d41acc72ef876a588
-    sha256: bcea6ddfea86f0e6a1a831d1d2c3f36f7613b5e447229e19f978ded0d184cf5a
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -8402,6 +3733,20 @@ package:
 - name: libhwloc
   version: 2.10.0
   manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxml2: '>=2.12.7,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.10.0-default_h5622ce7_1001.conda
+  hash:
+    md5: fc2d5b79c2d3f8568fbab31db7ae02f3
+    sha256: 6f19d26819d336cb76689861e20560404a3cd61cc9adf7cbc395b9a5e612e226
+  category: main
+  optional: false
+- name: libhwloc
+  version: 2.10.0
+  manager: conda
   platform: win-64
   dependencies:
     libxml2: '>=2.12.7,<3.0a0'
@@ -8425,19 +3770,8 @@ package:
   hash:
     md5: d66573916ffcf376178462f1b61c941e
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  category: dev
-  optional: true
-- name: libiconv
-  version: '1.17'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
-  hash:
-    md5: 69bda57310071cf6d2b86caf11573d2d
-    sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -8450,55 +3784,6 @@ package:
   hash:
     md5: e1eb10b1cca179f2baa3601e4efc8712
     sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
-  category: main
-  optional: false
-- name: libintl
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 3d216d0add050129007de3342be7b8c5
-    sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
-  category: dev
-  optional: true
-- name: libintl
-  version: 0.22.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
-  hash:
-    md5: aa622c938af057adc119f8b8eecada01
-    sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
-  category: dev
-  optional: true
-- name: libintl-devel
-  version: 0.22.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.22.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
-  hash:
-    md5: 962b3348c68efd25da253e94590ea9a2
-    sha256: e52b2d0c5711f64b523756ccd9b800ee6f10a6317432b20a417dc3792e0a794a
-  category: dev
-  optional: true
-- name: libjpeg-turbo
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-  hash:
-    md5: ea25936bb4080d843790b586850f82b8
-    sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
   category: main
   optional: false
 - name: libjpeg-turbo
@@ -8532,10 +3817,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_mkl.tar.bz2
   hash:
-    md5: b083767b6c877e24ee597d93b87ab838
-    sha256: db246341d42f9100d45adeb1a7ba8b1ef5b51ceb9056fd643e98046a3259fde6
+    md5: a2f166748917d6d6e4707841ca1f519e
+    sha256: d6201f860b2d76ed59027e69c2bbad6d1cb211a215ec9705cc487cde488fa1fa
   category: main
   optional: false
 - name: liblapack
@@ -8647,20 +3932,6 @@ package:
   hash:
     md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  category: main
-  optional: false
-- name: libopenblas
-  version: 0.3.27
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
-  hash:
-    md5: a356024784da6dfd4683dc5ecf45b155
-    sha256: 2ae7559aed0705deb3f716c7b247c74fd1b5e35b64e39834ce8b95f7564d4a3e
   category: main
   optional: false
 - name: libopenblas
@@ -8853,43 +4124,6 @@ package:
     sha256: 04331dad30a076ebb24c683197a5feabf4fd9be0fa0e06f416767096f287f900
   category: main
   optional: false
-- name: librsvg
-  version: 2.58.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    harfbuzz: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.1-hadf69e7_0.conda
-  hash:
-    md5: 73fc255d740d23da4f554b58dc4909fd
-    sha256: c3b6c48e50a3ff8522d868215dcccfbd8f2720e512084b12f4bfcb6a668c5552
-  category: dev
-  optional: true
-- name: librsvg
-  version: 2.58.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
-    gdk-pixbuf: '>=2.42.12,<3.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libxml2: '>=2.12.7,<3.0a0'
-    pango: '>=1.50.14,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.1-hbc281fb_0.conda
-  hash:
-    md5: e642889ae7e977769f6d0328e2ec7497
-    sha256: 01fdd2c28b24d319f46cf8072147beda48e223757a8fb6bca95fb6c93bad918b
-  category: dev
-  optional: true
 - name: libsqlite
   version: 3.46.0
   manager: conda
@@ -9034,23 +4268,23 @@ package:
   category: main
   optional: false
 - name: libtiff
-  version: 4.6.0
+  version: 4.5.0
   manager: conda
   platform: linux-64
   dependencies:
+    jpeg: '>=9e,<10a'
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
+    libdeflate: '>=1.17,<1.18.0a0'
     libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
     libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.3.2,<2.0a0'
+    libwebp-base: '>=1.2.4,<2.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
     xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
   hash:
-    md5: 66f03896ffbe1a110ffda05c7a856504
-    sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
+    md5: 2e648a34072eb39d7c4fc2a9981c5f0c
+    sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
   category: main
   optional: false
 - name: libtiff
@@ -9090,49 +4324,6 @@ package:
   hash:
     md5: 6d1828c9039929e2f185c5fa9d133018
     sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
-  category: main
-  optional: false
-- name: libtorch
-  version: 2.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    libuv: '>=1.48.0,<2.0a0'
-    sleef: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.1.2-cpu_generic_h0ec3652_4.conda
-  hash:
-    md5: 14d76e1994a097c59c8822aed877f5f4
-    sha256: f5b02ad2accc3fe5670afeb4ad1671db171cb1a19ce8507547ab5e6195d0cc9e
-  category: main
-  optional: false
-- name: libtorch
-  version: 2.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
-    liblapack: '>=3.9.0,<4.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libuv: '>=1.48.0,<2.0a0'
-    llvm-openmp: '>=16.0.6'
-    numpy: '>=1.19,<3'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    sleef: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.3.1-cpu_generic_hac4f340_0.conda
-  hash:
-    md5: e925d1407b971d451e490fd4a46f3206
-    sha256: 2a4d926caed2cd6d51aeeae14685a8b1c57863a4ad8ca0b438eb7f896cb9b1c8
   category: main
   optional: false
 - name: libutf8proc
@@ -9187,29 +4378,6 @@ package:
 - name: libuv
   version: 1.48.0
   manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
-  hash:
-    md5: 7e8b914b1062dd4386e3de4d82a3ead6
-    sha256: b7c0e8a0c93c2621be7645b37123d4e8d27e8a974da26a3fba47a9c37711aa7f
-  category: main
-  optional: false
-- name: libuv
-  version: 1.48.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
-  hash:
-    md5: abfd49e80f13453b62a56be226120ea8
-    sha256: 60bed2a7a85096387ab0381cbc32ea2da7f8dd99bd90e440983019c0cdd96ad1
-  category: main
-  optional: false
-- name: libuv
-  version: 1.48.0
-  manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
@@ -9221,55 +4389,6 @@ package:
     sha256: 6151c51857c2407139ce22fdc956022353e675b2bc96991a9201d51cceaa90b4
   category: main
   optional: false
-- name: libwebp
-  version: 1.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    giflib: '>=5.2.2,<5.3.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.4.0-h2c329e2_0.conda
-  hash:
-    md5: 80030debaa84cfc31755d53742df3ca6
-    sha256: bd45805b169e3e0ff166d360c3c4842d77107d28c8f9feba020a8e8b9c80f948
-  category: dev
-  optional: true
-- name: libwebp
-  version: 1.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    giflib: '>=5.2.2,<5.3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-1.4.0-h54798ee_0.conda
-  hash:
-    md5: 078abbcc54996b186b9144cf795bd30f
-    sha256: e75e7a58793236fc8e92733c8bad168ce7bea40ca54c8c643e357511ba4a7b98
-  category: dev
-  optional: true
-- name: libwebp
-  version: 1.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    libwebp-base: '>=1.4.0,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-1.4.0-h2466b09_0.conda
-  hash:
-    md5: 11334a8fb02041b453e2f89a4ae16f8d
-    sha256: ebabb57084e85cd09d529dbb4fe0f4db6cd0d369ad8095342c37b98855fd87fd
-  category: dev
-  optional: true
 - name: libwebp-base
   version: 1.4.0
   manager: conda
@@ -9308,18 +4427,18 @@ package:
   category: main
   optional: false
 - name: libxcb
-  version: '1.15'
+  version: '1.13'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=9.4.0'
     pthread-stubs: ''
     xorg-libxau: ''
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
   hash:
-    md5: 33277193f5b92bad9fdd230eb700929c
-    sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+    md5: b3653fdc58d03face9724f602218a904
+    sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
   category: main
   optional: false
 - name: libxcb
@@ -9378,24 +4497,8 @@ package:
   hash:
     md5: 340278ded8b0dc3a73f3660bbb0adbc6
     sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
-  category: dev
-  optional: true
-- name: libxml2
-  version: 2.12.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=73.2,<74.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-ha661575_1.conda
-  hash:
-    md5: 8ea71a74847498c793b0a8e9054a177a
-    sha256: 0ea12032b53d3767564a058ccd5208c0a1724ed2f8074dd22257ff3859ea6a4e
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: libxml2
   version: 2.12.7
   manager: conda
@@ -9448,6 +4551,18 @@ package:
   hash:
     md5: d4483ca8afc57ddf1f6dded53b36c17f
     sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 15.0.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libzlib: '>=1.2.13,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
+  hash:
+    md5: 589c9a3575a050b583241c3d688ad9aa
+    sha256: 7c67d383a8b1f3e7bf9e046e785325c481f6868194edcfb9d78d261da4ad65d4
   category: main
   optional: false
 - name: llvm-openmp
@@ -9700,45 +4815,6 @@ package:
     sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
   category: main
   optional: false
-- name: markdown-it-py
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    mdurl: '>=0.1,<1'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  category: dev
-  optional: true
-- name: markdown-it-py
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    mdurl: '>=0.1,<1'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  category: dev
-  optional: true
-- name: markdown-it-py
-  version: 3.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    mdurl: '>=0.1,<1'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  category: dev
-  optional: true
 - name: markupsafe
   version: 2.1.5
   manager: conda
@@ -9782,42 +4858,20 @@ package:
     sha256: c629f79fe78b5df7f08daa6b7f125f7a67f789bf734949c6d68aa063d7296208
   category: main
   optional: false
-- name: mdurl
-  version: 0.1.2
+- name: mkl
+  version: 2022.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+    _openmp_mutex: '>=4.5'
+    llvm-openmp: '>=15.0.6'
+    tbb: 2021.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2022.2.1-h84fe81f_16997.conda
   hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
-  category: dev
-  optional: true
-- name: mdurl
-  version: 0.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
-  category: dev
-  optional: true
-- name: mdurl
-  version: 0.1.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 776a8dd9e824f77abac30e6ef43a8f7a
-    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
-  category: dev
-  optional: true
+    md5: a7ce56d5757f5b57e7daabe703ade5bb
+    sha256: 5322750d5e96ff5d96b1457db5fb6b10300f2bc4030545e940e17b57c4e96d00
+  category: main
+  optional: false
 - name: mkl
   version: 2021.4.0
   manager: conda
@@ -9855,42 +4909,6 @@ package:
     sha256: d07c44d4054f208681737522b6f9fe25b00b7f2a10acb2dccda5ef84536bfa79
   category: main
   optional: false
-- name: more-itertools
-  version: 10.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a57fb23d0260a962a67c7d990ec1c812
-    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: dev
-  optional: true
-- name: more-itertools
-  version: 10.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a57fb23d0260a962a67c7d990ec1c812
-    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: dev
-  optional: true
-- name: more-itertools
-  version: 10.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a57fb23d0260a962a67c7d990ec1c812
-    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
-  category: dev
-  optional: true
 - name: mpc
   version: 1.3.1
   manager: conda
@@ -10205,11 +5223,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    tqdm: ''
     click: ''
     joblib: ''
     python: '>=3.7'
     regex: '>=2021.8.3'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
   hash:
     md5: 518c769ca4273480a99be6e559a26192
@@ -10221,123 +5239,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    tqdm: ''
     click: ''
     joblib: ''
     python: '>=3.7'
     regex: '>=2021.8.3'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
   hash:
     md5: 518c769ca4273480a99be6e559a26192
     sha256: ac5403c253608cb76e7f14e51902f02516cbc18edb9eebf62f1bcd0648d0ac6b
-  category: main
-  optional: false
-- name: nodeenv
-  version: 1.9.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: 2.7|>=3.7
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: dfe0528d0f1c16c1f7c528ea5536ab30
-    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
-  category: dev
-  optional: true
-- name: nodeenv
-  version: 1.9.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    setuptools: ''
-    python: 2.7|>=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: dfe0528d0f1c16c1f7c528ea5536ab30
-    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
-  category: dev
-  optional: true
-- name: nodeenv
-  version: 1.9.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    setuptools: ''
-    python: 2.7|>=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: dfe0528d0f1c16c1f7c528ea5536ab30
-    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
-  category: dev
-  optional: true
-- name: nodejs
-  version: 20.12.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libuv: '>=1.48.0,<1.49.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.12.2-hb753e55_0.conda
-  hash:
-    md5: 1fd16ca757a195c4357a1fbb2cb553b5
-    sha256: 2f5813d9718963861314c6d9f75fe4630c3e6d078ec1e792770daf9ce7ac5c4f
-  category: dev
-  optional: true
-- name: nodejs
-  version: 20.12.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16'
-    libuv: '>=1.48.0,<1.49.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-20.12.2-h3b52c9b_0.conda
-  hash:
-    md5: 0ba66fae46df4a035db42e2230453604
-    sha256: 81ea2a695b4b97ce6066220b9e54232e67b4a1e3eac3fc7016c08a463c588478
-  category: dev
-  optional: true
-- name: nodejs
-  version: 20.12.2
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/nodejs-20.12.2-h57928b3_0.conda
-  hash:
-    md5: 28d4536e0beff7b51232a5b16f9c3444
-    sha256: 31b275bf914d57941e818b31f7ee8367c6c6a8532a2918639c87816bad1323af
-  category: dev
-  optional: true
-- name: nomkl
-  version: '1.0'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
-  hash:
-    md5: 9a66894dfd07c4510beb6b3f9672ccc0
-    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-  category: main
-  optional: false
-- name: nomkl
-  version: '1.0'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
-  hash:
-    md5: 9a66894dfd07c4510beb6b3f9672ccc0
-    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
   category: main
   optional: false
 - name: numba
@@ -10499,65 +5409,20 @@ package:
     sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
   category: main
   optional: false
-- name: omegaconf
-  version: 2.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    antlr-python-runtime: 4.9.*
-    python: '>=3.7'
-    pyyaml: '>=5.1.0'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 23cc056834cab53849b91f78d6ee3ea0
-    sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
-  category: dev
-  optional: true
-- name: omegaconf
-  version: 2.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3.7'
-    pyyaml: '>=5.1.0'
-    antlr-python-runtime: 4.9.*
-  url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 23cc056834cab53849b91f78d6ee3ea0
-    sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
-  category: dev
-  optional: true
-- name: omegaconf
-  version: 2.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3.7'
-    pyyaml: '>=5.1.0'
-    antlr-python-runtime: 4.9.*
-  url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 23cc056834cab53849b91f78d6ee3ea0
-    sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
-  category: dev
-  optional: true
 - name: openjpeg
-  version: 2.5.2
+  version: 2.5.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libpng: '>=1.6.43,<1.7.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
+    libtiff: '>=4.5.0,<4.6.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
   hash:
-    md5: 7f2e286780f072ed750df46dc2631138
-    sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
+    md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
+    sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
   category: main
   optional: false
 - name: openjpeg
@@ -10691,47 +5556,6 @@ package:
     sha256: 8aca1dcb6e9b3e71ffbec26c2b84f45fa682d9075b78cd30acc48044b64149ec
   category: main
   optional: false
-- name: orjson
-  version: 3.10.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.10.4-py311h5ecf98a_0.conda
-  hash:
-    md5: e30a98410d7a1e9bb3fa713c1fd5c377
-    sha256: e9fe499a21223169361bd2277a19bc9486df77a88a6b5d8ed73adb1aa14d025a
-  category: dev
-  optional: true
-- name: orjson
-  version: 3.10.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orjson-3.10.4-py311h98c6a39_0.conda
-  hash:
-    md5: 6b3a5b6525c0dd048218c7505a81f0b5
-    sha256: 7d1bec93320924e7a500e136887c00a978e8bfd907845cfe178b02b53a522f00
-  category: dev
-  optional: true
-- name: orjson
-  version: 3.10.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/win-64/orjson-3.10.4-py311h633b200_0.conda
-  hash:
-    md5: 78665916419f610478a2e7922bcfdf3a
-    sha256: 284d2c5ec290aa318a9e1425242faf4ca5874b61e20e7dc386b936addb8b951e
-  category: dev
-  optional: true
 - name: packaging
   version: '24.1'
   manager: conda
@@ -10826,68 +5650,6 @@ package:
     sha256: 351b4f7211fc755ea1af8b218d2515418df3af08170197011934faf06bb5d98e
   category: main
   optional: false
-- name: pango
-  version: 1.54.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.5.0,<9.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h84a9a3c_0.conda
-  hash:
-    md5: 7c51e110b2f059c0843269d3324e4b22
-    sha256: 3d0ef5a908f0429d7821d8a03a6f19ea7801245802c47f7c8c57163ea60e45c7
-  category: dev
-  optional: true
-- name: pango
-  version: 1.54.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.5.0,<9.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h5cb9fbc_0.conda
-  hash:
-    md5: e490cbccf161da2220fd9be3463c0fac
-    sha256: 45dd6dc3a5b737871f8bc6a5fd9857d37f6e411f33051ce8043af41c35c7fa02
-  category: dev
-  optional: true
-- name: pango
-  version: 1.54.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    cairo: '>=1.18.0,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: ''
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.5.0,<9.0a0'
-    libglib: '>=2.80.2,<3.0a0'
-    libpng: '>=1.6.43,<1.7.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-h2231ffd_0.conda
-  hash:
-    md5: cef297f5eac752831efd6e680bf980bd
-    sha256: f7910cc0ea1cff76adb2bcec81627e10d6b13f1956a47a69422b71cdc554bfe6
-  category: dev
-  optional: true
 - name: partd
   version: 1.4.2
   manager: conda
@@ -10907,9 +5669,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    toolz: ''
     locket: ''
     python: '>=3.9'
+    toolz: ''
   url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 0badf9c54e24cecfb0ad2f99d680c163
@@ -10921,233 +5683,36 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    toolz: ''
     locket: ''
     python: '>=3.9'
+    toolz: ''
   url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 0badf9c54e24cecfb0ad2f99d680c163
     sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
   category: main
   optional: false
-- name: pastel
-  version: 0.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a4eea5bff523f26442405bc5d1f52adb
-    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
-  category: dev
-  optional: true
-- name: pastel
-  version: 0.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a4eea5bff523f26442405bc5d1f52adb
-    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
-  category: dev
-  optional: true
-- name: pastel
-  version: 0.2.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a4eea5bff523f26442405bc5d1f52adb
-    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
-  category: dev
-  optional: true
-- name: pathlib2
-  version: 2.3.7.post1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    six: '>=1.13.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pathlib2-2.3.7.post1-py311h38be061_3.conda
-  hash:
-    md5: 972a2dff56a924aa01d2d90b3e6d0837
-    sha256: cb0b39f14ec99b892fc25b2733adb8af5a2572786e8528a2dff7138640068177
-  category: dev
-  optional: true
-- name: pathlib2
-  version: 2.3.7.post1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    six: '>=1.13.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pathlib2-2.3.7.post1-py311h267d04e_3.conda
-  hash:
-    md5: 1e5fd88aed9ddedbd5ed8f16ff8a7d52
-    sha256: 14b02b2274b2882164f089c5cb3f125a103969450ff5674926e88a769febb28a
-  category: dev
-  optional: true
-- name: pathlib2
-  version: 2.3.7.post1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    six: '>=1.13.0'
-  url: https://conda.anaconda.org/conda-forge/win-64/pathlib2-2.3.7.post1-py311h1ea47a8_3.conda
-  hash:
-    md5: 9e85cb72eff51862c45a7f7c92a88272
-    sha256: c930d9ac59ef2b4dcac8f9880028bac7ba78ee183499a5855ce4c85bf7214216
-  category: dev
-  optional: true
-- name: pathspec
-  version: 0.12.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
-  category: dev
-  optional: true
-- name: pathspec
-  version: 0.12.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
-  category: dev
-  optional: true
-- name: pathspec
-  version: 0.12.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 17064acba08d3686f1135b5ec1b32b12
-    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
-  category: dev
-  optional: true
-- name: pcre2
-  version: '10.44'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
-  hash:
-    md5: 3914f7ac1761dce57102c72ca7c35d01
-    sha256: 90646ad0d8f9d0fd896170c4f3d754e88c4ba0eaf856c24d00842016f644baab
-  category: dev
-  optional: true
-- name: pcre2
-  version: '10.44'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_0.conda
-  hash:
-    md5: 62f8d7e2ef03b0aae64185b0f38316eb
-    sha256: 23ddc5022a1025027ac1957dc1947c70d93a78414fbb183026457a537e8b3770
-  category: dev
-  optional: true
-- name: pcre2
-  version: '10.44'
-  manager: conda
-  platform: win-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
-  hash:
-    md5: 007d07ab5027e0bf49f6fa660a9f89a0
-    sha256: 44351611091ed72c4682ad23e53d7874334757298ff0ebb2acd769359ae82ab3
-  category: dev
-  optional: true
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ptyprocess: '>=0.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: dev
-  optional: true
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    ptyprocess: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: dev
-  optional: true
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    ptyprocess: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: dev
-  optional: true
 - name: pillow
-  version: 10.3.0
+  version: 9.4.0
   manager: conda
   platform: linux-64
   dependencies:
     freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
+    jpeg: '>=9e,<10a'
+    lcms2: '>=2.14,<3.0a0'
     libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
+    libtiff: '>=4.5.0,<4.6.0a0'
+    libwebp-base: '>=1.2.4,<2.0a0'
+    libxcb: '>=1.13,<1.14.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-    tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py311h18e6fac_0.conda
+    tk: '>=8.6.12,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py311h50def17_1.conda
   hash:
-    md5: 6c520a9d36c9d7270988c7a6c360d6d4
-    sha256: 6e54cc2acead8884e81e3e1b4f299b18d5daa0e3d11f4db5686db9e2ada2a353
+    md5: 8b5d1da23907114bd7aa3d562150ff36
+    sha256: ffb114fc7cdc8053694c71109dc8efb126b2dc944798ebaaff6ec7d695e9192e
   category: main
   optional: false
 - name: pillow
@@ -11216,9 +5781,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.7'
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
   hash:
     md5: f586ac1e56c8638b64f9c8122a7b8a67
@@ -11230,291 +5795,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    python: '>=3.7'
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
   hash:
     md5: f586ac1e56c8638b64f9c8122a7b8a67
     sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
   category: main
   optional: false
-- name: pixman
-  version: 0.43.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
-  hash:
-    md5: 71004cbf7924e19c02746ccde9fd7123
-    sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
-  category: dev
-  optional: true
-- name: pixman
-  version: 0.43.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
-  hash:
-    md5: 0308c68e711cd295aaa026a4f8c4b1e5
-    sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
-  category: dev
-  optional: true
-- name: pixman
-  version: 0.43.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
-  hash:
-    md5: b98135614135d5f458b75ab9ebb9558c
-    sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
-  category: dev
-  optional: true
-- name: pkginfo
-  version: 1.11.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6a3e4fb1396215d0d88b3cc2f09de412
-    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: dev
-  optional: true
-- name: pkginfo
-  version: 1.11.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6a3e4fb1396215d0d88b3cc2f09de412
-    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: dev
-  optional: true
-- name: pkginfo
-  version: 1.11.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6a3e4fb1396215d0d88b3cc2f09de412
-    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
-  category: dev
-  optional: true
-- name: platformdirs
-  version: 3.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  category: dev
-  optional: true
-- name: platformdirs
-  version: 3.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  category: dev
-  optional: true
-- name: platformdirs
-  version: 3.11.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8f567c0a74aa44cf732f15773b4083b0
-    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
-  category: dev
-  optional: true
-- name: pluggy
-  version: 1.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: dev
-  optional: true
-- name: pluggy
-  version: 1.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: dev
-  optional: true
-- name: pluggy
-  version: 1.5.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
-    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
-  category: dev
-  optional: true
-- name: pre-commit
-  version: 3.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cfgv: '>=2.0.0'
-    identify: '>=1.0.0'
-    nodeenv: '>=0.11.1'
-    python: '>=3.9'
-    pyyaml: '>=5.1'
-    virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
-  hash:
-    md5: 724bc4489c1174fc8e3233b0624fa51f
-    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
-  category: dev
-  optional: true
-- name: pre-commit
-  version: 3.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.9'
-    pyyaml: '>=5.1'
-    identify: '>=1.0.0'
-    nodeenv: '>=0.11.1'
-    cfgv: '>=2.0.0'
-    virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
-  hash:
-    md5: 724bc4489c1174fc8e3233b0624fa51f
-    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
-  category: dev
-  optional: true
-- name: pre-commit
-  version: 3.7.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.9'
-    pyyaml: '>=5.1'
-    identify: '>=1.0.0'
-    nodeenv: '>=0.11.1'
-    cfgv: '>=2.0.0'
-    virtualenv: '>=20.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
-  hash:
-    md5: 724bc4489c1174fc8e3233b0624fa51f
-    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
-  category: dev
-  optional: true
-- name: prompt-toolkit
-  version: 3.0.47
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
-  hash:
-    md5: 1247c861065d227781231950e14fe817
-    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
-  category: dev
-  optional: true
-- name: prompt-toolkit
-  version: 3.0.47
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    wcwidth: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
-  hash:
-    md5: 1247c861065d227781231950e14fe817
-    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
-  category: dev
-  optional: true
-- name: prompt-toolkit
-  version: 3.0.47
-  manager: conda
-  platform: win-64
-  dependencies:
-    wcwidth: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
-  hash:
-    md5: 1247c861065d227781231950e14fe817
-    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
-  category: dev
-  optional: true
-- name: prompt_toolkit
-  version: 3.0.47
-  manager: conda
-  platform: linux-64
-  dependencies:
-    prompt-toolkit: '>=3.0.47,<3.0.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.47-hd8ed1ab_0.conda
-  hash:
-    md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
-    sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
-  category: dev
-  optional: true
-- name: prompt_toolkit
-  version: 3.0.47
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    prompt-toolkit: '>=3.0.47,<3.0.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.47-hd8ed1ab_0.conda
-  hash:
-    md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
-    sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
-  category: dev
-  optional: true
-- name: prompt_toolkit
-  version: 3.0.47
-  manager: conda
-  platform: win-64
-  dependencies:
-    prompt-toolkit: '>=3.0.47,<3.0.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.47-hd8ed1ab_0.conda
-  hash:
-    md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
-    sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
-  category: dev
-  optional: true
 - name: psutil
   version: 5.9.8
   manager: conda
@@ -11605,42 +5894,6 @@ package:
     sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
   category: main
   optional: false
-- name: ptyprocess
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-  category: dev
-  optional: true
-- name: ptyprocess
-  version: 0.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-  category: dev
-  optional: true
-- name: ptyprocess
-  version: 0.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-  category: dev
-  optional: true
 - name: pyarrow
   version: 16.1.0
   manager: conda
@@ -11774,8 +6027,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
     pyarrow: '>=0.14'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -11787,8 +6040,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.5'
     pyarrow: '>=0.14'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -11831,427 +6084,6 @@ package:
     sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
-- name: pydantic
-  version: 2.7.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.18.4
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
-    sha256: 329de082dbf174fa7ce3136eb747edfb5c63eb7c77d789ae275040b17fc92471
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.7.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.18.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
-    sha256: 329de082dbf174fa7ce3136eb747edfb5c63eb7c77d789ae275040b17fc92471
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.7.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.18.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
-    sha256: 329de082dbf174fa7ce3136eb747edfb5c63eb7c77d789ae275040b17fc92471
-  category: main
-  optional: false
-- name: pydantic-core
-  version: 2.18.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.18.4-py311h5ecf98a_0.conda
-  hash:
-    md5: c4de9699f095e3049dc02bcf811497b7
-    sha256: 2c34d272a1afe39afbf4713a7f96366a579cb628a0321159e3015695b1e54913
-  category: dev
-  optional: true
-- name: pydantic-core
-  version: 2.18.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.18.4-py311h98c6a39_0.conda
-  hash:
-    md5: d7a6b069772e61897ab8ade15d268dde
-    sha256: ca8342ba184e1e9ce1367c7225cbd837516b3d69381a17fc53c434bb2a2a1f0f
-  category: dev
-  optional: true
-- name: pydantic-core
-  version: 2.18.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    typing-extensions: '>=4.6.0,!=4.7.0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.18.4-py311h533ab2d_0.conda
-  hash:
-    md5: e91b2e309604559af562f15b19e39917
-    sha256: 675d5c219b68d82af3649564f12e882c49cfafc4a6cc394d3a3ee00f6d14a047
-  category: dev
-  optional: true
-- name: pydot
-  version: 2.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    graphviz: '>=2.38.0'
-    pyparsing: '>=3'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydot-2.0.0-py311h38be061_0.conda
-  hash:
-    md5: cdfd23a54a18f3c8d5320d7717f4ed52
-    sha256: 091228a33041e667dd03f38684e5f04ef11ef316b8fb0ac21ed2f2ada546e633
-  category: dev
-  optional: true
-- name: pydot
-  version: 2.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    graphviz: '>=2.38.0'
-    pyparsing: '>=3'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydot-2.0.0-py311h267d04e_0.conda
-  hash:
-    md5: 5ccaf6ac3d5cdb0b2c240f8fa4485d6e
-    sha256: 68aaf6ea99daf8093e4f4b426831f51d9d79ff5ae0901f2bab0a47dfee9b5eab
-  category: dev
-  optional: true
-- name: pydot
-  version: 2.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    graphviz: '>=2.38.0'
-    pyparsing: '>=3'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/win-64/pydot-2.0.0-py311h1ea47a8_0.conda
-  hash:
-    md5: acccbaf906c36b4c7b2986fffc5b908e
-    sha256: f9ea84b56e988b31bd99b3e621d6d092a38f587f7ddecf619f767d9f8d75d735
-  category: dev
-  optional: true
-- name: pygit2
-  version: 1.15.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cffi: ''
-    libgcc-ng: '>=12'
-    libgit2: '>=1.8.1,<1.9.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pygit2-1.15.0-py311h331c9d8_0.conda
-  hash:
-    md5: 32ebdd6cfcdfa0c8bb9cd06fa2b85b3e
-    sha256: 8229d452a19bce44c7f173023ff36827886cf63fbd9f1576f2fdfe12e92176f4
-  category: dev
-  optional: true
-- name: pygit2
-  version: 1.15.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    cffi: ''
-    libgit2: '>=1.8.1,<1.9.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pygit2-1.15.0-py311hd3f4193_0.conda
-  hash:
-    md5: 0b8128cf65ccf05bbcef1dd4f2ab4300
-    sha256: 8f8172c83d555b2268112c05e3e22a6a9fcd06d113478b9e75d477d98d2356ca
-  category: dev
-  optional: true
-- name: pygit2
-  version: 1.15.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    cffi: ''
-    libgit2: '>=1.8.1,<1.9.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pygit2-1.15.0-py311he736701_0.conda
-  hash:
-    md5: e4071da277f4f734bdeca8c98043e96d
-    sha256: f69cadd599f784579249606f41c476037768595dfc79f53a916334a6f9bdef2f
-  category: dev
-  optional: true
-- name: pygments
-  version: 2.18.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
-  category: dev
-  optional: true
-- name: pygments
-  version: 2.18.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
-  category: dev
-  optional: true
-- name: pygments
-  version: 2.18.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b7f5c092b8f9800150d998a71b76d5a1
-    sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
-  category: dev
-  optional: true
-- name: pygtrie
-  version: 2.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygtrie-2.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a041d1adf502fc6b3c6a0b0955e29fff
-    sha256: c77c8bc76e98ce95e28962c93613472a23cc30d14f523ce5eea625f91cef1e1a
-  category: dev
-  optional: true
-- name: pygtrie
-  version: 2.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygtrie-2.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a041d1adf502fc6b3c6a0b0955e29fff
-    sha256: c77c8bc76e98ce95e28962c93613472a23cc30d14f523ce5eea625f91cef1e1a
-  category: dev
-  optional: true
-- name: pygtrie
-  version: 2.5.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygtrie-2.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a041d1adf502fc6b3c6a0b0955e29fff
-    sha256: c77c8bc76e98ce95e28962c93613472a23cc30d14f523ce5eea625f91cef1e1a
-  category: dev
-  optional: true
-- name: pylev
-  version: 1.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylev-1.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: edf8651c4379d9d1495ad6229622d150
-    sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
-  category: dev
-  optional: true
-- name: pylev
-  version: 1.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylev-1.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: edf8651c4379d9d1495ad6229622d150
-    sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
-  category: dev
-  optional: true
-- name: pylev
-  version: 1.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pylev-1.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: edf8651c4379d9d1495ad6229622d150
-    sha256: 50bd91767686bfe769e50a5a1b883e238d944a6163fea43e7c0beaac54ca674f
-  category: dev
-  optional: true
-- name: pyopenssl
-  version: 24.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: '>=41.0.5,<43'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b50aec2c744a5c493c09cce9e2e7533e
-    sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
-  category: dev
-  optional: true
-- name: pyopenssl
-  version: 24.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    cryptography: '>=41.0.5,<43'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b50aec2c744a5c493c09cce9e2e7533e
-    sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
-  category: dev
-  optional: true
-- name: pyopenssl
-  version: 24.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    cryptography: '>=41.0.5,<43'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b50aec2c744a5c493c09cce9e2e7533e
-    sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
-  category: dev
-  optional: true
-- name: pyparsing
-  version: 3.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
-  category: dev
-  optional: true
-- name: pyparsing
-  version: 3.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
-  category: dev
-  optional: true
-- name: pyparsing
-  version: 3.1.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: b9a4dacf97241704529131a0dfc0494f
-    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
-  category: dev
-  optional: true
-- name: pyright
-  version: 1.1.367
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    nodeenv: '>=1.6.0'
-    nodejs: ''
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.367-py311h61187de_0.conda
-  hash:
-    md5: 74d20949d6fe2a207b2d9632d8e2a822
-    sha256: 2dd3cab564c910200ce7482481e259bf5ab1d262e58d90d522bc9ab792bd55b9
-  category: dev
-  optional: true
-- name: pyright
-  version: 1.1.367
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodeenv: '>=1.6.0'
-    nodejs: ''
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.367-py311hd3f4193_0.conda
-  hash:
-    md5: f041b08ae8b5c64bdddda8357496d5c8
-    sha256: ce4be02303942a7a16d3a10d3bb8cf6da4adedf4da2f98eb3db676ec433be71e
-  category: dev
-  optional: true
-- name: pyright
-  version: 1.1.367
-  manager: conda
-  platform: win-64
-  dependencies:
-    nodeenv: '>=1.6.0'
-    nodejs: ''
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.367-py311he736701_0.conda
-  hash:
-    md5: 4c51e348d47dc9a5d0351d113ef32a60
-    sha256: f02e99e4193ed742a3ceb8486dc6d398a0005a4f873e3a647eb6f3ddb9dae276
-  category: dev
-  optional: true
 - name: pysocks
   version: 1.7.1
   manager: conda
@@ -12284,68 +6116,14 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    win_inet_pton: ''
     python: '>=3.8'
+    win_inet_pton: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
   hash:
     md5: 56cd9fe388baac0e90c7149cfac95b60
     sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
   category: main
   optional: false
-- name: pytest
-  version: 8.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    colorama: ''
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: ''
-    packaging: ''
-    pluggy: <2.0,>=1.5
-    python: '>=3.8'
-    tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f3f49c22c7ef3a1195fa61dad3c43be
-    sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
-  category: dev
-  optional: true
-- name: pytest
-  version: 8.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    colorama: ''
-    iniconfig: ''
-    python: '>=3.8'
-    exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1'
-    pluggy: <2.0,>=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f3f49c22c7ef3a1195fa61dad3c43be
-    sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
-  category: dev
-  optional: true
-- name: pytest
-  version: 8.2.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    colorama: ''
-    iniconfig: ''
-    python: '>=3.8'
-    exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1'
-    pluggy: <2.0,>=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f3f49c22c7ef3a1195fa61dad3c43be
-    sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
-  category: dev
-  optional: true
 - name: python
   version: 3.11.9
   manager: conda
@@ -12506,55 +6284,6 @@ package:
     sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: main
   optional: false
-- name: python-gssapi
-  version: 1.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    decorator: ''
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.8.3-py311h0820609_0.conda
-  hash:
-    md5: 84fe6d156520937fd9fc634a88e36a52
-    sha256: eabe93b34fe0b53d3ab1163c2d6904bdd6be22f078c84dc4c5309154fd002763
-  category: dev
-  optional: true
-- name: python-gssapi
-  version: 1.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    decorator: ''
-    krb5: '>=1.21.2,<1.22.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-gssapi-1.8.3-py311hadfd579_0.conda
-  hash:
-    md5: 2e922095f5b48586cbb2c08808cb5b7f
-    sha256: 29c7cf8578fb383366276427efbc2ae9f9bbb5da63b24b7bd56042386e6eb017
-  category: dev
-  optional: true
-- name: python-gssapi
-  version: 1.8.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    decorator: ''
-    krb5: '>=1.21.2,<1.22.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-gssapi-1.8.3-py311h8a3cce8_0.conda
-  hash:
-    md5: 384a5a0aee51e2d50e6da34fa9e8303a
-    sha256: b55107429fd288611929d83ac8949d1026b942953303b2beb6b410d803a399e4
-  category: dev
-  optional: true
 - name: python-tzdata
   version: '2024.1'
   manager: conda
@@ -12671,65 +6400,43 @@ package:
   category: main
   optional: false
 - name: pytorch
-  version: 2.1.2
+  version: 2.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
+    blas: '*'
     filelock: ''
-    fsspec: ''
     jinja2: ''
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-    libtorch: 2.1.2.*
-    libuv: '>=1.48.0,<2.0a0'
+    llvm-openmp: <16
+    mkl: '>=2018'
     networkx: ''
-    nomkl: ''
-    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    sleef: '>=3.5.1,<4.0a0'
+    pytorch-mutex: '1.0'
+    pyyaml: ''
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.2-cpu_generic_py311h255d53b_4.conda
+  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-2.3.1-py3.11_cpu_0.tar.bz2
   hash:
-    md5: 740a2e20304b47db2c9a94f180d5be5d
-    sha256: 5822cc6f4cca0dd09899ef9f0e42ad9d1de4243f770d24b4389d545752ffec96
+    md5: 1f7a250b13cfcd4f24562707187da2a1
+    sha256: e526af10fa35f9f39b5c356ee5060a29de132d2ccaea060da5d7b6c42c31f16d
   category: main
   optional: false
 - name: pytorch
-  version: 2.3.1
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
     filelock: ''
-    fsspec: ''
     jinja2: ''
-    libabseil: '>=20240116.2,<20240117.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
-    liblapack: '>=3.9.0,<4.0a0'
-    libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libtorch: 2.3.1.*
-    libuv: '>=1.48.0,<2.0a0'
-    llvm-openmp: '>=16.0.6'
     networkx: ''
-    nomkl: ''
-    numpy: '>=1.19,<3'
     python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    sleef: '>=3.5.1,<4.0a0'
+    pyyaml: ''
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.3.1-cpu_generic_py311h82099cb_0.conda
+  url: https://conda.anaconda.org/pytorch/osx-arm64/pytorch-2.2.2-py3.11_0.tar.bz2
   hash:
-    md5: 66234dc95e9ce2ec73f62256a9fd7cbd
-    sha256: d2f8e12fc7d7f42bce69a802735ca20286978e4c4350a3e8af060e338b68965e
+    md5: cc4d0ea852c3f0e452b97cdc8a6eecfe
+    sha256: 61c94a761abf75ff132943be5c9f812dcc8fa6209ac74754574d1beacf6ef33f
   category: main
   optional: false
 - name: pytorch
@@ -12755,28 +6462,15 @@ package:
     sha256: bb24d176b407f69b2e6ebb10059697affa02a05746073cbaf8717559cd4ec1d4
   category: main
   optional: false
-- name: pytorch-cpu
-  version: 2.1.2
+- name: pytorch-mutex
+  version: '1.0'
   manager: conda
   platform: linux-64
-  dependencies:
-    pytorch: 2.1.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-cpu-2.1.2-cpu_generic_py311h9d11763_4.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
   hash:
-    md5: 6b72d7c404e09696c7d5d2e393879019
-    sha256: 71663b22bbab86f02784f63d8d2e29706dee02901818bdb0c2f79caf9a48cc4d
-  category: main
-  optional: false
-- name: pytorch-cpu
-  version: 2.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pytorch: 2.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.3.1-cpu_generic_py311h7a66607_0.conda
-  hash:
-    md5: 62bfc974de77ce58645111e90ca1ebe1
-    sha256: fac6ca96f30d909916c45cfc2344af9a89ce0eef995cbb27c886302838fc4983
+    md5: 49565ed726991fd28d08a39885caa88d
+    sha256: d48c964188ca49660d750cffd73698d217cf94e694cd51987f9f186425435e76
   category: main
   optional: false
 - name: pytorch-mutex
@@ -12787,6 +6481,7 @@ package:
   url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
   hash:
     md5: 49565ed726991fd28d08a39885caa88d
+    sha256: d48c964188ca49660d750cffd73698d217cf94e694cd51987f9f186425435e76
   category: main
   optional: false
 - name: pytz
@@ -12825,74 +6520,6 @@ package:
     sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   category: main
   optional: false
-- name: pywin32
-  version: '306'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py311h12c1d0e_2.conda
-  hash:
-    md5: 25df0fc55722ea1a94494f41302e2d1c
-    sha256: 79d942817bdaf384602113e5fcb9158dc45cae4044bed308918a5db97f141fdb
-  category: dev
-  optional: true
-- name: pywin32-ctypes
-  version: 0.2.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py311h1ea47a8_1.conda
-  hash:
-    md5: e1270294a55b716f9b76900340e8fc82
-    sha256: 75a80bda3a87ae9387e8860be7a5271a67846d8929fe8c99799ed40eb085130a
-  category: dev
-  optional: true
-- name: pywin32-on-windows
-  version: 0.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
-  hash:
-    md5: 2807a0becd1d986fe1ef9b7f8135f215
-    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: dev
-  optional: true
-- name: pywin32-on-windows
-  version: 0.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
-  hash:
-    md5: 2807a0becd1d986fe1ef9b7f8135f215
-    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
-  category: dev
-  optional: true
-- name: pywin32-on-windows
-  version: 0.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    pywin32: ''
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh07e9846_2.tar.bz2
-  hash:
-    md5: 91733394059b880d9cc0d010c20abda0
-    sha256: 09803b75cccc16d8586d2f41ea890658d165f4afc359973fa1c7904a2c140eae
-  category: dev
-  optional: true
 - name: pyyaml
   version: 6.0.1
   manager: conda
@@ -13058,220 +6685,40 @@ package:
   hash:
     md5: 5ede4753180c7a550a443c430dc8ab52
     sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: requests
   version: 2.32.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
     md5: 5ede4753180c7a550a443c430dc8ab52
     sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: requests
   version: 2.32.3
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
     md5: 5ede4753180c7a550a443c430dc8ab52
     sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: dev
-  optional: true
-- name: rich
-  version: 13.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    markdown-it-py: '>=2.2.0'
-    pygments: '>=2.13.0,<3.0.0'
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: dev
-  optional: true
-- name: rich
-  version: 13.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: dev
-  optional: true
-- name: rich
-  version: 13.7.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7.0'
-    typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: ba445bf767ae6f0d959ff2b40c20912b
-    sha256: 2b26d58aa59e46f933c3126367348651b0dab6e0bf88014e857415bb184a4667
-  category: dev
-  optional: true
-- name: ruamel.yaml
-  version: 0.18.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ruamel.yaml.clib: '>=0.1.2'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.6-py311h459d7ec_0.conda
-  hash:
-    md5: 4dccc0bc3bb4d6e5c30bccbd053c4f90
-    sha256: b7056cf0f680a70c24d0a9addea6e8b640bfeafda4c37887e276331757404da0
-  category: dev
-  optional: true
-- name: ruamel.yaml
-  version: 0.18.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ruamel.yaml.clib: '>=0.1.2'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.6-py311h05b510d_0.conda
-  hash:
-    md5: d2a62ffc98713af809060950a6c1d107
-    sha256: 7ed21c406b18c0ae1c3f6815afe5d7dcfddc374a0ac212fd9f203767d0a18ad4
-  category: dev
-  optional: true
-- name: ruamel.yaml
-  version: 0.18.6
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ruamel.yaml.clib: '>=0.1.2'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.6-py311ha68e1ae_0.conda
-  hash:
-    md5: d471ed4194d2e3aa016278223a8fa52c
-    sha256: a6914bab1f8350c1c4d1b3cd09cf753d788b2e8bd496d78389390660e5be18cd
-  category: dev
-  optional: true
-- name: ruamel.yaml.clib
-  version: 0.2.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h459d7ec_0.conda
-  hash:
-    md5: 7865c897d89a39abc0056d89e37bd9e9
-    sha256: b6a4b72ec2a59de0307fca0c699da6238391ee20deb2d121780d10559b5a61a3
-  category: dev
-  optional: true
-- name: ruamel.yaml.clib
-  version: 0.2.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py311h05b510d_0.conda
-  hash:
-    md5: 0fbb200e26cec1931d0337ee70422965
-    sha256: 8b64d7ac6d544cdb1c5e3677c3a6ea10f1d87f818888b25df5f3b97f271ef14f
-  category: dev
-  optional: true
-- name: ruamel.yaml.clib
-  version: 0.2.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py311ha68e1ae_0.conda
-  hash:
-    md5: 4938101fc72fa2a9919c51f194a733cb
-    sha256: 40896e9a78f24d108ee5cd4156042e2a71bd40fcf74167af0cca3e2551e02eda
-  category: dev
-  optional: true
-- name: ruff
-  version: 0.4.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.4.9-py311hae69bc3_0.conda
-  hash:
-    md5: 97b1901b332439b6a3ba8c1ebee8e0ee
-    sha256: 45765e0262e9b9435b653467e7efc50831753e530db808468a95cfb5d211cd38
-  category: dev
-  optional: true
-- name: ruff
-  version: 0.4.9
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.4.9-py311hd374d79_0.conda
-  hash:
-    md5: 48cc00763083875f15a2cf4005ceefeb
-    sha256: edb688fcf874fda757e7034a55b21a7195a7b70fcddbbfb2acaeb3d0ca6446e4
-  category: dev
-  optional: true
-- name: ruff
-  version: 0.4.9
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.4.9-py311ha637bb9_0.conda
-  hash:
-    md5: 4b660bf499ffff4ddf379b5c4fc443e7
-    sha256: 3b3cbe3f005f86a8e400c3ac1822a3bb82eaf3a61899015d2da40b47d8334cd0
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: s2n
   version: 1.4.16
   manager: conda
@@ -13285,90 +6732,6 @@ package:
     sha256: 8fb1e5eaf0e25b66be90d14caf87f3643451a0297bfdcbe376f3f49793bbbda4
   category: main
   optional: false
-- name: s3fs
-  version: 2024.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiobotocore: '>=2.5.4,<3.0.0'
-    aiohttp: ''
-    fsspec: 2024.5.0
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 69f9f792aa777125aa284263067d1e97
-    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
-  category: dev
-  optional: true
-- name: s3fs
-  version: 2024.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aiohttp: ''
-    python: '>=3.8'
-    aiobotocore: '>=2.5.4,<3.0.0'
-    fsspec: 2024.5.0
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 69f9f792aa777125aa284263067d1e97
-    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
-  category: dev
-  optional: true
-- name: s3fs
-  version: 2024.5.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    aiohttp: ''
-    python: '>=3.8'
-    aiobotocore: '>=2.5.4,<3.0.0'
-    fsspec: 2024.5.0
-  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 69f9f792aa777125aa284263067d1e97
-    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
-  category: dev
-  optional: true
-- name: s3transfer
-  version: 0.10.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    botocore: '>=1.33.2,<2.0a.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
-  category: dev
-  optional: true
-- name: s3transfer
-  version: 0.10.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    botocore: '>=1.33.2,<2.0a.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
-  category: dev
-  optional: true
-- name: s3transfer
-  version: 0.10.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    botocore: '>=1.33.2,<2.0a.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
-  category: dev
-  optional: true
 - name: safetensors
   version: 0.4.3
   manager: conda
@@ -13474,88 +6837,6 @@ package:
     sha256: d692402c159ab3c23a722d3d168b013f21193ab01ce1a913582e6db7fe2f0ecf
   category: main
   optional: false
-- name: scmrepo
-  version: 3.3.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aiohttp-retry: '>=2.5.0'
-    asyncssh: '>=2.13.1,<3'
-    dulwich: '>=0.22.1'
-    fsspec: '>=2024.2.0'
-    funcy: '>=1.14'
-    gitpython: '>3'
-    pathspec: '>=0.9.0'
-    pygit2: '>=1.14.0'
-    pygtrie: '>=2.3.2'
-    python: '>=3.8'
-    tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 633f93803051c8eae944808e40c17976
-    sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
-  category: dev
-  optional: true
-- name: scmrepo
-  version: 3.3.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    tqdm: ''
-    python: '>=3.8'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    pathspec: '>=0.9.0'
-    gitpython: '>3'
-    fsspec: '>=2024.2.0'
-    aiohttp-retry: '>=2.5.0'
-    asyncssh: '>=2.13.1,<3'
-    pygit2: '>=1.14.0'
-    dulwich: '>=0.22.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 633f93803051c8eae944808e40c17976
-    sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
-  category: dev
-  optional: true
-- name: scmrepo
-  version: 3.3.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    tqdm: ''
-    python: '>=3.8'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    pathspec: '>=0.9.0'
-    gitpython: '>3'
-    fsspec: '>=2024.2.0'
-    aiohttp-retry: '>=2.5.0'
-    asyncssh: '>=2.13.1,<3'
-    pygit2: '>=1.14.0'
-    dulwich: '>=0.22.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 633f93803051c8eae944808e40c17976
-    sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
-  category: dev
-  optional: true
-- name: secretstorage
-  version: 3.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cryptography: ''
-    dbus: ''
-    jeepney: '>=0.6'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py311h38be061_2.conda
-  hash:
-    md5: 30a57eaa8e72cb0c2c84d6d7db32010c
-    sha256: 45e7d85a3663993e8bffdb7c6040561923c848e3262228b163042663caa4485e
-  category: dev
-  optional: true
 - name: seedbank
   version: 0.1.3
   manager: conda
@@ -13575,9 +6856,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-    numpy: '>=1.17'
     anyconfig: '>=0.12'
+    numpy: '>=1.17'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/seedbank-0.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 4e16b309563adbb713646c3b948a1151
@@ -13589,51 +6870,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-    numpy: '>=1.17'
     anyconfig: '>=0.12'
+    numpy: '>=1.17'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/seedbank-0.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 4e16b309563adbb713646c3b948a1151
     sha256: 8ccddbb690e94c8f3ff342b30e1cff0ee82109d151defce6664406df0d6456e9
   category: main
   optional: false
-- name: semver
-  version: 3.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5efb3fccda53974aed800b6d575f72ed
-    sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
-  category: dev
-  optional: true
-- name: semver
-  version: 3.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5efb3fccda53974aed800b6d575f72ed
-    sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
-  category: dev
-  optional: true
-- name: semver
-  version: 3.0.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5efb3fccda53974aed800b6d575f72ed
-    sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
-  category: dev
-  optional: true
 - name: setuptools
   version: 70.0.0
   manager: conda
@@ -13670,114 +6915,6 @@ package:
     sha256: daa4638d288cfdf3b0ecea395d8efa25cafc4ebf4026464a36c797c84541d2be
   category: main
   optional: false
-- name: shellingham
-  version: 1.5.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
-  category: dev
-  optional: true
-- name: shellingham
-  version: 1.5.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
-  category: dev
-  optional: true
-- name: shellingham
-  version: 1.5.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: d08db09a552699ee9e7eec56b4eb3899
-    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
-  category: dev
-  optional: true
-- name: shortuuid
-  version: 1.0.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/shortuuid-1.0.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 241e47b9e59bd1689ba0c444306fe6b1
-    sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
-  category: dev
-  optional: true
-- name: shortuuid
-  version: 1.0.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/shortuuid-1.0.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 241e47b9e59bd1689ba0c444306fe6b1
-    sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
-  category: dev
-  optional: true
-- name: shortuuid
-  version: 1.0.13
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/shortuuid-1.0.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 241e47b9e59bd1689ba0c444306fe6b1
-    sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
-  category: dev
-  optional: true
-- name: shtab
-  version: 1.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5cf937409ac178717946edbfa82a5da
-    sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
-  category: dev
-  optional: true
-- name: shtab
-  version: 1.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5cf937409ac178717946edbfa82a5da
-    sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
-  category: dev
-  optional: true
-- name: shtab
-  version: 1.7.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5cf937409ac178717946edbfa82a5da
-    sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
-  category: dev
-  optional: true
 - name: six
   version: 1.16.0
   manager: conda
@@ -13812,31 +6949,6 @@ package:
   hash:
     md5: e5f25f8dbc060e9a8d912e432202afc2
     sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-  category: main
-  optional: false
-- name: sleef
-  version: 3.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h9b69904_2.tar.bz2
-  hash:
-    md5: 6e016cf4c525d04a7bd038cee53ad3fd
-    sha256: 77d644a16f682e6d01df63fe9d25315011393498b63cf08c0e548780e46b2170
-  category: main
-  optional: false
-- name: sleef
-  version: 3.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    llvm-openmp: '>=12.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.5.1-h156473d_2.tar.bz2
-  hash:
-    md5: bd159e7f04dbf79b06ed2bd37e112458
-    sha256: a3d20bed697aaababfcb53ca2011486cf5e44e20855142c170fa0826df5f952c
   category: main
   optional: false
 - name: smart-open
@@ -13893,8 +7005,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    wrapt: ''
     python: '>=3.6'
+    wrapt: ''
   url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
   hash:
     md5: 2804ae86934b30c2afbd713d1448afe5
@@ -13906,50 +7018,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    wrapt: ''
     python: '>=3.6'
+    wrapt: ''
   url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
   hash:
     md5: 2804ae86934b30c2afbd713d1448afe5
     sha256: c298144d1b5035bcdaee2e2b363a7fc29d10707b38c62c717d6cfd0657b601d3
   category: main
   optional: false
-- name: smmap
-  version: 5.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: dev
-  optional: true
-- name: smmap
-  version: 5.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: dev
-  optional: true
-- name: smmap
-  version: 5.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 62f26a3d1387acee31322208f0cfa3e0
-    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
-  category: dev
-  optional: true
 - name: snappy
   version: 1.2.0
   manager: conda
@@ -13989,42 +7065,6 @@ package:
     sha256: de02a222071d6a832ad3b790c8c977725161ad430ec694fd7b35769b6e1104b4
   category: main
   optional: false
-- name: sniffio
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 490730480d76cf9c8f8f2849719c6e2b
-    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
-  category: dev
-  optional: true
-- name: sniffio
-  version: 1.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 490730480d76cf9c8f8f2849719c6e2b
-    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
-  category: dev
-  optional: true
-- name: sniffio
-  version: 1.3.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 490730480d76cf9c8f8f2849719c6e2b
-    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
-  category: dev
-  optional: true
 - name: sortedcontainers
   version: 2.4.0
   manager: conda
@@ -14061,51 +7101,6 @@ package:
     sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
   category: main
   optional: false
-- name: sqltrie
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: ''
-    orjson: ''
-    pygtrie: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sqltrie-0.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b51fd2979cbda01f74ebaf7e4c2d632b
-    sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
-  category: dev
-  optional: true
-- name: sqltrie
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    attrs: ''
-    orjson: ''
-    pygtrie: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sqltrie-0.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b51fd2979cbda01f74ebaf7e4c2d632b
-    sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
-  category: dev
-  optional: true
-- name: sqltrie
-  version: 0.11.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    attrs: ''
-    orjson: ''
-    pygtrie: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/sqltrie-0.11.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b51fd2979cbda01f74ebaf7e4c2d632b
-    sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
-  category: dev
-  optional: true
 - name: swifter
   version: 1.4.0
   manager: conda
@@ -14127,10 +7122,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
+    dask: '>=2.10.0'
     pandas: '>=1.0.0'
     psutil: '>=5.6.6'
-    dask: '>=2.10.0'
+    python: '>=3.6'
     tqdm: '>=4.33.0'
   url: https://conda.anaconda.org/conda-forge/noarch/swifter-1.4.0-pyhd8ed1ab_0.conda
   hash:
@@ -14143,10 +7138,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
+    dask: '>=2.10.0'
     pandas: '>=1.0.0'
     psutil: '>=5.6.6'
-    dask: '>=2.10.0'
+    python: '>=3.6'
     tqdm: '>=4.33.0'
   url: https://conda.anaconda.org/conda-forge/noarch/swifter-1.4.0-pyhd8ed1ab_0.conda
   hash:
@@ -14175,9 +7170,9 @@ package:
   platform: osx-arm64
   dependencies:
     __unix: ''
-    python: '*'
-    mpmath: '>=0.19'
     gmpy2: '>=2.0.8'
+    mpmath: '>=0.19'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
   hash:
     md5: 4af9db19148140eb2ff3b2a93697063b
@@ -14189,50 +7184,28 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     mpmath: '>=0.19'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pyh04b8f61_3.conda
   hash:
     md5: 2a2ecb906ec4efabca7e40bd36b627c8
     sha256: cd488f0c44dec1f1f5d0c65144d144ccb5f8325c63bfcc60ab81e557d8bfc2b2
   category: main
   optional: false
-- name: tabulate
-  version: 0.9.0
+- name: tbb
+  version: 2021.12.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+    libgcc-ng: '>=12'
+    libhwloc: '>=2.10.0,<2.10.1.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h297d8ca_1.conda
   hash:
-    md5: 4759805cce2d914c38472f70bf4d8bcb
-    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: dev
-  optional: true
-- name: tabulate
-  version: 0.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 4759805cce2d914c38472f70bf4d8bcb
-    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: dev
-  optional: true
-- name: tabulate
-  version: 0.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 4759805cce2d914c38472f70bf4d8bcb
-    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  category: dev
-  optional: true
+    md5: 3ff978d8994f591818a506640c6a7071
+    sha256: ab706931ba80e8117995fc838509f044ccd1388a4cd7cc4ff1a55ea904bac723
+  category: main
+  optional: false
 - name: tbb
   version: 2021.12.0
   manager: conda
@@ -14372,114 +7345,6 @@ package:
     sha256: bd8058dab28ba1499c8a2cde21ed54399baedc2a5b4da668ba1bb4e49f23b914
   category: main
   optional: false
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: dev
-  optional: true
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: dev
-  optional: true
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: dev
-  optional: true
-- name: tomli-w
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 73506d1ab4202481841c68c169b7ef6c
-    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
-  category: dev
-  optional: true
-- name: tomli-w
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 73506d1ab4202481841c68c169b7ef6c
-    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
-  category: dev
-  optional: true
-- name: tomli-w
-  version: 1.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 73506d1ab4202481841c68c169b7ef6c
-    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
-  category: dev
-  optional: true
-- name: tomlkit
-  version: 0.12.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.5-pyha770c72_0.conda
-  hash:
-    md5: e5dde5caf905e9d95895e05f94967e14
-    sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
-  category: dev
-  optional: true
-- name: tomlkit
-  version: 0.12.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.5-pyha770c72_0.conda
-  hash:
-    md5: e5dde5caf905e9d95895e05f94967e14
-    sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
-  category: dev
-  optional: true
-- name: tomlkit
-  version: 0.12.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.5-pyha770c72_0.conda
-  hash:
-    md5: e5dde5caf905e9d95895e05f94967e14
-    sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
-  category: dev
-  optional: true
 - name: toolz
   version: 0.12.1
   manager: conda
@@ -14627,18 +7492,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
+    datasets: '!=2.5.0'
     filelock: ''
+    huggingface_hub: '>=0.23.0,<1.0'
+    numpy: '>=1.17'
+    packaging: '>=20.0'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.0'
-    numpy: '>=1.17'
     regex: '!=2019.12.17'
-    tqdm: '>=4.27'
-    datasets: '!=2.5.0'
+    requests: ''
     safetensors: '>=0.4.1'
     tokenizers: '>=0.19,<0.20'
-    huggingface_hub: '>=0.23.0,<1.0'
+    tqdm: '>=4.27'
   url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.41.2-pyhd8ed1ab_0.conda
   hash:
     md5: b4518ee13246d1c62fa6544b19d4ccd9
@@ -14650,183 +7515,24 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
+    datasets: '!=2.5.0'
     filelock: ''
+    huggingface_hub: '>=0.23.0,<1.0'
+    numpy: '>=1.17'
+    packaging: '>=20.0'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.0'
-    numpy: '>=1.17'
     regex: '!=2019.12.17'
-    tqdm: '>=4.27'
-    datasets: '!=2.5.0'
+    requests: ''
     safetensors: '>=0.4.1'
     tokenizers: '>=0.19,<0.20'
-    huggingface_hub: '>=0.23.0,<1.0'
+    tqdm: '>=4.27'
   url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.41.2-pyhd8ed1ab_0.conda
   hash:
     md5: b4518ee13246d1c62fa6544b19d4ccd9
     sha256: fd8921a42d1d94052c13a2365969a8598280b1986b117c8507abb39a50477711
   category: main
   optional: false
-- name: trove-classifiers
-  version: 2024.5.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: a887538e7f6697ed52a487dbaa0ebff5
-    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
-  category: dev
-  optional: true
-- name: trove-classifiers
-  version: 2024.5.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: a887538e7f6697ed52a487dbaa0ebff5
-    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
-  category: dev
-  optional: true
-- name: trove-classifiers
-  version: 2024.5.22
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
-  hash:
-    md5: a887538e7f6697ed52a487dbaa0ebff5
-    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
-  category: dev
-  optional: true
-- name: typer
-  version: 0.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
-  category: dev
-  optional: true
-- name: typer
-  version: 0.12.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
-  category: dev
-  optional: true
-- name: typer
-  version: 0.12.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
-  category: dev
-  optional: true
-- name: typer-slim
-  version: 0.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.0.0'
-    python: '>=3.7'
-    typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
-  category: dev
-  optional: true
-- name: typer-slim
-  version: 0.12.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    click: '>=8.0.0'
-    typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
-  category: dev
-  optional: true
-- name: typer-slim
-  version: 0.12.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    click: '>=8.0.0'
-    typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
-  category: dev
-  optional: true
-- name: typer-slim-standard
-  version: 0.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    rich: ''
-    shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
-  hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
-  category: dev
-  optional: true
-- name: typer-slim-standard
-  version: 0.12.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    rich: ''
-    shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
-  hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
-  category: dev
-  optional: true
-- name: typer-slim-standard
-  version: 0.12.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    rich: ''
-    shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
-  hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
-  category: dev
-  optional: true
 - name: typing-extensions
   version: 4.12.2
   manager: conda
@@ -14943,175 +7649,48 @@ package:
     sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
   category: main
   optional: false
-- name: ukkonen
-  version: 1.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cffi: ''
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311h9547e67_4.conda
-  hash:
-    md5: 586da7df03b68640de14dc3e8bcbf76f
-    sha256: c2d33e998f637b594632eba3727529171a06eb09896e36aa42f1ebcb03779472
-  category: dev
-  optional: true
-- name: ukkonen
-  version: 1.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cffi: ''
-    libcxx: '>=15.0.7'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py311he4fd1f5_4.conda
-  hash:
-    md5: 5d5ab5c5af32931e03608034f4a5fd75
-    sha256: 384fc81a34e248019d43a115386f77859ab63e0e6f12dade486d76359703743f
-  category: dev
-  optional: true
-- name: ukkonen
-  version: 1.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    cffi: ''
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py311h005e61a_4.conda
-  hash:
-    md5: d9988836cc20c90e05901ab05962f496
-    sha256: ef774047df25201a6425fe1ec194505a3cac9ba02e96953360442f59364d12b3
-  category: dev
-  optional: true
 - name: urllib3
-  version: 1.26.18
+  version: 2.2.2
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 92cdb6fe54b78739ad70637e4f0deb07
+    sha256: 8cd972048f297b8e0601158ce352f5ca9510dda9f2706a46560220aa58b9f038
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.18
+  version: 2.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 92cdb6fe54b78739ad70637e4f0deb07
+    sha256: 8cd972048f297b8e0601158ce352f5ca9510dda9f2706a46560220aa58b9f038
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.18
+  version: 2.2.2
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 92cdb6fe54b78739ad70637e4f0deb07
+    sha256: 8cd972048f297b8e0601158ce352f5ca9510dda9f2706a46560220aa58b9f038
   category: main
   optional: false
-- name: userpath
-  version: 1.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5bf074c9253a3bf914becfc50757406f
-    sha256: c8cbddd625340e1b00b53bafabc764526ee85f7ddb91018424bab0eea057796d
-  category: dev
-  optional: true
-- name: userpath
-  version: 1.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5bf074c9253a3bf914becfc50757406f
-    sha256: c8cbddd625340e1b00b53bafabc764526ee85f7ddb91018424bab0eea057796d
-  category: dev
-  optional: true
-- name: userpath
-  version: 1.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    click: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5bf074c9253a3bf914becfc50757406f
-    sha256: c8cbddd625340e1b00b53bafabc764526ee85f7ddb91018424bab0eea057796d
-  category: dev
-  optional: true
-- name: uv
-  version: 0.2.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.6-h0ea3d13_0.conda
-  hash:
-    md5: 59b5b6fd31fe993afe844687c36f64b5
-    sha256: a3476e0af359a15fcc4e575b106cd4d44d9633de43f83687c82a2b3b657ecb54
-  category: dev
-  optional: true
-- name: uv
-  version: 0.2.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.6-hc069d6b_0.conda
-  hash:
-    md5: d02bbc69d6ddfbcd822f64643360ec81
-    sha256: be826015f52a30931940291ceafea4b57d8cb539bae21974fe252cf5b3dc8486
-  category: dev
-  optional: true
-- name: uv
-  version: 0.2.6
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.6-ha08ef0e_0.conda
-  hash:
-    md5: 434644f2e1bc03498baf906a4f318ee7
-    sha256: 7884ae5d1027c20d79242a633ba0e6578c28f628f0c6c8e4e56f95dcc8667c96
-  category: dev
-  optional: true
 - name: vc
   version: '14.3'
   manager: conda
@@ -15136,123 +7715,6 @@ package:
     sha256: af3cfa347e3d7c1277e9b964b0849a9a9f095bff61836cb3c3a89862fbc32e17
   category: main
   optional: false
-- name: vine
-  version: 5.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: af71debe5f1819b065c0ba2b062ae81c
-    sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
-  category: dev
-  optional: true
-- name: vine
-  version: 5.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: af71debe5f1819b065c0ba2b062ae81c
-    sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
-  category: dev
-  optional: true
-- name: vine
-  version: 5.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: af71debe5f1819b065c0ba2b062ae81c
-    sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
-  category: dev
-  optional: true
-- name: virtualenv
-  version: 20.26.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    distlib: <1,>=0.3.7
-    filelock: <4,>=3.12.2
-    platformdirs: <5,>=3.9.1
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7d36e7a485ea2f5829408813bdbbfb38
-    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
-  category: dev
-  optional: true
-- name: virtualenv
-  version: 20.26.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    distlib: <1,>=0.3.7
-    filelock: <4,>=3.12.2
-    platformdirs: <5,>=3.9.1
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7d36e7a485ea2f5829408813bdbbfb38
-    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
-  category: dev
-  optional: true
-- name: virtualenv
-  version: 20.26.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    distlib: <1,>=0.3.7
-    filelock: <4,>=3.12.2
-    platformdirs: <5,>=3.9.1
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7d36e7a485ea2f5829408813bdbbfb38
-    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
-  category: dev
-  optional: true
-- name: voluptuous
-  version: 0.14.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: d61310a459c334702a00a2b7f4fc534c
-    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
-  category: dev
-  optional: true
-- name: voluptuous
-  version: 0.14.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: d61310a459c334702a00a2b7f4fc534c
-    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
-  category: dev
-  optional: true
-- name: voluptuous
-  version: 0.14.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: d61310a459c334702a00a2b7f4fc534c
-    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
-  category: dev
-  optional: true
 - name: vs2015_runtime
   version: 14.40.33810
   manager: conda
@@ -15265,78 +7727,6 @@ package:
     sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
   category: main
   optional: false
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: dev
-  optional: true
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: dev
-  optional: true
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: dev
-  optional: true
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: dev
-  optional: true
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: dev
-  optional: true
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: dev
-  optional: true
 - name: wheel
   version: 0.43.0
   manager: conda
@@ -15429,117 +7819,6 @@ package:
     sha256: e8209b3ebdde15834b59101fd14a7f293d868d2fbad2dcd634357cc3406f1052
   category: main
   optional: false
-- name: xorg-kbproto
-  version: 1.0.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-  hash:
-    md5: 4b230e8381279d76131116660f5a241a
-    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
-  category: dev
-  optional: true
-- name: xorg-kbproto
-  version: 1.0.7
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-kbproto-1.0.7-hcd874cb_1002.tar.bz2
-  hash:
-    md5: 8d11c1dac4756ca57e78c1bfe173bba4
-    sha256: 5b16e1ca1ecc0d2907f236bc4d8e6ecfd8417db013c862a01afb7f9d78e48c09
-  category: dev
-  optional: true
-- name: xorg-libice
-  version: 1.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
-  hash:
-    md5: b462a33c0be1421532f28bfe8f4a7514
-    sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  category: dev
-  optional: true
-- name: xorg-libice
-  version: 1.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-    m2w64-gcc-libs-core: ''
-    xorg-libx11: '>=1.8.4,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libice-1.1.1-hcd874cb_0.conda
-  hash:
-    md5: 5271e3af4791170e2c55d02818366916
-    sha256: 353e07e311eb10e934f03e0123d0f05d9b3770a70b0c3993e6d11cf74d85689f
-  category: dev
-  optional: true
-- name: xorg-libsm
-  version: 1.2.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libuuid: '>=2.38.1,<3.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-  hash:
-    md5: 93ee23f12bc2e684548181256edd2cf6
-    sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  category: dev
-  optional: true
-- name: xorg-libsm
-  version: 1.2.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-    m2w64-gcc-libs-core: ''
-    xorg-libice: '>=1.1.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libsm-1.2.4-hcd874cb_0.conda
-  hash:
-    md5: 25926681339df15918243d9a7cec25a1
-    sha256: 3a8cc151142c379d3ec3ec4420395d3a273873d3a45a94cd3038d143f5a519e8
-  category: dev
-  optional: true
-- name: xorg-libx11
-  version: 1.8.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-kbproto: ''
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-    xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
-  hash:
-    md5: 077b6e8ad6a3ddb741fce2496dd01bec
-    sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
-  category: dev
-  optional: true
-- name: xorg-libx11
-  version: 1.8.9
-  manager: conda
-  platform: win-64
-  dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
-    m2w64-gcc-libs: ''
-    m2w64-gcc-libs-core: ''
-    xorg-kbproto: ''
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-    xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.9-hefa74cf_0.conda
-  hash:
-    md5: 3672e991346895f332af1ebc60b8bca9
-    sha256: 15217b9180ff7d6840762363647fabcb79636517454d2c05dd69cb3fc38a1001
-  category: dev
-  optional: true
 - name: xorg-libxau
   version: 1.0.11
   manager: conda
@@ -15611,144 +7890,6 @@ package:
     sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
   category: main
   optional: false
-- name: xorg-libxext
-  version: 1.3.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.7.2,<2.0a0'
-    xorg-xextproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
-  hash:
-    md5: 82b6df12252e6f32402b96dacc656fec
-    sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  category: dev
-  optional: true
-- name: xorg-libxext
-  version: 1.3.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-    xorg-libx11: '>=1.7.2,<2.0a0'
-    xorg-xextproto: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxext-1.3.4-hcd874cb_2.conda
-  hash:
-    md5: 2aa695ac3c56193fd8d526e3b511e021
-    sha256: 829320f05866ea1cc51924828427f215f4d0db093e748a662e3bb68b764785a4
-  category: dev
-  optional: true
-- name: xorg-libxpm
-  version: 3.5.17
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-    m2w64-gcc-libs-core: ''
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxt: '>=1.3.0,<2.0a0'
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-    xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxpm-3.5.17-hcd874cb_0.conda
-  hash:
-    md5: 029be9b667bf3896fa28bc32adb1bfc3
-    sha256: d5cc2f026658e8b85679813bff35c16c857f873ba02489e6eb6e30d5865dacc4
-  category: dev
-  optional: true
-- name: xorg-libxrender
-  version: 0.9.11
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-renderproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
-  hash:
-    md5: ed67c36f215b310412b2af935bf3e530
-    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  category: dev
-  optional: true
-- name: xorg-libxt
-  version: 1.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-    m2w64-gcc-libs-core: ''
-    xorg-kbproto: ''
-    xorg-libice: '>=1.1.1,<2.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxt-1.3.0-hcd874cb_1.conda
-  hash:
-    md5: 511a29edd2ff3d973f63e54f19dcc06e
-    sha256: d513e0c627f098ef6655ce188eca79a672eaf763b0bbf37b228cb46dc82a66ca
-  category: dev
-  optional: true
-- name: xorg-renderproto
-  version: 0.11.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
-  hash:
-    md5: 06feff3d2634e3097ce2fe681474b534
-    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  category: dev
-  optional: true
-- name: xorg-xextproto
-  version: 7.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
-  hash:
-    md5: bce9f945da8ad2ae9b1d7165a64d0f87
-    sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
-  category: dev
-  optional: true
-- name: xorg-xextproto
-  version: 7.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-xextproto-7.3.0-hcd874cb_1003.conda
-  hash:
-    md5: 6e6c2639620e436bddb7c040cd4f3adb
-    sha256: 04c0a08fd34fa33406c20f729e8f9cc40e8fd898072b952a5c14280fcf26f2e6
-  category: dev
-  optional: true
-- name: xorg-xproto
-  version: 7.0.31
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-  hash:
-    md5: b4a4381d54784606820704f7b5f05a15
-    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-  category: dev
-  optional: true
-- name: xorg-xproto
-  version: 7.0.31
-  manager: conda
-  platform: win-64
-  dependencies:
-    m2w64-gcc-libs: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-xproto-7.0.31-hcd874cb_1007.tar.bz2
-  hash:
-    md5: 88f3c65d2ad13826a9e0b162063be023
-    sha256: b84cacba8479fa14199c9255fb62e005cacc619e90198c53b1653973709ec331
-  category: dev
-  optional: true
 - name: xxhash
   version: 0.8.2
   manager: conda
@@ -15943,45 +8084,6 @@ package:
     sha256: 647a7f6395be44b82a3dd4ad58d02fd1ce56cca19083061cbb118f788c0f31e5
   category: main
   optional: false
-- name: zc.lockfile
-  version: 3.0.post1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2'
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5de65315ad9643b7fb67e985fbb54a9
-    sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
-  category: dev
-  optional: true
-- name: zc.lockfile
-  version: 3.0.post1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    setuptools: ''
-    python: '>=2'
-  url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5de65315ad9643b7fb67e985fbb54a9
-    sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
-  category: dev
-  optional: true
-- name: zc.lockfile
-  version: 3.0.post1
-  manager: conda
-  platform: win-64
-  dependencies:
-    setuptools: ''
-    python: '>=2'
-  url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c5de65315ad9643b7fb67e985fbb54a9
-    sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
-  category: dev
-  optional: true
 - name: zict
   version: 3.0.0
   manager: conda
@@ -16054,93 +8156,6 @@ package:
     sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
   category: main
   optional: false
-- name: zlib
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
-  hash:
-    md5: 9653f1bf3766164d0e65fa723cabbc54
-    sha256: cee16ab07a11303de721915f0a269e8c7a54a5c834aa52f74b1cc3a59000ade8
-  category: dev
-  optional: true
-- name: zlib
-  version: 1.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: 1.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-hfb2fe0b_1.conda
-  hash:
-    md5: f27e021db7862b6ddbc1d3578f10d883
-    sha256: 87360c2dc662916aac37cf01e53324b4f4f78db6f399220818076752b093ede5
-  category: dev
-  optional: true
-- name: zlib
-  version: 1.3.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    libzlib: 1.3.1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
-  hash:
-    md5: f8e0a35bf6df768ad87ed7bbbc36ab04
-    sha256: 76409556e6c7cb91991cd94d7fc853c9272c2872bd7e3573ff35eb33d6fca5be
-  category: dev
-  optional: true
-- name: zstandard
-  version: 0.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cffi: '>=1.8'
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py311hd4cff14_0.tar.bz2
-  hash:
-    md5: 056b3271f46abaa4673c8c6783283a07
-    sha256: 8aac43cc4fbdcc420fe8a22c764b67f6ac9168b103bfd10d79a82b748304ddf6
-  category: dev
-  optional: true
-- name: zstandard
-  version: 0.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cffi: '>=1.8'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py311he2be06e_0.tar.bz2
-  hash:
-    md5: ece21cb47a93c985aa4b44219c4c8c8b
-    sha256: 43eaee70cd406468d96d1643b75d16e0da3955a9c1d37056767134b91b61d515
-  category: dev
-  optional: true
-- name: zstandard
-  version: 0.19.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    cffi: '>=1.8'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.19.0-py311ha68e1ae_0.tar.bz2
-  hash:
-    md5: 94114ffe0cad9e1e704e2c0015c8aa87
-    sha256: c687a7d884e98c69f4f1fee8cb9949157bba7c76a54176edeb3262c156e08e71
-  category: dev
-  optional: true
 - name: zstd
   version: 1.5.6
   manager: conda
@@ -16183,19 +8198,49 @@ package:
     sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
   category: main
   optional: false
+- name: annotated-types
+  version: 0.7.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+  hash:
+    sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.7.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+  hash:
+    sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
+  category: main
+  optional: false
+- name: annotated-types
+  version: 0.7.0
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+  hash:
+    sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
+  category: main
+  optional: false
 - name: poprox-concepts
   version: 0.0.1
   manager: pip
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16203,13 +8248,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16217,11 +8262,83 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+  optional: false
+- name: pydantic
+  version: 2.7.4
+  manager: pip
+  platform: linux-64
+  dependencies:
+    annotated-types: '>=0.4.0'
+    pydantic-core: 2.18.4
+    typing-extensions: '>=4.6.1'
+  url: https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl
+  hash:
+    sha256: ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.7.4
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    annotated-types: '>=0.4.0'
+    pydantic-core: 2.18.4
+    typing-extensions: '>=4.6.1'
+  url: https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl
+  hash:
+    sha256: ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
+  category: main
+  optional: false
+- name: pydantic
+  version: 2.7.4
+  manager: pip
+  platform: win-64
+  dependencies:
+    annotated-types: '>=0.4.0'
+    pydantic-core: 2.18.4
+    typing-extensions: '>=4.6.1'
+  url: https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl
+  hash:
+    sha256: ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
+  category: main
+  optional: false
+- name: pydantic-core
+  version: 2.18.4
+  manager: pip
+  platform: linux-64
+  dependencies:
+    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
+  url: https://files.pythonhosted.org/packages/d6/4b/51141c5ea1874e7204efac93899eefcb690ff6772a92c9a6521b32e5b71f/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  hash:
+    sha256: 0fbbdc827fe5e42e4d196c746b890b3d72876bdbf160b0eafe9f0334525119c8
+  category: main
+  optional: false
+- name: pydantic-core
+  version: 2.18.4
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
+  url: https://files.pythonhosted.org/packages/6c/a2/229dbee765ce711cd42c056da497ca26f7267384362e6767ab3bcdafca79/pydantic_core-2.18.4-cp311-cp311-macosx_11_0_arm64.whl
+  hash:
+    sha256: b2ebef0e0b4454320274f5e83a41844c63438fdc874ea40a8b5b4ecb7693f1c4
+  category: main
+  optional: false
+- name: pydantic-core
+  version: 2.18.4
+  manager: pip
+  platform: win-64
+  dependencies:
+    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
+  url: https://files.pythonhosted.org/packages/00/29/62236e5e19b92c1b908089589300e5834a8fcb5f870ae4f2a08b17782142/pydantic_core-2.18.4-cp311-none-win_amd64.whl
+  hash:
+    sha256: 8a7164fe2005d03c64fd3b85649891cd4953a8de53107940bf272500ba8a788b
+  category: main
   optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -6,6 +6,8 @@
 #
 # Install this environment as "YOURENV" with:
 #     conda-lock install -n YOURENV conda-lock.yml
+# This lock contains optional development dependencies. Include them in the installed environment with:
+#     conda-lock install --dev-dependencies -n YOURENV conda-lock.yml
 # To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock  --lockfile conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
@@ -13,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    win-64: 59e314b4ba0bca5d657dd648996370be325c9d922104fafd8f61025611d90cec
-    linux-64: ab396931007a24d1a35129393f752681009e22db348a4d4fb86c190819aa70f3
-    osx-arm64: bbe4bf4d9b7d6d8d0857e0fea55550ea3a030419e58ff130c77dcb72e86d8baa
+    win-64: fba7e4600a1e315a247e3a2d7e381652256d3deba38ae7be417ec16753dce948
+    linux-64: 8e60b19f7a61d97a94368c2a3bb8d8f22597a9ec25928b41dc1f32b8f86714d6
+    osx-arm64: eb91ef97e74ca957b1f4b248cfb99129366ca80a6642c5f74e391252c82ce920
   channels:
   - url: pytorch
     used_env_vars: []
@@ -47,13 +49,61 @@ package:
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-    llvm-openmp: '>=9.0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
-    md5: 562b26ba2e19059551a811e72ab7f793
-    sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
+    md5: 73aaf86a425cc6e73fcf236a5a46396d
+    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   category: main
   optional: false
+- name: aiobotocore
+  version: 2.13.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.107'
+    python: '>=3.8'
+    wrapt: '>=1.10.10,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c1ba7be2b8a71c6a9de23402a5810ea2
+    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
+  category: dev
+  optional: true
+- name: aiobotocore
+  version: 2.13.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.107'
+    python: '>=3.8'
+    wrapt: '>=1.10.10,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c1ba7be2b8a71c6a9de23402a5810ea2
+    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
+  category: dev
+  optional: true
+- name: aiobotocore
+  version: 2.13.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.107'
+    python: '>=3.8'
+    wrapt: '>=1.10.10,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c1ba7be2b8a71c6a9de23402a5810ea2
+    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
+  category: dev
+  optional: true
 - name: aiohttp
   version: 3.9.5
   manager: conda
@@ -112,6 +162,84 @@ package:
     sha256: 03e161ef1e710089630276964921bb6de9c9852d0b04a59e3fe528c608327767
   category: main
   optional: false
+- name: aiohttp-retry
+  version: 2.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiohttp: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohttp-retry-2.8.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 63075586964c3e0d53e1a8d804d89090
+    sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
+  category: dev
+  optional: true
+- name: aiohttp-retry
+  version: 2.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aiohttp: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohttp-retry-2.8.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 63075586964c3e0d53e1a8d804d89090
+    sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
+  category: dev
+  optional: true
+- name: aiohttp-retry
+  version: 2.8.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    aiohttp: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohttp-retry-2.8.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 63075586964c3e0d53e1a8d804d89090
+    sha256: 1a0098aa927a06daae6457eaaeee29092c1f6c174b2e1d3a523816d22b447bfe
+  category: dev
+  optional: true
+- name: aioitertools
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 59c40397276a286241c65faec5e1be3c
+    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
+  category: dev
+  optional: true
+- name: aioitertools
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 59c40397276a286241c65faec5e1be3c
+    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
+  category: dev
+  optional: true
+- name: aioitertools
+  version: 0.11.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+    typing_extensions: '>=4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.11.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 59c40397276a286241c65faec5e1be3c
+    sha256: be2dbd6710438fa48b83bf06841091227276ae545d145dfe5cb5149c6484e951
+  category: dev
+  optional: true
 - name: aiosignal
   version: 1.3.1
   manager: conda
@@ -304,6 +432,203 @@ package:
     sha256: ae29de72b8e0b8fefb8d2778b29f7cee0a01ba99691c5e353f0843274365008b
   category: main
   optional: false
+- name: anyio
+  version: 4.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  category: dev
+  optional: true
+- name: anyio
+  version: 4.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  category: dev
+  optional: true
+- name: anyio
+  version: 4.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
+    sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  category: dev
+  optional: true
+- name: appdirs
+  version: 1.4.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 5f095bc6454094e96f146491fd03633b
+    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  category: dev
+  optional: true
+- name: appdirs
+  version: 1.4.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 5f095bc6454094e96f146491fd03633b
+    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  category: dev
+  optional: true
+- name: appdirs
+  version: 1.4.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 5f095bc6454094e96f146491fd03633b
+    sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+  category: dev
+  optional: true
+- name: asyncssh
+  version: 2.14.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: ''
+    pyopenssl: '>=17.0.0'
+    python: '>=3.4'
+    python-gssapi: '>=1.2.0'
+    typing_extensions: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a88675dc80fa5b2d082fca1cc2a804c5
+    sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
+  category: dev
+  optional: true
+- name: asyncssh
+  version: 2.14.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cryptography: ''
+    pyopenssl: '>=17.0.0'
+    python: '>=3.4'
+    python-gssapi: '>=1.2.0'
+    typing_extensions: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a88675dc80fa5b2d082fca1cc2a804c5
+    sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
+  category: dev
+  optional: true
+- name: asyncssh
+  version: 2.14.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    cryptography: ''
+    pyopenssl: '>=17.0.0'
+    python: '>=3.4'
+    python-gssapi: '>=1.2.0'
+    typing_extensions: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a88675dc80fa5b2d082fca1cc2a804c5
+    sha256: 053dcd3c72747dd0d5f55d424f72b67ce694f56d964b672ea0a11903501a5147
+  category: dev
+  optional: true
+- name: atk-1.0
+  version: 2.38.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libglib: '>=2.80.0,<3.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+  hash:
+    md5: f730d54ba9cd543666d7220c9f7ed563
+    sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
+  category: dev
+  optional: true
+- name: atk-1.0
+  version: 2.38.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=16'
+    libglib: '>=2.80.0,<3.0a0'
+    libintl: '>=0.22.5,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
+  hash:
+    md5: 57301986d02d30d6805fdce6c99074ee
+    sha256: b0747f9b1bc03d1932b4d8c586f39a35ac97e7e72fe6e63f2b2a2472d466f3c1
+  category: dev
+  optional: true
+- name: atpublic
+  version: 3.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/atpublic-3.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 39904aaf8de88f03fe9c27286dc35681
+    sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
+  category: dev
+  optional: true
+- name: atpublic
+  version: 3.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/atpublic-3.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 39904aaf8de88f03fe9c27286dc35681
+    sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
+  category: dev
+  optional: true
+- name: atpublic
+  version: 3.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/atpublic-3.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 39904aaf8de88f03fe9c27286dc35681
+    sha256: 6720f02d2e2293864f5f6cc8faf8f8a308706caefd7e6324d144ea492450d16b
+  category: dev
+  optional: true
 - name: attrs
   version: 23.2.0
   manager: conda
@@ -970,6 +1295,163 @@ package:
     sha256: b8aa3a1cce16c0cc11c4daaab8ee8c9e49f39380352f32d15bbc0253f99eba38
   category: main
   optional: false
+- name: backports
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  hash:
+    md5: 54ca2e08b3220c148a1d8329c2678e02
+    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  category: dev
+  optional: true
+- name: backports
+  version: '1.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  hash:
+    md5: 54ca2e08b3220c148a1d8329c2678e02
+    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  category: dev
+  optional: true
+- name: backports
+  version: '1.0'
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
+  hash:
+    md5: 54ca2e08b3220c148a1d8329c2678e02
+    sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+  category: dev
+  optional: true
+- name: backports.tarfile
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    backports: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: c747b1d79f136013c3b7ebcba876afa6
+    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
+  category: dev
+  optional: true
+- name: backports.tarfile
+  version: 1.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    backports: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: c747b1d79f136013c3b7ebcba876afa6
+    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
+  category: dev
+  optional: true
+- name: backports.tarfile
+  version: 1.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    backports: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.0.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: c747b1d79f136013c3b7ebcba876afa6
+    sha256: 7ba30f32daad2e7ca251508525185ba170eedc14123572611c2acf261c7956b3
+  category: dev
+  optional: true
+- name: backports.zoneinfo
+  version: 0.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zoneinfo-0.2.1-py311h38be061_8.conda
+  hash:
+    md5: 5384590f14dfe6ccd02811236afc9f8e
+    sha256: 1708c5e6729567f30ccde7761492cb43ee72fa2f7d5065b9102785278718505b
+  category: dev
+  optional: true
+- name: backports.zoneinfo
+  version: 0.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zoneinfo-0.2.1-py311h267d04e_8.conda
+  hash:
+    md5: acbef984789bc78fc49cca2e736b8006
+    sha256: a1cdbc446ff4db99e9e39b73b1611932dc9c5111ecd90dd131fa6fdf62de904d
+  category: dev
+  optional: true
+- name: backports.zoneinfo
+  version: 0.2.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/win-64/backports.zoneinfo-0.2.1-py311h1ea47a8_8.conda
+  hash:
+    md5: 6784cf61285ebc6d3772d9a51d9982eb
+    sha256: 30d71fe787342045a7a1896835627c0ed0a1a8b796a497d63b0d36b31a84b7e7
+  category: dev
+  optional: true
+- name: billiard
+  version: 4.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/billiard-4.2.0-py311h459d7ec_0.conda
+  hash:
+    md5: d408435aabfb23b364dcca868386cf0b
+    sha256: fc947afbd0eb61ac2e98195ae26a1b43b89ffb91b71c43cb0db7b52f131bc60c
+  category: dev
+  optional: true
+- name: billiard
+  version: 4.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/billiard-4.2.0-py311h05b510d_0.conda
+  hash:
+    md5: d2100bf5626206fdfb56b2a92423bc53
+    sha256: e70cbec50b46109f00fdd1b45cef33c4edb908ede67534fe6aaa0033d4f9217b
+  category: dev
+  optional: true
+- name: billiard
+  version: 4.2.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/billiard-4.2.0-py311ha68e1ae_0.conda
+  hash:
+    md5: c2023bec2510422052ce8cfc484f0f62
+    sha256: 8c3432023fe40cfa8c69d00855996403902dea0562cff298f28e2216c6be86f0
+  category: dev
+  optional: true
 - name: binpickle
   version: 0.3.4
   manager: conda
@@ -1013,18 +1495,6 @@ package:
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
     sha256: 409dd557027a01d3c1be325fa34b0104fb1a0842e9eea90bf03decc77d08b361
-  category: main
-  optional: false
-- name: blas
-  version: '1.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    mkl: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-1.0-mkl.tar.bz2
-  hash:
-    md5: 349aef876b1d8c9dccae01de20d5b385
-    sha256: a9a9125029a66905fc9e932dfd4f595be3a59a30db37fd7bf4a675a5c6151d62
   category: main
   optional: false
 - name: blas
@@ -1176,6 +1646,96 @@ package:
     sha256: 0289e61d7a30a693cf79d36484abd13f72ad785bd23cadc227c29dca89d95046
   category: main
   optional: false
+- name: boto3
+  version: 1.34.106
+  manager: conda
+  platform: linux-64
+  dependencies:
+    botocore: '>=1.34.106,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
+  hash:
+    md5: 190a8f3c28a2c6047dcca712eca663b1
+    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
+  category: dev
+  optional: true
+- name: boto3
+  version: 1.34.106
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    botocore: '>=1.34.106,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
+  hash:
+    md5: 190a8f3c28a2c6047dcca712eca663b1
+    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
+  category: dev
+  optional: true
+- name: boto3
+  version: 1.34.106
+  manager: conda
+  platform: win-64
+  dependencies:
+    botocore: '>=1.34.106,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
+  hash:
+    md5: 190a8f3c28a2c6047dcca712eca663b1
+    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
+  category: dev
+  optional: true
+- name: botocore
+  version: 1.34.106
+  manager: conda
+  platform: linux-64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
+  hash:
+    md5: ff7f42537b4f054b10b4d02732e10ab8
+    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
+  category: dev
+  optional: true
+- name: botocore
+  version: 1.34.106
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
+  hash:
+    md5: ff7f42537b4f054b10b4d02732e10ab8
+    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
+  category: dev
+  optional: true
+- name: botocore
+  version: 1.34.106
+  manager: conda
+  platform: win-64
+  dependencies:
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
+    urllib3: '>=1.25.4,!=2.2.0,<3'
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
+  hash:
+    md5: ff7f42537b4f054b10b4d02732e10ab8
+    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
+  category: dev
+  optional: true
 - name: brotli-python
   version: 1.1.0
   manager: conda
@@ -1347,9 +1907,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-    msgpack-python: '>=0.5.2,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: a54e449940b3e4bb2129b8daae0c1f65
@@ -1361,9 +1921,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-    msgpack-python: '>=0.5.2,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: a54e449940b3e4bb2129b8daae0c1f65
@@ -1389,9 +1949,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
     cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: 42a12b0b21d64b36a9ab9a24a04eb910
@@ -1403,9 +1963,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
     cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: 42a12b0b21d64b36a9ab9a24a04eb910
@@ -1549,18 +2109,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
+    billiard: '>=4.2.0,<5.0'
     click: '>=8.1.2,<9.0'
     click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
+    click-plugins: '>=1.1.1'
+    click-repl: '>=0.2.0'
+    importlib-metadata: '>=3.6'
     kombu: '>=5.3.4,<6.0'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    python-tzdata: '>=2022.7'
+    vine: '>=5.1.0,<6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
@@ -1572,18 +2132,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
+    billiard: '>=4.2.0,<5.0'
     click: '>=8.1.2,<9.0'
     click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
+    click-plugins: '>=1.1.1'
+    click-repl: '>=0.2.0'
+    importlib-metadata: '>=3.6'
     kombu: '>=5.3.4,<6.0'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    python-tzdata: '>=2022.7'
+    vine: '>=5.1.0,<6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
@@ -1674,6 +2234,42 @@ package:
     sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
   category: main
   optional: false
+- name: cfgv
+  version: 3.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
+    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
+  category: dev
+  optional: true
+- name: cfgv
+  version: 3.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
+    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
+  category: dev
+  optional: true
+- name: cfgv
+  version: 3.3.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ebb5f5f7dc4f1a3780ef7ea7738db08c
+    sha256: fbc03537a27ef756162c49b1d0608bf7ab12fa5e38ceb8563d6f4859e835ac5c
+  category: dev
+  optional: true
 - name: charset-normalizer
   version: 3.3.2
   manager: conda
@@ -1750,6 +2346,210 @@ package:
     sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
   category: main
   optional: false
+- name: click-default-group
+  version: 1.2.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2b6931f9b3548ed78478332095c3e9
+    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+  category: dev
+  optional: true
+- name: click-default-group
+  version: 1.2.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2b6931f9b3548ed78478332095c3e9
+    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+  category: dev
+  optional: true
+- name: click-default-group
+  version: 1.2.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-default-group-1.2.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c2b6931f9b3548ed78478332095c3e9
+    sha256: b36e35d735ddd29d7c592eb3de4b3979e13a9f76f1b4bc939f2cb4402758d6d0
+  category: dev
+  optional: true
+- name: click-didyoumean
+  version: 0.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: '>=7'
+    python: '>=3.6.2,<4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: ab1b094a8471e571b95c208bde719a4a
+    sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
+  category: dev
+  optional: true
+- name: click-didyoumean
+  version: 0.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: '>=7'
+    python: '>=3.6.2,<4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: ab1b094a8471e571b95c208bde719a4a
+    sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
+  category: dev
+  optional: true
+- name: click-didyoumean
+  version: 0.3.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: '>=7'
+    python: '>=3.6.2,<4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/click-didyoumean-0.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: ab1b094a8471e571b95c208bde719a4a
+    sha256: 37b40b25c766499c79e5f64fb7c6453c882f9a5dabd262e431c9e68ecd971843
+  category: dev
+  optional: true
+- name: click-plugins
+  version: 1.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: '>=3.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  hash:
+    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  category: dev
+  optional: true
+- name: click-plugins
+  version: 1.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: '>=3.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  hash:
+    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  category: dev
+  optional: true
+- name: click-plugins
+  version: 1.1.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: '>=3.0'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
+  hash:
+    md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
+    sha256: ddef6e559dde6673ee504b0e29dd814d36e22b6b9b1f519fa856ee268905bf92
+  category: dev
+  optional: true
+- name: click-repl
+  version: 0.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: ''
+    prompt_toolkit: ''
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 27eb8f68250666c1a19d1b6ec9d12c4e
+    sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
+  category: dev
+  optional: true
+- name: click-repl
+  version: 0.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: ''
+    prompt_toolkit: ''
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 27eb8f68250666c1a19d1b6ec9d12c4e
+    sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
+  category: dev
+  optional: true
+- name: click-repl
+  version: 0.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: ''
+    prompt_toolkit: ''
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 27eb8f68250666c1a19d1b6ec9d12c4e
+    sha256: 69c16e0b89e1fb4fc444af4798ef1222b3075d074cbcbe70b9af793668200a14
+  category: dev
+  optional: true
+- name: clikit
+  version: 0.6.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+  hash:
+    md5: 02abb7b66b02e8b9f5a9b05454400087
+    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+  category: dev
+  optional: true
+- name: clikit
+  version: 0.6.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+  hash:
+    md5: 02abb7b66b02e8b9f5a9b05454400087
+    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+  category: dev
+  optional: true
+- name: clikit
+  version: 0.6.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
+  hash:
+    md5: 02abb7b66b02e8b9f5a9b05454400087
+    sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
+  category: dev
+  optional: true
 - name: cloudpickle
   version: 3.0.0
   manager: conda
@@ -1822,6 +2622,153 @@ package:
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   category: main
   optional: false
+- name: conda-lock
+  version: 2.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cachecontrol-with-filecache: '>=0.12.9'
+    cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
+    clikit: '>=0.6.2'
+    crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
+    pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
+    tomlkit: '>=0.7.0'
+    toolz: '>=0.12.0,<1.0.0'
+    typing_extensions: ''
+    urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 154d0c643be6a9ce6fbe655d007d8e4e
+    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
+  category: dev
+  optional: true
+- name: conda-lock
+  version: 2.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cachecontrol-with-filecache: '>=0.12.9'
+    cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
+    clikit: '>=0.6.2'
+    crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
+    pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
+    tomlkit: '>=0.7.0'
+    toolz: '>=0.12.0,<1.0.0'
+    typing_extensions: ''
+    urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 154d0c643be6a9ce6fbe655d007d8e4e
+    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
+  category: dev
+  optional: true
+- name: conda-lock
+  version: 2.5.7
+  manager: conda
+  platform: win-64
+  dependencies:
+    cachecontrol-with-filecache: '>=0.12.9'
+    cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
+    clikit: '>=0.6.2'
+    crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
+    pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
+    tomlkit: '>=0.7.0'
+    toolz: '>=0.12.0,<1.0.0'
+    typing_extensions: ''
+    urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
+  hash:
+    md5: 154d0c643be6a9ce6fbe655d007d8e4e
+    sha256: bdce4c0d6491d12db676633dcf1cae031a5105073996a4a0ae8dba9ecafda2b2
+  category: dev
+  optional: true
+- name: configobj
+  version: 5.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 04c71f400324538d4396407ea2ffb34f
+    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
+  category: dev
+  optional: true
+- name: configobj
+  version: 5.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 04c71f400324538d4396407ea2ffb34f
+    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
+  category: dev
+  optional: true
+- name: configobj
+  version: 5.0.8
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 04c71f400324538d4396407ea2ffb34f
+    sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
+  category: dev
+  optional: true
 - name: contourpy
   version: 1.2.1
   manager: conda
@@ -1870,6 +2817,139 @@ package:
     sha256: f9c392ae4c746ac32c55b20d8c487cbc06a91d5dd650261089d90fb55cfcb8c2
   category: main
   optional: false
+- name: coverage
+  version: 7.5.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    tomli: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.5.3-py311h331c9d8_0.conda
+  hash:
+    md5: 543dd05fd661e4e9c9deb3b37093d6a2
+    sha256: 88e0063cf333147890aafacc2f87360867991241af827a111d97433b7055691e
+  category: dev
+  optional: true
+- name: coverage
+  version: 7.5.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    tomli: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.5.3-py311hd3f4193_0.conda
+  hash:
+    md5: 402a8b40b9c9423f40a32be066b467be
+    sha256: dcdfa3b24affe7399654f2e8429c15e05a54b8cce32583263a0731c37b62dcbc
+  category: dev
+  optional: true
+- name: coverage
+  version: 7.5.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    tomli: ''
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.5.3-py311he736701_0.conda
+  hash:
+    md5: eead686af955162027fb5825e83a3131
+    sha256: 16b1692a5ea5254842267e3f66489ecc009ff0d63c0d02148d756e32495c0947
+  category: dev
+  optional: true
+- name: crashtest
+  version: 0.4.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 709a2295dd907bb34afb57d54320642f
+    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+  category: dev
+  optional: true
+- name: crashtest
+  version: 0.4.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 709a2295dd907bb34afb57d54320642f
+    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+  category: dev
+  optional: true
+- name: crashtest
+  version: 0.4.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6,<4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/crashtest-0.4.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 709a2295dd907bb34afb57d54320642f
+    sha256: 2f05954a3faf0700c14c1deddc085385160ee32abe111699c78d9cb277e915cc
+  category: dev
+  optional: true
+- name: cryptography
+  version: 42.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cffi: '>=1.12'
+    libgcc-ng: '>=12'
+    openssl: '>=3.3.1,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.8-py311h4a61cc7_0.conda
+  hash:
+    md5: 962bcc96f59a31b62c43ac2b306812af
+    sha256: 887557c1cc5083f68e531ffe98bb95e0ea2e99fb36f9d12f7f66c4cad2de7502
+  category: dev
+  optional: true
+- name: cryptography
+  version: 42.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cffi: '>=1.12'
+    openssl: '>=3.3.1,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.8-py311hcaeb4ce_0.conda
+  hash:
+    md5: 167cc1ddd4e8afab3959811dabaa79d8
+    sha256: 3dd780ec2a637e8fa1095111cbf0b4ff13e9d01c2d81aa1b5b8f8ad2186873c5
+  category: dev
+  optional: true
+- name: cryptography
+  version: 42.0.8
+  manager: conda
+  platform: win-64
+  dependencies:
+    cffi: '>=1.12'
+    openssl: '>=3.3.1,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/cryptography-42.0.8-py311hfd75b31_0.conda
+  hash:
+    md5: df7b0031f07fe3a35892fbad84b62ea0
+    sha256: c422f83400092c9764d28f8551787bb1e8c0a3077ff665da324e88e168d1eb18
+  category: dev
+  optional: true
 - name: csr
   version: 0.5.2
   manager: conda
@@ -2192,8 +3272,6 @@ package:
     pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    pyarrow: '>=15.0.0'
-    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -2221,14 +3299,98 @@ package:
     pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    pyarrow: '>=15.0.0'
-    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
     sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
   category: main
   optional: false
+- name: dbus
+  version: 1.13.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    expat: '>=2.4.2,<3.0a0'
+    libgcc-ng: '>=9.4.0'
+    libglib: '>=2.70.2,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+  hash:
+    md5: ecfff944ba3960ecb334b9a2663d708d
+    sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
+  category: dev
+  optional: true
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 43afe5ab04e35e17ba28649471dd7364
+    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  category: dev
+  optional: true
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 43afe5ab04e35e17ba28649471dd7364
+    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  category: dev
+  optional: true
+- name: decorator
+  version: 5.1.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 43afe5ab04e35e17ba28649471dd7364
+    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  category: dev
+  optional: true
+- name: dictdiffer
+  version: 0.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/dictdiffer-0.9.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3cb49199274e7f4d457d8fa2b84dea52
+    sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
+  category: dev
+  optional: true
+- name: dictdiffer
+  version: 0.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/dictdiffer-0.9.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3cb49199274e7f4d457d8fa2b84dea52
+    sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
+  category: dev
+  optional: true
+- name: dictdiffer
+  version: 0.9.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/dictdiffer-0.9.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 3cb49199274e7f4d457d8fa2b84dea52
+    sha256: e60061903052844b7a7d9151bcf8d577275a2cdb0c924f589195d98c36ef0164
+  category: dev
+  optional: true
 - name: dill
   version: 0.3.8
   manager: conda
@@ -2265,6 +3427,78 @@ package:
     sha256: 482b5b566ca559119b504c53df12b08f3962a5ef8e48061d62fd58a47f8f2ec4
   category: main
   optional: false
+- name: diskcache
+  version: 5.6.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c33109f652b5d8c995ab243436c9370
+    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
+  category: dev
+  optional: true
+- name: diskcache
+  version: 5.6.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c33109f652b5d8c995ab243436c9370
+    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
+  category: dev
+  optional: true
+- name: diskcache
+  version: 5.6.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4c33109f652b5d8c995ab243436c9370
+    sha256: 2547a3aa97f0862e55d9d4bbef457b087d35f4bff05766c8169c82719bc61e17
+  category: dev
+  optional: true
+- name: distlib
+  version: 0.3.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: 2.7|>=3.6
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: db16c66b759a64dc5183d69cc3745a52
+    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+  category: dev
+  optional: true
+- name: distlib
+  version: 0.3.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: 2.7|>=3.6
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: db16c66b759a64dc5183d69cc3745a52
+    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+  category: dev
+  optional: true
+- name: distlib
+  version: 0.3.8
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: 2.7|>=3.6
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: db16c66b759a64dc5183d69cc3745a52
+    sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+  category: dev
+  optional: true
 - name: distributed
   version: 2024.6.0
   manager: conda
@@ -2563,49 +3797,49 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    fsspec: ''
-    dvc-objects: ''
-    omegaconf: ''
-    celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    requests: '>=2.22'
-    configobj: '>=5.0.6'
-    colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
-    packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
-    pydot: '>=1.2.4'
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
     attrs: '>=22.2.0'
-    dvc-task: '>=0.3.0,<1'
-    flufl.lock: '>=5,<8'
-    gto: '>=1.6.0,<2'
+    celery: ''
+    colorama: '>=0.3.9'
+    configobj: '>=5.0.6'
+    distro: '>=1.3'
+    dpath: <3,>=2.1.0
+    dulwich: ''
+    dvc-data: '>=3.15,<3.16'
+    dvc-http: '>=2.29.0'
+    dvc-objects: ''
     dvc-render: '>=1.0.1,<2'
     dvc-studio-client: '>=0.20,<1'
-    dvc-data: '>=3.15,<3.16'
+    dvc-task: '>=0.3.0,<1'
+    flatten-dict: <1,>=0.4.1
+    flufl.lock: '>=5,<8'
+    fsspec: ''
+    funcy: '>=1.14'
+    grandalf: <1,>=0.7
+    gto: '>=1.6.0,<2'
+    hydra-core: '>=1.1'
+    iterative-telemetry: '>=0.0.7'
+    kombu: ''
+    networkx: '>=2.5'
+    omegaconf: ''
+    packaging: '>=19'
+    pathspec: '>=0.10.3'
+    platformdirs: <4,>=3.1.1
+    psutil: '>=5.8'
+    pydot: '>=1.2.4'
+    pygtrie: '>=2.3.2'
+    pyparsing: '>=2.4.7'
+    python: '>=3.9'
+    requests: '>=2.22'
+    rich: '>=12'
+    ruamel.yaml: '>=0.17.11'
     scmrepo: '>=3.3.4,<4'
+    shortuuid: '>=0.5'
+    shtab: <2,>=1.3.4
+    tabulate: '>=0.8.7'
+    tomlkit: '>=0.11.1'
+    tqdm: <5,>=4.63.1
+    voluptuous: '>=0.11.7'
+    zc.lockfile: '>=1.2.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
   hash:
     md5: b8d2488c8bbe93bcd4f6faa160656703
@@ -2617,49 +3851,49 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    fsspec: ''
-    dvc-objects: ''
-    omegaconf: ''
-    celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    requests: '>=2.22'
-    configobj: '>=5.0.6'
-    colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
-    packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
-    pydot: '>=1.2.4'
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
     attrs: '>=22.2.0'
-    dvc-task: '>=0.3.0,<1'
-    flufl.lock: '>=5,<8'
-    gto: '>=1.6.0,<2'
+    celery: ''
+    colorama: '>=0.3.9'
+    configobj: '>=5.0.6'
+    distro: '>=1.3'
+    dpath: <3,>=2.1.0
+    dulwich: ''
+    dvc-data: '>=3.15,<3.16'
+    dvc-http: '>=2.29.0'
+    dvc-objects: ''
     dvc-render: '>=1.0.1,<2'
     dvc-studio-client: '>=0.20,<1'
-    dvc-data: '>=3.15,<3.16'
+    dvc-task: '>=0.3.0,<1'
+    flatten-dict: <1,>=0.4.1
+    flufl.lock: '>=5,<8'
+    fsspec: ''
+    funcy: '>=1.14'
+    grandalf: <1,>=0.7
+    gto: '>=1.6.0,<2'
+    hydra-core: '>=1.1'
+    iterative-telemetry: '>=0.0.7'
+    kombu: ''
+    networkx: '>=2.5'
+    omegaconf: ''
+    packaging: '>=19'
+    pathspec: '>=0.10.3'
+    platformdirs: <4,>=3.1.1
+    psutil: '>=5.8'
+    pydot: '>=1.2.4'
+    pygtrie: '>=2.3.2'
+    pyparsing: '>=2.4.7'
+    python: '>=3.9'
+    requests: '>=2.22'
+    rich: '>=12'
+    ruamel.yaml: '>=0.17.11'
     scmrepo: '>=3.3.4,<4'
+    shortuuid: '>=0.5'
+    shtab: <2,>=1.3.4
+    tabulate: '>=0.8.7'
+    tomlkit: '>=0.11.1'
+    tqdm: <5,>=4.63.1
+    voluptuous: '>=0.11.7'
+    zc.lockfile: '>=1.2.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
   hash:
     md5: b8d2488c8bbe93bcd4f6faa160656703
@@ -2692,16 +3926,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    diskcache: '>=5.2.1'
     attrs: '>=21.3.0'
     dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
-    sqltrie: '>=0.11.0,<1'
+    diskcache: '>=5.2.1'
     dvc-objects: '>=4.0.1,<6'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    pygtrie: '>=2.3.2'
+    python: '>=3.9'
+    sqltrie: '>=0.11.0,<1'
+    tqdm: '>=4.63.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
@@ -2713,16 +3947,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    diskcache: '>=5.2.1'
     attrs: '>=21.3.0'
     dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
-    sqltrie: '>=0.11.0,<1'
+    diskcache: '>=5.2.1'
     dvc-objects: '>=4.0.1,<6'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    pygtrie: '>=2.3.2'
+    python: '>=3.9'
+    sqltrie: '>=0.11.0,<1'
+    tqdm: '>=4.63.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
@@ -2748,9 +3982,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    aiohttp-retry: '>=2.5.0'
     fsspec: ''
     python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
@@ -2762,9 +3996,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    aiohttp-retry: '>=2.5.0'
     fsspec: ''
     python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
@@ -2790,9 +4024,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
     fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
@@ -2804,9 +4038,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
     fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
@@ -2833,10 +4067,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    flatten-dict: '>=0.4.1'
+    funcy: '>=1.17'
     python: '>=3.7'
     tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
@@ -2848,10 +4082,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    flatten-dict: '>=0.4.1'
+    funcy: '>=1.17'
     python: '>=3.7'
     tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
@@ -2878,9 +4112,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    boto3: '>=1.9.201'
     dvc: ''
     python: '>=3.8'
-    boto3: '>=1.9.201'
     s3fs: '>=2021.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -2893,9 +4127,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    boto3: '>=1.9.201'
     dvc: ''
     python: '>=3.8'
-    boto3: '>=1.9.201'
     s3fs: '>=2021.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -2923,10 +4157,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
-    voluptuous: ''
     dulwich: ''
     python: '>=3.8'
+    requests: ''
+    voluptuous: ''
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: ebedafb4704c48d7ad274acb1d0b2475
@@ -2938,10 +4172,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
-    voluptuous: ''
     dulwich: ''
     python: '>=3.8'
+    requests: ''
+    voluptuous: ''
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: ebedafb4704c48d7ad274acb1d0b2475
@@ -2970,12 +4204,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pywin32-on-windows: ''
+    celery: '>=5.3.0,<6'
+    funcy: '>=1.17'
     kombu: ''
     python: '>=3.7'
+    pywin32-on-windows: ''
     shortuuid: '>=1.0.8'
-    funcy: '>=1.17'
-    celery: '>=5.3.0,<6'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
@@ -2987,12 +4221,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pywin32-on-windows: ''
+    celery: '>=5.3.0,<6'
+    funcy: '>=1.17'
     kombu: ''
     python: '>=3.7'
+    pywin32-on-windows: ''
     shortuuid: '>=1.0.8'
-    funcy: '>=1.17'
-    celery: '>=5.3.0,<6'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
@@ -3057,12 +4291,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     appdirs: ''
+    click: '>=5.1'
     filelock: ''
+    packaging: ''
     python: '>=3.7'
     requests: '>=2'
-    click: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
@@ -3074,12 +4308,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     appdirs: ''
+    click: '>=5.1'
     filelock: ''
+    packaging: ''
     python: '>=3.7'
     requests: '>=2'
-    click: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
@@ -3231,6 +4465,354 @@ package:
     sha256: 4b32cbd6082db21d463250cbfaaaaf37bfaa84950deeb1298753cae8d45771e7
   category: main
   optional: false
+- name: flatten-dict
+  version: 0.4.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
+    six: '>=1.12,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: ccfb30b92adfeb283d4dcae3d0b6441b
+    sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
+  category: dev
+  optional: true
+- name: flatten-dict
+  version: 0.4.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
+    six: '>=1.12,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: ccfb30b92adfeb283d4dcae3d0b6441b
+    sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
+  category: dev
+  optional: true
+- name: flatten-dict
+  version: 0.4.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
+    six: '>=1.12,<2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: ccfb30b92adfeb283d4dcae3d0b6441b
+    sha256: f54ee1fc29bdc4ca53fbca66114f79e6aea00b3225bab372366c036e8584154d
+  category: dev
+  optional: true
+- name: flufl.lock
+  version: '7.1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    atpublic: ''
+    psutil: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9164819e1a375013c4fbcbaa9538f96c
+    sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
+  category: dev
+  optional: true
+- name: flufl.lock
+  version: '7.1'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    atpublic: ''
+    psutil: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9164819e1a375013c4fbcbaa9538f96c
+    sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
+  category: dev
+  optional: true
+- name: flufl.lock
+  version: '7.1'
+  manager: conda
+  platform: win-64
+  dependencies:
+    atpublic: ''
+    psutil: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9164819e1a375013c4fbcbaa9538f96c
+    sha256: 7fa791a18b77e134955a1ec0356b780d71abf47449c367a0fe408fe7e827b5a3
+  category: dev
+  optional: true
+- name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  hash:
+    md5: 0c96522c6bdaed4b1566d11387caaf45
+    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  category: dev
+  optional: true
+- name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  hash:
+    md5: 0c96522c6bdaed4b1566d11387caaf45
+    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  category: dev
+  optional: true
+- name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  hash:
+    md5: 0c96522c6bdaed4b1566d11387caaf45
+    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  category: dev
+  optional: true
+- name: font-ttf-inconsolata
+  version: '3.000'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  hash:
+    md5: 34893075a5c9e55cdafac56607368fc6
+    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  category: dev
+  optional: true
+- name: font-ttf-inconsolata
+  version: '3.000'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  hash:
+    md5: 34893075a5c9e55cdafac56607368fc6
+    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  category: dev
+  optional: true
+- name: font-ttf-inconsolata
+  version: '3.000'
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  hash:
+    md5: 34893075a5c9e55cdafac56607368fc6
+    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  category: dev
+  optional: true
+- name: font-ttf-source-code-pro
+  version: '2.038'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  hash:
+    md5: 4d59c254e01d9cde7957100457e2d5fb
+    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  category: dev
+  optional: true
+- name: font-ttf-source-code-pro
+  version: '2.038'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  hash:
+    md5: 4d59c254e01d9cde7957100457e2d5fb
+    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  category: dev
+  optional: true
+- name: font-ttf-source-code-pro
+  version: '2.038'
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  hash:
+    md5: 4d59c254e01d9cde7957100457e2d5fb
+    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  category: dev
+  optional: true
+- name: font-ttf-ubuntu
+  version: '0.83'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  hash:
+    md5: cbbe59391138ea5ad3658c76912e147f
+    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
+  category: dev
+  optional: true
+- name: font-ttf-ubuntu
+  version: '0.83'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  hash:
+    md5: cbbe59391138ea5ad3658c76912e147f
+    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
+  category: dev
+  optional: true
+- name: font-ttf-ubuntu
+  version: '0.83'
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  hash:
+    md5: cbbe59391138ea5ad3658c76912e147f
+    sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
+  category: dev
+  optional: true
+- name: fontconfig
+  version: 2.14.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    expat: '>=2.5.0,<3.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    libgcc-ng: '>=12'
+    libuuid: '>=2.32.1,<3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  hash:
+    md5: 0f69b688f52ff6da70bccb7ff7001d1d
+    sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  category: dev
+  optional: true
+- name: fontconfig
+  version: 2.14.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    expat: '>=2.5.0,<3.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  hash:
+    md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+    sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  category: dev
+  optional: true
+- name: fontconfig
+  version: 2.14.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    expat: '>=2.5.0,<3.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vs2015_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+  hash:
+    md5: 08767992f1a4f1336a257af1241034bd
+    sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
+  category: dev
+  optional: true
+- name: fonts-conda-ecosystem
+  version: '1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    fonts-conda-forge: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  hash:
+    md5: fee5683a3f04bd15cbd8318b096a27ab
+    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  category: dev
+  optional: true
+- name: fonts-conda-ecosystem
+  version: '1'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    fonts-conda-forge: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  hash:
+    md5: fee5683a3f04bd15cbd8318b096a27ab
+    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  category: dev
+  optional: true
+- name: fonts-conda-ecosystem
+  version: '1'
+  manager: conda
+  platform: win-64
+  dependencies:
+    fonts-conda-forge: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  hash:
+    md5: fee5683a3f04bd15cbd8318b096a27ab
+    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  category: dev
+  optional: true
+- name: fonts-conda-forge
+  version: '1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    font-ttf-dejavu-sans-mono: ''
+    font-ttf-inconsolata: ''
+    font-ttf-source-code-pro: ''
+    font-ttf-ubuntu: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  hash:
+    md5: f766549260d6815b0c52253f1fb1bb29
+    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  category: dev
+  optional: true
+- name: fonts-conda-forge
+  version: '1'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    font-ttf-dejavu-sans-mono: ''
+    font-ttf-inconsolata: ''
+    font-ttf-source-code-pro: ''
+    font-ttf-ubuntu: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  hash:
+    md5: f766549260d6815b0c52253f1fb1bb29
+    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  category: dev
+  optional: true
+- name: fonts-conda-forge
+  version: '1'
+  manager: conda
+  platform: win-64
+  dependencies:
+    font-ttf-dejavu-sans-mono: ''
+    font-ttf-inconsolata: ''
+    font-ttf-source-code-pro: ''
+    font-ttf-ubuntu: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  hash:
+    md5: f766549260d6815b0c52253f1fb1bb29
+    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  category: dev
+  optional: true
 - name: freetype
   version: 2.12.1
   manager: conda
@@ -3274,6 +4856,42 @@ package:
     sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
   category: main
   optional: false
+- name: fribidi
+  version: 1.0.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+  hash:
+    md5: ac7bc6a654f8f41b352b38f4051135f8
+    sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
+  category: dev
+  optional: true
+- name: fribidi
+  version: 1.0.10
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+  hash:
+    md5: c64443234ff91d70cb9c7dc926c58834
+    sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
+  category: dev
+  optional: true
+- name: fribidi
+  version: 1.0.10
+  manager: conda
+  platform: win-64
+  dependencies:
+    vc: '>=14.1,<15.0a0'
+    vs2015_runtime: '>=14.16.27012'
+  url: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.10-h8d14728_0.tar.bz2
+  hash:
+    md5: 807e81d915f2bb2e49951648615241f6
+    sha256: e0323e6d7b6047042970812ee810c6b1e1a11a3af4025db26d0965ae5d206104
+  category: dev
+  optional: true
 - name: frozenlist
   version: 1.4.1
   manager: conda
@@ -3353,6 +4971,158 @@ package:
     sha256: 34149798edaf7f67251ee09612cd50b52ee8a69b45e63ddb79732085ae7423cd
   category: main
   optional: false
+- name: funcy
+  version: '2.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/funcy-2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ecf68a50baba6d9151addcb69cecfb92
+    sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
+  category: dev
+  optional: true
+- name: funcy
+  version: '2.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/funcy-2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ecf68a50baba6d9151addcb69cecfb92
+    sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
+  category: dev
+  optional: true
+- name: funcy
+  version: '2.0'
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/funcy-2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ecf68a50baba6d9151addcb69cecfb92
+    sha256: aa21baa066cf5ad440e2300ca95a303db83d747d3ceb67a878fb44d2342e64dc
+  category: dev
+  optional: true
+- name: future
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 650a7807e689642dddd3590eb817beed
+    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
+  category: dev
+  optional: true
+- name: future
+  version: 1.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 650a7807e689642dddd3590eb817beed
+    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
+  category: dev
+  optional: true
+- name: future
+  version: 1.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 650a7807e689642dddd3590eb817beed
+    sha256: 8c918a63595ae01575b738ddf0bff10dc23a5002d4af4c8b445d1179a76a8efd
+  category: dev
+  optional: true
+- name: gdk-pixbuf
+  version: 2.42.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libglib: '>=2.80.2,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.42.12-hb9ae30d_0.conda
+  hash:
+    md5: 201db6c2d9a3c5e46573ac4cb2e92f4f
+    sha256: d5283b95a8d49dcd88d29b360d8b38694aaa905d968d156d72ab71d32b38facb
+  category: dev
+  optional: true
+- name: gdk-pixbuf
+  version: 2.42.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libglib: '>=2.80.2,<3.0a0'
+    libintl: '>=0.22.5,<1.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.12-h7ddc832_0.conda
+  hash:
+    md5: 151309a7e1eb57a3c2ab8088a1d74f3e
+    sha256: 72bcf0a4d3f9aa6d99d7d1d224d19f76ccdb3a4fa85e60f77d17e17985c81bd2
+  category: dev
+  optional: true
+- name: getopt-win32
+  version: '0.1'
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/getopt-win32-0.1-hcfcfb64_1.conda
+  hash:
+    md5: 714d0882dc5e692ca4683d8e520f73c6
+    sha256: f3b6e689724a62f36591f6f0e4657db5507feca78e7ef08690a6b2a384216a5c
+  category: dev
+  optional: true
+- name: gettext
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gettext-tools: 0.22.5
+    libasprintf: 0.22.5
+    libasprintf-devel: 0.22.5
+    libcxx: '>=16'
+    libgettextpo: 0.22.5
+    libgettextpo-devel: 0.22.5
+    libiconv: '>=1.17,<2.0a0'
+    libintl: 0.22.5
+    libintl-devel: 0.22.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 404e2894e9cb2835246cef47317ff763
+    sha256: 7188b466071698759b125aaed9b4d78940e72e6299b0c6dbad6f35c85cf3d27b
+  category: dev
+  optional: true
+- name: gettext-tools
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+    libintl: 0.22.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 31117a80d73f4fac856ab09fd9f3c6b5
+    sha256: f60d1671e30ac60598396c11fcec4426f7ddb281bf9e37af2262016b4d812cce
+  category: dev
+  optional: true
 - name: gflags
   version: 2.2.2
   manager: conda
@@ -3378,6 +5148,110 @@ package:
     sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
   category: main
   optional: false
+- name: giflib
+  version: 5.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  hash:
+    md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+    sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  category: dev
+  optional: true
+- name: giflib
+  version: 5.2.2
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
+  hash:
+    md5: 95fa1486c77505330c20f7202492b913
+    sha256: 843b3f364ff844137e37d5c0a181f11f6d51adcedd216f019d074e5aa5d7e09c
+  category: dev
+  optional: true
+- name: gitdb
+  version: 4.0.11
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    smmap: '>=3.0.1,<6'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  hash:
+    md5: 623b19f616f2ca0c261441067e18ae40
+    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  category: dev
+  optional: true
+- name: gitdb
+  version: 4.0.11
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    smmap: '>=3.0.1,<6'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  hash:
+    md5: 623b19f616f2ca0c261441067e18ae40
+    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  category: dev
+  optional: true
+- name: gitdb
+  version: 4.0.11
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+    smmap: '>=3.0.1,<6'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
+  hash:
+    md5: 623b19f616f2ca0c261441067e18ae40
+    sha256: 52ab2798be31b8f509eeec458712f447ced4f96ecb672c6c9a42778f47e07b1b
+  category: dev
+  optional: true
+- name: gitpython
+  version: 3.1.43
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gitdb: '>=4.0.1,<5'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0b2154c1818111e17381b1df5b4b0176
+    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+  category: dev
+  optional: true
+- name: gitpython
+  version: 3.1.43
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gitdb: '>=4.0.1,<5'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0b2154c1818111e17381b1df5b4b0176
+    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+  category: dev
+  optional: true
+- name: gitpython
+  version: 3.1.43
+  manager: conda
+  platform: win-64
+  dependencies:
+    gitdb: '>=4.0.1,<5'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0b2154c1818111e17381b1df5b4b0176
+    sha256: cbb2802641a009ce9bcc2a047e817fd8816f9c842036a42f4730398d8e4cda2a
+  category: dev
+  optional: true
 - name: glog
   version: 0.7.1
   manager: conda
@@ -3465,6 +5339,763 @@ package:
     sha256: 047dd4dd8255fea1cf3c0629e5cfcb3a1602c18ab46fa0e16b615b669b9f8efe
   category: main
   optional: false
+- name: grandalf
+  version: '0.7'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    future: ''
+    pyparsing: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/grandalf-0.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5d632e0f82bfaad59fe060f4b442fd11
+    sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
+  category: dev
+  optional: true
+- name: grandalf
+  version: '0.7'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    future: ''
+    pyparsing: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/grandalf-0.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5d632e0f82bfaad59fe060f4b442fd11
+    sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
+  category: dev
+  optional: true
+- name: grandalf
+  version: '0.7'
+  manager: conda
+  platform: win-64
+  dependencies:
+    future: ''
+    pyparsing: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/grandalf-0.7-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5d632e0f82bfaad59fe060f4b442fd11
+    sha256: 44a1b8baf1ee806055b583ab04442a1562a1bb7aeddea3db4723ba6870a49622
+  category: dev
+  optional: true
+- name: graphite2
+  version: 1.3.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+  hash:
+    md5: f87c7b7c2cb45f323ffbce941c78ab7c
+    sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
+  category: dev
+  optional: true
+- name: graphite2
+  version: 1.3.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-hebf3989_1003.conda
+  hash:
+    md5: 339991336eeddb70076d8ca826dac625
+    sha256: 2eadafbfc52f5e7df3da3c3b7e5bbe34d970bea1d645ffe60b0b1c3a216657f5
+  category: dev
+  optional: true
+- name: graphite2
+  version: 1.3.13
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+  hash:
+    md5: 3194499ee7d1a67404a87d0eefdd92c6
+    sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
+  category: dev
+  optional: true
+- name: graphviz
+  version: 11.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    fonts-conda-ecosystem: ''
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    gtk2: ''
+    gts: '>=0.7.6,<0.8.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
+    libgcc-ng: '>=12'
+    libgd: '>=2.3.3,<2.4.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    librsvg: '>=2.58.0,<3.0a0'
+    libstdcxx-ng: '>=12'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphviz-11.0.0-hc68bbd7_0.conda
+  hash:
+    md5: 52a531ef95358086a56086c45d97ab75
+    sha256: 7e7ca0901c0d2de455718ec7a0974e2091c38e608f90a4ba98084e4902d93c17
+  category: dev
+  optional: true
+- name: graphviz
+  version: 11.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.0,<2.0a0'
+    fonts-conda-ecosystem: ''
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    gtk2: ''
+    gts: '>=0.7.6,<0.8.0a0'
+    libcxx: '>=16'
+    libexpat: '>=2.6.2,<3.0a0'
+    libgd: '>=2.3.3,<2.4.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    librsvg: '>=2.58.0,<3.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphviz-11.0.0-h9bb9bc9_0.conda
+  hash:
+    md5: c004a0e5dfbe0ce38af9ab4684abd236
+    sha256: ced49a72b8f3c92a76d3f07bb75be2a64d3572d433f2711d36003e1b565d1d4e
+  category: dev
+  optional: true
+- name: graphviz
+  version: 11.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    getopt-win32: '>=0.1,<0.2.0a0'
+    gts: '>=0.7.6,<0.8.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
+    libgd: '>=2.3.3,<2.4.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    pango: '>=1.50.14,<2.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/graphviz-11.0.0-h09e431a_0.conda
+  hash:
+    md5: c6c2ec410aa5e77e09948bf7a4367c00
+    sha256: 9a41d852f32f5654980492934cc547776b94b3910e5c86beff3cb58eeddd08a5
+  category: dev
+  optional: true
+- name: gtk2
+  version: 2.24.33
+  manager: conda
+  platform: linux-64
+  dependencies:
+    atk-1.0: '>=2.38.0'
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    gdk-pixbuf: '>=2.42.10,<3.0a0'
+    harfbuzz: '>=8.3.0,<9.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.78.4,<3.0a0'
+    pango: '>=1.50.14,<2.0a0'
+    xorg-libx11: '>=1.8.7,<2.0a0'
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h280cfa0_4.conda
+  hash:
+    md5: 410f86e58e880dcc7b0e910a8e89c05c
+    sha256: b946ba60d177d72157cad8af51723f1d081a4794741d35debe53f8b2c807f3af
+  category: dev
+  optional: true
+- name: gtk2
+  version: 2.24.33
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    atk-1.0: '>=2.38.0'
+    cairo: '>=1.18.0,<2.0a0'
+    gdk-pixbuf: '>=2.42.10,<3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    libglib: '>=2.78.4,<3.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gtk2-2.24.33-h7895bb2_4.conda
+  hash:
+    md5: 9c1ba062d59f3f49a2d32d9611d72686
+    sha256: fab8403a67273f69780b1e9b5f1db1aff74ff9472acc9f6df6d9b50fc252bd50
+  category: dev
+  optional: true
+- name: gto
+  version: 1.7.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    entrypoints: ''
+    funcy: ''
+    pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
+    semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: ed39fb2671c7beeb6e87f8471392da64
+    sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
+  category: dev
+  optional: true
+- name: gto
+  version: 1.7.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    entrypoints: ''
+    funcy: ''
+    pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
+    semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: ed39fb2671c7beeb6e87f8471392da64
+    sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
+  category: dev
+  optional: true
+- name: gto
+  version: 1.7.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    entrypoints: ''
+    funcy: ''
+    pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
+    semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
+  hash:
+    md5: ed39fb2671c7beeb6e87f8471392da64
+    sha256: 65a73a4cacd6762b6e58929cda81fb56d32a58952b4994df01c7229ae3846114
+  category: dev
+  optional: true
+- name: gts
+  version: 0.7.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libglib: '>=2.76.3,<3.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+  hash:
+    md5: 4d8df0b0db060d33c9a702ada998a8fe
+    sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
+  category: dev
+  optional: true
+- name: gts
+  version: 0.7.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=15.0.7'
+    libglib: '>=2.76.3,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
+  hash:
+    md5: 21b4dd3098f63a74cf2aa9159cbef57d
+    sha256: e0f8c7bc1b9ea62ded78ffa848e37771eeaaaf55b3146580513c7266862043ba
+  category: dev
+  optional: true
+- name: gts
+  version: 0.7.6
+  manager: conda
+  platform: win-64
+  dependencies:
+    libglib: '>=2.76.3,<3.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
+  hash:
+    md5: a41f14768d5e377426ad60c613f2923b
+    sha256: b79755d2f9fc2113b6949bfc170c067902bc776e2c20da26e746e780f4f5a2d4
+  category: dev
+  optional: true
+- name: h11
+  version: 0.14.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: dev
+  optional: true
+- name: h11
+  version: 0.14.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: dev
+  optional: true
+- name: h11
+  version: 0.14.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b21ed0883505ba1910994f1df031a428
+    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
+  category: dev
+  optional: true
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b748fbf7060927a6e82df7cb5ee8f097
+    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  category: dev
+  optional: true
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b748fbf7060927a6e82df7cb5ee8f097
+    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  category: dev
+  optional: true
+- name: h2
+  version: 4.1.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    hpack: '>=4.0,<5'
+    hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: b748fbf7060927a6e82df7cb5ee8f097
+    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  category: dev
+  optional: true
+- name: harfbuzz
+  version: 8.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    graphite2: ''
+    icu: '>=73.2,<74.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.80.2,<3.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.5.0-hfac3d4d_0.conda
+  hash:
+    md5: f5126317dd0ce0ba26945e411ecc6960
+    sha256: a141fc55f8bfdab7db03fe9d8e61cb0f8c8b5970ed6540eda2db7186223f4444
+  category: dev
+  optional: true
+- name: harfbuzz
+  version: 8.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.0,<2.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    graphite2: ''
+    icu: '>=73.2,<74.0a0'
+    libcxx: '>=16'
+    libglib: '>=2.80.2,<3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.5.0-h1836168_0.conda
+  hash:
+    md5: aa22b942b980c17612d344adcd0f8798
+    sha256: 91121ed30fa7d775f1cf7ae5de2f7852d66a604269509c4bb108b143315d8321
+  category: dev
+  optional: true
+- name: harfbuzz
+  version: 8.5.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    graphite2: ''
+    icu: '>=73.2,<74.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.5.0-h81778c3_0.conda
+  hash:
+    md5: 2ff854071c04998038c0e1db4c9232f7
+    sha256: f633a33dfe5c799a571af41e3515fc706a6f4988701d39e7b5d37811a1745bb9
+  category: dev
+  optional: true
+- name: hatch
+  version: 1.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
+    httpx: '>=0.22.0'
+    hyperlink: '>=21.0.0'
+    keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
+    shellingham: '>=1.4.0'
+    tomli-w: '>=1.0'
+    tomlkit: '>=0.11.1'
+    userpath: '>=1.7,<2'
+    uv: '>=0.1.35'
+    virtualenv: '>=20.26.1'
+    zstandard: <1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
+    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
+  category: dev
+  optional: true
+- name: hatch
+  version: 1.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
+    httpx: '>=0.22.0'
+    hyperlink: '>=21.0.0'
+    keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
+    shellingham: '>=1.4.0'
+    tomli-w: '>=1.0'
+    tomlkit: '>=0.11.1'
+    userpath: '>=1.7,<2'
+    uv: '>=0.1.35'
+    virtualenv: '>=20.26.1'
+    zstandard: <1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
+    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
+  category: dev
+  optional: true
+- name: hatch
+  version: 1.12.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
+    httpx: '>=0.22.0'
+    hyperlink: '>=21.0.0'
+    keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
+    shellingham: '>=1.4.0'
+    tomli-w: '>=1.0'
+    tomlkit: '>=0.11.1'
+    userpath: '>=1.7,<2'
+    uv: '>=0.1.35'
+    virtualenv: '>=20.26.1'
+    zstandard: <1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 75ef4cd9ebf1c870d9389d2af8c67a42
+    sha256: 8f0e887f1a2f07866b357f9ab7b7ae424778723b1b896484990a0de62d1fac92
+  category: dev
+  optional: true
+- name: hatchling
+  version: 1.24.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28cef29029f6da70e7a987a76a3599a4
+    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+  category: dev
+  optional: true
+- name: hatchling
+  version: 1.24.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28cef29029f6da70e7a987a76a3599a4
+    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+  category: dev
+  optional: true
+- name: hatchling
+  version: 1.24.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 28cef29029f6da70e7a987a76a3599a4
+    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+  category: dev
+  optional: true
+- name: hpack
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: dev
+  optional: true
+- name: hpack
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: dev
+  optional: true
+- name: hpack
+  version: 4.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: 914d6646c4dbb1fd3ff539830a12fd71
+    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  category: dev
+  optional: true
+- name: html5lib
+  version: '1.1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+    six: '>=1.9'
+    webencodings: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: b2355343d6315c892543200231d7154a
+    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+  category: dev
+  optional: true
+- name: html5lib
+  version: '1.1'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+    six: '>=1.9'
+    webencodings: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: b2355343d6315c892543200231d7154a
+    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+  category: dev
+  optional: true
+- name: html5lib
+  version: '1.1'
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+    six: '>=1.9'
+    webencodings: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
+  hash:
+    md5: b2355343d6315c892543200231d7154a
+    sha256: 9ad06446fe9847e86cb20d220bf11614afcd2cbe9f58096f08d5d4018877bee4
+  category: dev
+  optional: true
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: '>=3.0,<5.0'
+    certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
+    python: '>=3.8'
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: dev
+  optional: true
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    anyio: '>=3.0,<5.0'
+    certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
+    python: '>=3.8'
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: dev
+  optional: true
+- name: httpcore
+  version: 1.0.5
+  manager: conda
+  platform: win-64
+  dependencies:
+    anyio: '>=3.0,<5.0'
+    certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
+    python: '>=3.8'
+    sniffio: 1.*
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: a6b9a0158301e697e4d0a36a3d60e133
+    sha256: 4025644200eefa0598e4600a66fd4804a57d9fd7054a5c8c45e508fd875e0b84
+  category: dev
+  optional: true
+- name: httpx
+  version: 0.27.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: dev
+  optional: true
+- name: httpx
+  version: 0.27.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: dev
+  optional: true
+- name: httpx
+  version: 0.27.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    anyio: ''
+    certifi: ''
+    httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9f359af5a886fd6ca6b2b6ea02e58332
+    sha256: fdaf341fb2630b7afe8238315448fc93947f77ebfa4da68bb349e1bcf820af58
+  category: dev
+  optional: true
 - name: huggingface_hub
   version: 0.23.4
   manager: conda
@@ -3496,6 +6127,7 @@ package:
     pyyaml: '>=5.1'
     requests: ''
     tqdm: '>=4.42.1'
+    typing-extensions: '>=3.7.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
     md5: 759dfbd44e93d75a23b203fe50dade8d
@@ -3514,12 +6146,136 @@ package:
     pyyaml: '>=5.1'
     requests: ''
     tqdm: '>=4.42.1'
+    typing-extensions: '>=3.7.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
     md5: 759dfbd44e93d75a23b203fe50dade8d
     sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
+- name: hydra-core
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    antlr-python-runtime: 4.9.*
+    importlib_resources: ''
+    omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 297d09ccdcec5b347d44c88f2b61cf03
+    sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
+  category: dev
+  optional: true
+- name: hydra-core
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    antlr-python-runtime: 4.9.*
+    importlib_resources: ''
+    omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 297d09ccdcec5b347d44c88f2b61cf03
+    sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
+  category: dev
+  optional: true
+- name: hydra-core
+  version: 1.3.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    antlr-python-runtime: 4.9.*
+    importlib_resources: ''
+    omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 297d09ccdcec5b347d44c88f2b61cf03
+    sha256: 35044b4bb1059c4ed7d8392b776e663a390ad7a2bb6f7e2f09ecd5e9b5d40b75
+  category: dev
+  optional: true
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: dev
+  optional: true
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: dev
+  optional: true
+- name: hyperframe
+  version: 6.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9f765cbfab6870c8435b9eefecd7a1f4
+    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  category: dev
+  optional: true
+- name: hyperlink
+  version: 21.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    idna: '>=2.6'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
+    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
+  category: dev
+  optional: true
+- name: hyperlink
+  version: 21.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    idna: '>=2.6'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
+    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
+  category: dev
+  optional: true
+- name: hyperlink
+  version: 21.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    idna: '>=2.6'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 1303beb57b40f8f4ff6fb1bb23bf0553
+    sha256: 026cb82ada41be9ee2836a2ace526e85c4603e77617887c41c6e62c9bde798b3
+  category: dev
+  optional: true
 - name: icu
   version: '73.2'
   manager: conda
@@ -3531,8 +6287,72 @@ package:
   hash:
     md5: cc47e1facc155f91abd89b11e48e72ff
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: icu
+  version: '73.2'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  hash:
+    md5: 8521bd47c0e11c5902535bb1a17c565f
+    sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  category: dev
+  optional: true
+- name: icu
+  version: '73.2'
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+  hash:
+    md5: 0f47d9e3192d9e09ae300da0d28e0f56
+    sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
+  category: dev
+  optional: true
+- name: identify
+  version: 2.5.36
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+    ukkonen: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
+  hash:
+    md5: ba68cb5105760379432cebc82b45af40
+    sha256: dc98ab2233d3ed3692499e2a06b027489ee317658cef9277ec23cab00236f31c
+  category: dev
+  optional: true
+- name: identify
+  version: 2.5.36
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+    ukkonen: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
+  hash:
+    md5: ba68cb5105760379432cebc82b45af40
+    sha256: dc98ab2233d3ed3692499e2a06b027489ee317658cef9277ec23cab00236f31c
+  category: dev
+  optional: true
+- name: identify
+  version: 2.5.36
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+    ukkonen: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
+  hash:
+    md5: ba68cb5105760379432cebc82b45af40
+    sha256: dc98ab2233d3ed3692499e2a06b027489ee317658cef9277ec23cab00236f31c
+  category: dev
+  optional: true
 - name: idna
   version: '3.7'
   manager: conda
@@ -3644,6 +6464,81 @@ package:
     sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
   category: main
   optional: false
+- name: importlib_resources
+  version: 6.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=3.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5d3907ad8bd7bf557521a1833cf7e6d
+    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+  category: dev
+  optional: true
+- name: importlib_resources
+  version: 6.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=3.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5d3907ad8bd7bf557521a1833cf7e6d
+    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+  category: dev
+  optional: true
+- name: importlib_resources
+  version: 6.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+    zipp: '>=3.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5d3907ad8bd7bf557521a1833cf7e6d
+    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+  category: dev
+  optional: true
+- name: iniconfig
+  version: 2.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f800d2da156d08e289b14e87e43c1ae5
+    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  category: dev
+  optional: true
+- name: iniconfig
+  version: 2.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f800d2da156d08e289b14e87e43c1ae5
+    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  category: dev
+  optional: true
+- name: iniconfig
+  version: 2.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f800d2da156d08e289b14e87e43c1ae5
+    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  category: dev
+  optional: true
 - name: intel-openmp
   version: 2024.1.0
   manager: conda
@@ -3655,6 +6550,183 @@ package:
     sha256: 77465396f2636c8b3b3a587f1636ee35c17a73e2a2c7e0ea0957b05f84704cf3
   category: main
   optional: false
+- name: iterative-telemetry
+  version: 0.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    appdirs: ''
+    distro: ''
+    filelock: ''
+    python: '>=3.7'
+    requests: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6eb5ad35a97da6f5efe7689ead4ab79f
+    sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
+  category: dev
+  optional: true
+- name: iterative-telemetry
+  version: 0.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    appdirs: ''
+    distro: ''
+    filelock: ''
+    python: '>=3.7'
+    requests: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6eb5ad35a97da6f5efe7689ead4ab79f
+    sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
+  category: dev
+  optional: true
+- name: iterative-telemetry
+  version: 0.0.8
+  manager: conda
+  platform: win-64
+  dependencies:
+    appdirs: ''
+    distro: ''
+    filelock: ''
+    python: '>=3.7'
+    requests: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6eb5ad35a97da6f5efe7689ead4ab79f
+    sha256: 3ac3c95bf82bf3f9b88e4a1c78615ba5b15f4e83ab1d8af82089fcc78a3eff13
+  category: dev
+  optional: true
+- name: jaraco.classes
+  version: 3.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7b756504d362cbad9b73a50a5455cafd
+    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
+  category: dev
+  optional: true
+- name: jaraco.classes
+  version: 3.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7b756504d362cbad9b73a50a5455cafd
+    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
+  category: dev
+  optional: true
+- name: jaraco.classes
+  version: 3.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 7b756504d362cbad9b73a50a5455cafd
+    sha256: 538b1c6df537a36c63fd0ed83cb1c1c25b07d8d3b5e401991fdaff261a4b5b4d
+  category: dev
+  optional: true
+- name: jaraco.context
+  version: 5.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    backports.tarfile: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
+    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
+  category: dev
+  optional: true
+- name: jaraco.context
+  version: 5.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    backports.tarfile: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
+    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
+  category: dev
+  optional: true
+- name: jaraco.context
+  version: 5.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    backports.tarfile: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-5.3.0-pyhd8ed1ab_1.conda
+  hash:
+    md5: 72d7ad2dcd0f37eccb2ee35a1c8f6aaa
+    sha256: 9e2aeacb1aed3ab4fc5883a357e8a874e12f687af300f8708ec12de2995e17d2
+  category: dev
+  optional: true
+- name: jaraco.functools
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 547670a612fd335eaa5ffbf0fa75cb64
+    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+  category: dev
+  optional: true
+- name: jaraco.functools
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 547670a612fd335eaa5ffbf0fa75cb64
+    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+  category: dev
+  optional: true
+- name: jaraco.functools
+  version: 4.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    more-itertools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 547670a612fd335eaa5ffbf0fa75cb64
+    sha256: d2e866fd22a48eaa2f795b6a3b0bf16f066293322ce04dd65cca36267160ead6
+  category: dev
+  optional: true
+- name: jeepney
+  version: 0.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 9800ad1699b42612478755a2d26c722d
+    sha256: 16639759b811866d63315fe1391f6fb45f5478b823972f4d3d9f0392b7dd80b8
+  category: dev
+  optional: true
 - name: jinja2
   version: 3.1.4
   manager: conda
@@ -3694,6 +6766,42 @@ package:
     sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
   category: main
   optional: false
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  category: dev
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  category: dev
+  optional: true
+- name: jmespath
+  version: 1.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
+    sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
+  category: dev
+  optional: true
 - name: joblib
   version: 1.4.2
   manager: conda
@@ -3733,18 +6841,63 @@ package:
     sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
   category: main
   optional: false
-- name: jpeg
-  version: 9e
+- name: keyring
+  version: 25.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+    __linux: ''
+    importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    jeepney: '>=0.4.2'
+    python: '>=3.8'
+    secretstorage: '>=3.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyha804496_0.conda
   hash:
-    md5: c7a069243e1fbe9a556ed2ec030e6407
-    sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
-  category: main
-  optional: false
+    md5: 8508b734287ac18dd1caa72a0d8127ee
+    sha256: a9608fa7d3ec6a58f01a8901773a28bbe08f2e799476cd2b9aae7f578dff8fab
+  category: dev
+  optional: true
+- name: keyring
+  version: 25.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: ''
+    importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh534df25_0.conda
+  hash:
+    md5: 8c071c544a2fc27cbc75dfa0d7362f0c
+    sha256: 25c638602ef3854a8f1785004124ac3acba2b1ceaa7a2f23f51dfa09b5cd6d3f
+  category: dev
+  optional: true
+- name: keyring
+  version: 25.2.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    __win: ''
+    importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.8'
+    pywin32-ctypes: '>=0.2.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh7428d3b_0.conda
+  hash:
+    md5: 70fb816c1b6ab81e048e4c6227ec922c
+    sha256: 3c7402db93f974fee3ef88f1208c8d9ab4009f33392a6b6d340516c96b3ae5b5
+  category: dev
+  optional: true
 - name: keyutils
   version: 1.6.1
   manager: conda
@@ -3757,6 +6910,54 @@ package:
     sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   category: main
   optional: false
+- name: kombu
+  version: 5.3.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    amqp: '>=5.1.1,<6.0.0'
+    boto3: '>=1.26.143'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    vine: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/kombu-5.3.7-py311h38be061_0.conda
+  hash:
+    md5: 256ce94762bf2e25822232253c029b5b
+    sha256: 5e5edf48bb1910dc851c997ea990d8d960b333044fae11d10ca93cfdc1f72a4c
+  category: dev
+  optional: true
+- name: kombu
+  version: 5.3.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    amqp: '>=5.1.1,<6.0.0'
+    boto3: '>=1.26.143'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    vine: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/kombu-5.3.7-py311h267d04e_0.conda
+  hash:
+    md5: 1e42e45f351207e0571782c2d08ed983
+    sha256: c0810b295a185b4bb7d586b432ee12140efcf08745d322cff2e2d28dff8750ee
+  category: dev
+  optional: true
+- name: kombu
+  version: 5.3.7
+  manager: conda
+  platform: win-64
+  dependencies:
+    amqp: '>=5.1.1,<6.0.0'
+    boto3: '>=1.26.143'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    vine: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/kombu-5.3.7-py311h1ea47a8_0.conda
+  hash:
+    md5: 6f3bce35fa4b4612fc1f2413a9b4033e
+    sha256: e1338942952ecc2bcff542443a6f0c329b3448d5432772dffbc6ea1480f24211
+  category: dev
+  optional: true
 - name: krb5
   version: 1.21.2
   manager: conda
@@ -3803,17 +7004,17 @@ package:
   category: main
   optional: false
 - name: lcms2
-  version: '2.15'
+  version: '2.16'
   manager: conda
   platform: linux-64
   dependencies:
-    jpeg: '>=9e,<10a'
     libgcc-ng: '>=12'
-    libtiff: '>=4.5.0,<4.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
   hash:
-    md5: aa8840cdf17ef0c6084d1e24abc7a28b
-    sha256: 443e926b585528112ec6aa4d85bf087722914ed8d85a2f75ae47c023c55c4238
+    md5: 51bb7010fc86f70eee639b4bb7a894f5
+    sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
   category: main
   optional: false
 - name: lcms2
@@ -4236,16 +7437,39 @@ package:
     sha256: b8ff3db6459d10320708981c54241cf7ede3cd10e022f3b5c94f754fd5e0c95f
   category: main
   optional: false
+- name: libasprintf
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 1b27402397a76115679c4855ab2ece41
+    sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
+  category: dev
+  optional: true
+- name: libasprintf-devel
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libasprintf: 0.22.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 480c106e87d4c4791e6b55a6d1678866
+    sha256: f5331486854a5fe80bb837891efb28a28623f762327372cb4cbc264c9c4bf9e2
+  category: dev
+  optional: true
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    mkl: '>=2022.1.0,<2023.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_mkl.tar.bz2
+    libopenblas: '>=0.3.27,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
   hash:
-    md5: 85f61af03fd291dae33150ffe89dc09a
-    sha256: 24e656f13b402b6fceb88df386768445ab9beb657d451a8e5a88d4b3380cf7a4
+    md5: 1a2a0cd3153464fee6646f3dd6dad9b8
+    sha256: 082b8ac20d43a7bbcdc28b3b1cd40e4df3a8b5daf0a2d23d68953a44d2d12c1b
   category: main
   optional: false
 - name: libblas
@@ -4395,10 +7619,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_mkl.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
   hash:
-    md5: 361bf757b95488de76c4f123805742d3
-    sha256: 892ba10508f22310ccfe748df1fd3b6c7f20e7b6f6b79e69ed337863551c1bd8
+    md5: 4b31699e0ec5de64d5896e580389c9a1
+    sha256: da1b2faa017663c8f5555c1c5518e96ac4cd8e0be2a673c1c9e2cb8507c8fe46
   category: main
   optional: false
 - name: libcblas
@@ -4528,15 +7752,15 @@ package:
   category: main
   optional: false
 - name: libdeflate
-  version: '1.17'
+  version: '1.20'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
   hash:
-    md5: 5cc781fd91968b11a8a7fdbee0982676
-    sha256: f9983a8ea03531f2c14bce76c870ca325c0fddf0c4e872bff1f78bc52624179c
+    md5: 8e88f9389f1165d7c0936fe40d9a9a79
+    sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
   category: main
   optional: false
 - name: libdeflate
@@ -4735,6 +7959,111 @@ package:
     sha256: 78931358d83ff585d0cd448632366a5cbe6bcf41a66c07e8178200008127c2b5
   category: main
   optional: false
+- name: libgd
+  version: 2.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    expat: ''
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libgcc-ng: '>=12'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp: ''
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h119a65a_9.conda
+  hash:
+    md5: cfebc557e54905dadc355c0e9f003004
+    sha256: b74f95a6e1f3b31a74741b39cba83ed99fc82d17243c0fd3b5ab16ddd48ab89d
+  category: dev
+  optional: true
+- name: libgd
+  version: 2.3.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    expat: ''
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp: ''
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgd-2.3.3-hfdf3952_9.conda
+  hash:
+    md5: 0d847466f115fbdaaf2b6926f2e33278
+    sha256: cfdecfaa27807abc2728bd8c60b923ce1b44020553e122e9a56fc3acb77acaec
+  category: dev
+  optional: true
+- name: libgd
+  version: 2.3.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    expat: ''
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp: ''
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+    xorg-libxpm: '>=3.5.16,<4.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/libgd-2.3.3-h312136b_9.conda
+  hash:
+    md5: 69c987e1f9268d9ade86497c4ab8cc45
+    sha256: fa75f4206eb9cd8e5e24fe1b6381a7450cfcb507c42813fd028a924a4872bc76
+  category: dev
+  optional: true
+- name: libgettextpo
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+    libintl: 0.22.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: a66fad933e22d22599a6dd149d359d25
+    sha256: c3f5580e172c3fc03d33e8994024f08b709a239bd599792e51435fa7a06beb64
+  category: dev
+  optional: true
+- name: libgettextpo-devel
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libgettextpo: 0.22.5
+    libiconv: '>=1.17,<2.0a0'
+    libintl: 0.22.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 1113aa220b042b7ce8d077ea8f696f98
+    sha256: b1be0bb8a726e2c47a025ff348e6ba8b51ef668f6ace06694657025d84ae66e2
+  category: dev
+  optional: true
 - name: libgfortran
   version: 5.0.0
   manager: conda
@@ -4781,6 +8110,122 @@ package:
   hash:
     md5: 66ac81d54e95c534ae488726c1f698ea
     sha256: bafc679eedb468a86aa4636061c55966186399ee0a04b605920d208d97ac579a
+  category: main
+  optional: false
+- name: libgit2
+  version: 1.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=12'
+    libssh2: '>=1.11.0,<2.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.8.1-he8d1d4c_1.conda
+  hash:
+    md5: febd0520afc041dd938acdce0f26d71b
+    sha256: 7b59e6f31d9b4e877322ec1b9b7da61fc3f34950ca6a2b4576ba2de0de5718e6
+  category: dev
+  optional: true
+- name: libgit2
+  version: 1.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=16'
+    libiconv: '>=1.17,<2.0a0'
+    libssh2: '>=1.11.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgit2-1.8.1-h7d81828_1.conda
+  hash:
+    md5: 4a7d5c262df8bc95a0509ce29881293e
+    sha256: 9dd6e511540298213bab05b1a640259d4f874c58137568fca5162305df0d3e73
+  category: dev
+  optional: true
+- name: libgit2
+  version: 1.8.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    libssh2: '>=1.11.0,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libgit2-1.8.1-hc1607c6_1.conda
+  hash:
+    md5: 96b2ee01e59abd5d8252b4da99f8ca7f
+    sha256: 68554180fe022e4cb7069e08906a3474732664763cea1594cc68b5671459ca57
+  category: dev
+  optional: true
+- name: libglib
+  version: 2.80.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    libgcc-ng: '>=12'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-h8a4344b_1.conda
+  hash:
+    md5: 9c406bb3d4dac2b358873e6462496d09
+    sha256: 03dcc12fe937e32b1fbd7bd7cfe0f7a3e82ee4fe8d29c4d67afb657f13d04394
+  category: dev
+  optional: true
+- name: libglib
+  version: 2.80.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libffi: '>=3.4,<4.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libintl: '>=0.22.5,<1.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h59d46d9_1.conda
+  hash:
+    md5: 104d740896163d3e5b4b5ca7bc8f5bbb
+    sha256: 630c10b41bad621c1b6c7cf7241bceca4a009fdc1db2a5b9125dc49059eab070
+  category: dev
+  optional: true
+- name: libglib
+  version: 2.80.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    libffi: '>=3.4,<4.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libintl: '>=0.22.5,<1.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pcre2: '>=10.44,<10.45.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h7025463_1.conda
+  hash:
+    md5: f9f0561c59e62d02f6d6d118ce8b5b63
+    sha256: 84dc3f80a2956a055c7aa3b5df9061756cf5d3eecb11bf656688e1ee6177bd7e
+  category: dev
+  optional: true
+- name: libgomp
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _libgcc_mutex: '0.1'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h77fa898_10.conda
+  hash:
+    md5: 9404d1686e63142d41acc72ef876a588
+    sha256: bcea6ddfea86f0e6a1a831d1d2c3f36f7613b5e447229e19f978ded0d184cf5a
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -4957,20 +8402,6 @@ package:
 - name: libhwloc
   version: 2.10.0
   manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.7,<3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.10.0-default_h5622ce7_1001.conda
-  hash:
-    md5: fc2d5b79c2d3f8568fbab31db7ae02f3
-    sha256: 6f19d26819d336cb76689861e20560404a3cd61cc9adf7cbc395b9a5e612e226
-  category: main
-  optional: false
-- name: libhwloc
-  version: 2.10.0
-  manager: conda
   platform: win-64
   dependencies:
     libxml2: '>=2.12.7,<3.0a0'
@@ -4994,8 +8425,19 @@ package:
   hash:
     md5: d66573916ffcf376178462f1b61c941e
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
+  hash:
+    md5: 69bda57310071cf6d2b86caf11573d2d
+    sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
+  category: dev
+  optional: true
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -5008,6 +8450,55 @@ package:
   hash:
     md5: e1eb10b1cca179f2baa3601e4efc8712
     sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  category: main
+  optional: false
+- name: libintl
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 3d216d0add050129007de3342be7b8c5
+    sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
+  category: dev
+  optional: true
+- name: libintl
+  version: 0.22.5
+  manager: conda
+  platform: win-64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+  hash:
+    md5: aa622c938af057adc119f8b8eecada01
+    sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
+  category: dev
+  optional: true
+- name: libintl-devel
+  version: 0.22.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+    libintl: 0.22.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
+  hash:
+    md5: 962b3348c68efd25da253e94590ea9a2
+    sha256: e52b2d0c5711f64b523756ccd9b800ee6f10a6317432b20a417dc3792e0a794a
+  category: dev
+  optional: true
+- name: libjpeg-turbo
+  version: 3.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+  hash:
+    md5: ea25936bb4080d843790b586850f82b8
+    sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
   category: main
   optional: false
 - name: libjpeg-turbo
@@ -5041,10 +8532,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_mkl.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
   hash:
-    md5: a2f166748917d6d6e4707841ca1f519e
-    sha256: d6201f860b2d76ed59027e69c2bbad6d1cb211a215ec9705cc487cde488fa1fa
+    md5: b083767b6c877e24ee597d93b87ab838
+    sha256: db246341d42f9100d45adeb1a7ba8b1ef5b51ceb9056fd643e98046a3259fde6
   category: main
   optional: false
 - name: liblapack
@@ -5156,6 +8647,20 @@ package:
   hash:
     md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  category: main
+  optional: false
+- name: libopenblas
+  version: 0.3.27
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libgfortran-ng: ''
+    libgfortran5: '>=12.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
+  hash:
+    md5: a356024784da6dfd4683dc5ecf45b155
+    sha256: 2ae7559aed0705deb3f716c7b247c74fd1b5e35b64e39834ce8b95f7564d4a3e
   category: main
   optional: false
 - name: libopenblas
@@ -5348,6 +8853,43 @@ package:
     sha256: 04331dad30a076ebb24c683197a5feabf4fd9be0fa0e06f416767096f287f900
   category: main
   optional: false
+- name: librsvg
+  version: 2.58.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    harfbuzz: '>=8.5.0,<9.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.1-hadf69e7_0.conda
+  hash:
+    md5: 73fc255d740d23da4f554b58dc4909fd
+    sha256: c3b6c48e50a3ff8522d868215dcccfbd8f2720e512084b12f4bfcb6a668c5552
+  category: dev
+  optional: true
+- name: librsvg
+  version: 2.58.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.0,<2.0a0'
+    gdk-pixbuf: '>=2.42.12,<3.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libxml2: '>=2.12.7,<3.0a0'
+    pango: '>=1.50.14,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.1-hbc281fb_0.conda
+  hash:
+    md5: e642889ae7e977769f6d0328e2ec7497
+    sha256: 01fdd2c28b24d319f46cf8072147beda48e223757a8fb6bca95fb6c93bad918b
+  category: dev
+  optional: true
 - name: libsqlite
   version: 3.46.0
   manager: conda
@@ -5492,23 +9034,23 @@ package:
   category: main
   optional: false
 - name: libtiff
-  version: 4.5.0
+  version: 4.6.0
   manager: conda
   platform: linux-64
   dependencies:
-    jpeg: '>=9e,<10a'
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.17,<1.18.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
     libgcc-ng: '>=12'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
     libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.2.4,<2.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
     xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
   hash:
-    md5: 2e648a34072eb39d7c4fc2a9981c5f0c
-    sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
+    md5: 66f03896ffbe1a110ffda05c7a856504
+    sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
   category: main
   optional: false
 - name: libtiff
@@ -5548,6 +9090,49 @@ package:
   hash:
     md5: 6d1828c9039929e2f185c5fa9d133018
     sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
+  category: main
+  optional: false
+- name: libtorch
+  version: 2.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+    libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libstdcxx-ng: '>=12'
+    libuv: '>=1.48.0,<2.0a0'
+    sleef: '>=3.5.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.1.2-cpu_generic_h0ec3652_4.conda
+  hash:
+    md5: 14d76e1994a097c59c8822aed877f5f4
+    sha256: f5b02ad2accc3fe5670afeb4ad1671db171cb1a19ce8507547ab5e6195d0cc9e
+  category: main
+  optional: false
+- name: libtorch
+  version: 2.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=16'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libuv: '>=1.48.0,<2.0a0'
+    llvm-openmp: '>=16.0.6'
+    numpy: '>=1.19,<3'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.3.1-cpu_generic_hac4f340_0.conda
+  hash:
+    md5: e925d1407b971d451e490fd4a46f3206
+    sha256: 2a4d926caed2cd6d51aeeae14685a8b1c57863a4ad8ca0b438eb7f896cb9b1c8
   category: main
   optional: false
 - name: libutf8proc
@@ -5602,6 +9187,29 @@ package:
 - name: libuv
   version: 1.48.0
   manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
+  hash:
+    md5: 7e8b914b1062dd4386e3de4d82a3ead6
+    sha256: b7c0e8a0c93c2621be7645b37123d4e8d27e8a974da26a3fba47a9c37711aa7f
+  category: main
+  optional: false
+- name: libuv
+  version: 1.48.0
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
+  hash:
+    md5: abfd49e80f13453b62a56be226120ea8
+    sha256: 60bed2a7a85096387ab0381cbc32ea2da7f8dd99bd90e440983019c0cdd96ad1
+  category: main
+  optional: false
+- name: libuv
+  version: 1.48.0
+  manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
@@ -5613,6 +9221,55 @@ package:
     sha256: 6151c51857c2407139ce22fdc956022353e675b2bc96991a9201d51cceaa90b4
   category: main
   optional: false
+- name: libwebp
+  version: 1.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    giflib: '>=5.2.2,<5.3.0a0'
+    libgcc-ng: '>=12'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.4.0-h2c329e2_0.conda
+  hash:
+    md5: 80030debaa84cfc31755d53742df3ca6
+    sha256: bd45805b169e3e0ff166d360c3c4842d77107d28c8f9feba020a8e8b9c80f948
+  category: dev
+  optional: true
+- name: libwebp
+  version: 1.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    giflib: '>=5.2.2,<5.3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-1.4.0-h54798ee_0.conda
+  hash:
+    md5: 078abbcc54996b186b9144cf795bd30f
+    sha256: e75e7a58793236fc8e92733c8bad168ce7bea40ca54c8c643e357511ba4a7b98
+  category: dev
+  optional: true
+- name: libwebp
+  version: 1.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    libwebp-base: '>=1.4.0,<2.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-1.4.0-h2466b09_0.conda
+  hash:
+    md5: 11334a8fb02041b453e2f89a4ae16f8d
+    sha256: ebabb57084e85cd09d529dbb4fe0f4db6cd0d369ad8095342c37b98855fd87fd
+  category: dev
+  optional: true
 - name: libwebp-base
   version: 1.4.0
   manager: conda
@@ -5651,18 +9308,18 @@ package:
   category: main
   optional: false
 - name: libxcb
-  version: '1.13'
+  version: '1.15'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
+    libgcc-ng: '>=12'
     pthread-stubs: ''
     xorg-libxau: ''
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
   hash:
-    md5: b3653fdc58d03face9724f602218a904
-    sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+    md5: 33277193f5b92bad9fdd230eb700929c
+    sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
   category: main
   optional: false
 - name: libxcb
@@ -5721,8 +9378,24 @@ package:
   hash:
     md5: 340278ded8b0dc3a73f3660bbb0adbc6
     sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
-  category: main
-  optional: false
+  category: dev
+  optional: true
+- name: libxml2
+  version: 2.12.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=73.2,<74.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<2.0a0'
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-ha661575_1.conda
+  hash:
+    md5: 8ea71a74847498c793b0a8e9054a177a
+    sha256: 0ea12032b53d3767564a058ccd5208c0a1724ed2f8074dd22257ff3859ea6a4e
+  category: dev
+  optional: true
 - name: libxml2
   version: 2.12.7
   manager: conda
@@ -5775,18 +9448,6 @@ package:
   hash:
     md5: d4483ca8afc57ddf1f6dded53b36c17f
     sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 15.0.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-15.0.7-h0cdce71_0.conda
-  hash:
-    md5: 589c9a3575a050b583241c3d688ad9aa
-    sha256: 7c67d383a8b1f3e7bf9e046e785325c481f6868194edcfb9d78d261da4ad65d4
   category: main
   optional: false
 - name: llvm-openmp
@@ -6039,6 +9700,45 @@ package:
     sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
   category: main
   optional: false
+- name: markdown-it-py
+  version: 3.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    mdurl: '>=0.1,<1'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 93a8e71256479c62074356ef6ebf501b
+    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  category: dev
+  optional: true
+- name: markdown-it-py
+  version: 3.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    mdurl: '>=0.1,<1'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 93a8e71256479c62074356ef6ebf501b
+    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  category: dev
+  optional: true
+- name: markdown-it-py
+  version: 3.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    mdurl: '>=0.1,<1'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 93a8e71256479c62074356ef6ebf501b
+    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  category: dev
+  optional: true
 - name: markupsafe
   version: 2.1.5
   manager: conda
@@ -6082,20 +9782,42 @@ package:
     sha256: c629f79fe78b5df7f08daa6b7f125f7a67f789bf734949c6d68aa063d7296208
   category: main
   optional: false
-- name: mkl
-  version: 2022.2.1
+- name: mdurl
+  version: 0.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    _openmp_mutex: '>=4.5'
-    llvm-openmp: '>=15.0.6'
-    tbb: 2021.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2022.2.1-h84fe81f_16997.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: a7ce56d5757f5b57e7daabe703ade5bb
-    sha256: 5322750d5e96ff5d96b1457db5fb6b10300f2bc4030545e940e17b57c4e96d00
-  category: main
-  optional: false
+    md5: 776a8dd9e824f77abac30e6ef43a8f7a
+    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  category: dev
+  optional: true
+- name: mdurl
+  version: 0.1.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 776a8dd9e824f77abac30e6ef43a8f7a
+    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  category: dev
+  optional: true
+- name: mdurl
+  version: 0.1.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 776a8dd9e824f77abac30e6ef43a8f7a
+    sha256: 64073dfb6bb429d52fff30891877b48c7ec0f89625b1bf844905b66a81cce6e1
+  category: dev
+  optional: true
 - name: mkl
   version: 2021.4.0
   manager: conda
@@ -6133,6 +9855,42 @@ package:
     sha256: d07c44d4054f208681737522b6f9fe25b00b7f2a10acb2dccda5ef84536bfa79
   category: main
   optional: false
+- name: more-itertools
+  version: 10.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a57fb23d0260a962a67c7d990ec1c812
+    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
+  category: dev
+  optional: true
+- name: more-itertools
+  version: 10.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a57fb23d0260a962a67c7d990ec1c812
+    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
+  category: dev
+  optional: true
+- name: more-itertools
+  version: 10.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a57fb23d0260a962a67c7d990ec1c812
+    sha256: 9c485cc52dfd646ea584e9055c1bbaac8f27687d806c1ef00f299ec2e642ce04
+  category: dev
+  optional: true
 - name: mpc
   version: 1.3.1
   manager: conda
@@ -6474,6 +10232,114 @@ package:
     sha256: ac5403c253608cb76e7f14e51902f02516cbc18edb9eebf62f1bcd0648d0ac6b
   category: main
   optional: false
+- name: nodeenv
+  version: 1.9.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: 2.7|>=3.7
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: dfe0528d0f1c16c1f7c528ea5536ab30
+    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+  category: dev
+  optional: true
+- name: nodeenv
+  version: 1.9.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: 2.7|>=3.7
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: dfe0528d0f1c16c1f7c528ea5536ab30
+    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+  category: dev
+  optional: true
+- name: nodeenv
+  version: 1.9.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: 2.7|>=3.7
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: dfe0528d0f1c16c1f7c528ea5536ab30
+    sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+  category: dev
+  optional: true
+- name: nodejs
+  version: 20.12.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=73.2,<74.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libuv: '>=1.48.0,<1.49.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.12.2-hb753e55_0.conda
+  hash:
+    md5: 1fd16ca757a195c4357a1fbb2cb553b5
+    sha256: 2f5813d9718963861314c6d9f75fe4630c3e6d078ec1e792770daf9ce7ac5c4f
+  category: dev
+  optional: true
+- name: nodejs
+  version: 20.12.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    icu: '>=73.2,<74.0a0'
+    libcxx: '>=16'
+    libuv: '>=1.48.0,<1.49.0a0'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    zlib: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-20.12.2-h3b52c9b_0.conda
+  hash:
+    md5: 0ba66fae46df4a035db42e2230453604
+    sha256: 81ea2a695b4b97ce6066220b9e54232e67b4a1e3eac3fc7016c08a463c588478
+  category: dev
+  optional: true
+- name: nodejs
+  version: 20.12.2
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/nodejs-20.12.2-h57928b3_0.conda
+  hash:
+    md5: 28d4536e0beff7b51232a5b16f9c3444
+    sha256: 31b275bf914d57941e818b31f7ee8367c6c6a8532a2918639c87816bad1323af
+  category: dev
+  optional: true
+- name: nomkl
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  hash:
+    md5: 9a66894dfd07c4510beb6b3f9672ccc0
+    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+  category: main
+  optional: false
+- name: nomkl
+  version: '1.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  hash:
+    md5: 9a66894dfd07c4510beb6b3f9672ccc0
+    sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+  category: main
+  optional: false
 - name: numba
   version: 0.58.1
   manager: conda
@@ -6633,20 +10499,65 @@ package:
     sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
   category: main
   optional: false
+- name: omegaconf
+  version: 2.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    antlr-python-runtime: 4.9.*
+    python: '>=3.7'
+    pyyaml: '>=5.1.0'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 23cc056834cab53849b91f78d6ee3ea0
+    sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
+  category: dev
+  optional: true
+- name: omegaconf
+  version: 2.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    antlr-python-runtime: 4.9.*
+    python: '>=3.7'
+    pyyaml: '>=5.1.0'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 23cc056834cab53849b91f78d6ee3ea0
+    sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
+  category: dev
+  optional: true
+- name: omegaconf
+  version: 2.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    antlr-python-runtime: 4.9.*
+    python: '>=3.7'
+    pyyaml: '>=5.1.0'
+    typing_extensions: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 23cc056834cab53849b91f78d6ee3ea0
+    sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
+  category: dev
+  optional: true
 - name: openjpeg
-  version: 2.5.0
+  version: 2.5.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libtiff: '>=4.5.0,<4.6.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
   hash:
-    md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
-    sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
+    md5: 7f2e286780f072ed750df46dc2631138
+    sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
   category: main
   optional: false
 - name: openjpeg
@@ -6780,6 +10691,47 @@ package:
     sha256: 8aca1dcb6e9b3e71ffbec26c2b84f45fa682d9075b78cd30acc48044b64149ec
   category: main
   optional: false
+- name: orjson
+  version: 3.10.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.10.4-py311h5ecf98a_0.conda
+  hash:
+    md5: e30a98410d7a1e9bb3fa713c1fd5c377
+    sha256: e9fe499a21223169361bd2277a19bc9486df77a88a6b5d8ed73adb1aa14d025a
+  category: dev
+  optional: true
+- name: orjson
+  version: 3.10.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orjson-3.10.4-py311h98c6a39_0.conda
+  hash:
+    md5: 6b3a5b6525c0dd048218c7505a81f0b5
+    sha256: 7d1bec93320924e7a500e136887c00a978e8bfd907845cfe178b02b53a522f00
+  category: dev
+  optional: true
+- name: orjson
+  version: 3.10.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/win-64/orjson-3.10.4-py311h633b200_0.conda
+  hash:
+    md5: 78665916419f610478a2e7922bcfdf3a
+    sha256: 284d2c5ec290aa318a9e1425242faf4ca5874b61e20e7dc386b936addb8b951e
+  category: dev
+  optional: true
 - name: packaging
   version: '24.1'
   manager: conda
@@ -6874,6 +10826,68 @@ package:
     sha256: 351b4f7211fc755ea1af8b218d2515418df3af08170197011934faf06bb5d98e
   category: main
   optional: false
+- name: pango
+  version: 1.54.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    fribidi: '>=1.0.10,<2.0a0'
+    harfbuzz: '>=8.5.0,<9.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.54.0-h84a9a3c_0.conda
+  hash:
+    md5: 7c51e110b2f059c0843269d3324e4b22
+    sha256: 3d0ef5a908f0429d7821d8a03a6f19ea7801245802c47f7c8c57163ea60e45c7
+  category: dev
+  optional: true
+- name: pango
+  version: 1.54.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    fribidi: '>=1.0.10,<2.0a0'
+    harfbuzz: '>=8.5.0,<9.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h5cb9fbc_0.conda
+  hash:
+    md5: e490cbccf161da2220fd9be3463c0fac
+    sha256: 45dd6dc3a5b737871f8bc6a5fd9857d37f6e411f33051ce8043af41c35c7fa02
+  category: dev
+  optional: true
+- name: pango
+  version: 1.54.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    cairo: '>=1.18.0,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: ''
+    freetype: '>=2.12.1,<3.0a0'
+    fribidi: '>=1.0.10,<2.0a0'
+    harfbuzz: '>=8.5.0,<9.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-h2231ffd_0.conda
+  hash:
+    md5: cef297f5eac752831efd6e680bf980bd
+    sha256: f7910cc0ea1cff76adb2bcec81627e10d6b13f1956a47a69422b71cdc554bfe6
+  category: dev
+  optional: true
 - name: partd
   version: 1.4.2
   manager: conda
@@ -6916,27 +10930,224 @@ package:
     sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
   category: main
   optional: false
+- name: pastel
+  version: 0.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: a4eea5bff523f26442405bc5d1f52adb
+    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
+  category: dev
+  optional: true
+- name: pastel
+  version: 0.2.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: a4eea5bff523f26442405bc5d1f52adb
+    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
+  category: dev
+  optional: true
+- name: pastel
+  version: 0.2.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pastel-0.2.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: a4eea5bff523f26442405bc5d1f52adb
+    sha256: 9153f0f38c76a09da7688a61fdbf8f3d7504e2326bef53e4ec20d994311b15bd
+  category: dev
+  optional: true
+- name: pathlib2
+  version: 2.3.7.post1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    six: '>=1.13.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pathlib2-2.3.7.post1-py311h38be061_3.conda
+  hash:
+    md5: 972a2dff56a924aa01d2d90b3e6d0837
+    sha256: cb0b39f14ec99b892fc25b2733adb8af5a2572786e8528a2dff7138640068177
+  category: dev
+  optional: true
+- name: pathlib2
+  version: 2.3.7.post1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    six: '>=1.13.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pathlib2-2.3.7.post1-py311h267d04e_3.conda
+  hash:
+    md5: 1e5fd88aed9ddedbd5ed8f16ff8a7d52
+    sha256: 14b02b2274b2882164f089c5cb3f125a103969450ff5674926e88a769febb28a
+  category: dev
+  optional: true
+- name: pathlib2
+  version: 2.3.7.post1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    six: '>=1.13.0'
+  url: https://conda.anaconda.org/conda-forge/win-64/pathlib2-2.3.7.post1-py311h1ea47a8_3.conda
+  hash:
+    md5: 9e85cb72eff51862c45a7f7c92a88272
+    sha256: c930d9ac59ef2b4dcac8f9880028bac7ba78ee183499a5855ce4c85bf7214216
+  category: dev
+  optional: true
+- name: pathspec
+  version: 0.12.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  category: dev
+  optional: true
+- name: pathspec
+  version: 0.12.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  category: dev
+  optional: true
+- name: pathspec
+  version: 0.12.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 17064acba08d3686f1135b5ec1b32b12
+    sha256: 4e534e66bfe8b1e035d2169d0e5b185450546b17e36764272863e22e0370be4d
+  category: dev
+  optional: true
+- name: pcre2
+  version: '10.44'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libgcc-ng: '>=12'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
+  hash:
+    md5: 3914f7ac1761dce57102c72ca7c35d01
+    sha256: 90646ad0d8f9d0fd896170c4f3d754e88c4ba0eaf856c24d00842016f644baab
+  category: dev
+  optional: true
+- name: pcre2
+  version: '10.44'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-h297a79d_0.conda
+  hash:
+    md5: 62f8d7e2ef03b0aae64185b0f38316eb
+    sha256: 23ddc5022a1025027ac1957dc1947c70d93a78414fbb183026457a537e8b3770
+  category: dev
+  optional: true
+- name: pcre2
+  version: '10.44'
+  manager: conda
+  platform: win-64
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
+  hash:
+    md5: 007d07ab5027e0bf49f6fa660a9f89a0
+    sha256: 44351611091ed72c4682ad23e53d7874334757298ff0ebb2acd769359ae82ab3
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ptyprocess: '>=0.5'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ptyprocess: '>=0.5'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: dev
+  optional: true
+- name: pexpect
+  version: 4.9.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    ptyprocess: '>=0.5'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 629f3203c99b32e0988910c93e77f3b6
+    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
+  category: dev
+  optional: true
 - name: pillow
-  version: 9.4.0
+  version: 10.3.0
   manager: conda
   platform: linux-64
   dependencies:
     freetype: '>=2.12.1,<3.0a0'
-    jpeg: '>=9e,<10a'
-    lcms2: '>=2.14,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
     libgcc-ng: '>=12'
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libwebp-base: '>=1.2.4,<2.0a0'
-    libxcb: '>=1.13,<1.14.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-    tk: '>=8.6.12,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py311h50def17_1.conda
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py311h18e6fac_0.conda
   hash:
-    md5: 8b5d1da23907114bd7aa3d562150ff36
-    sha256: ffb114fc7cdc8053694c71109dc8efb126b2dc944798ebaaff6ec7d695e9192e
+    md5: 6c520a9d36c9d7270988c7a6c360d6d4
+    sha256: 6e54cc2acead8884e81e3e1b4f299b18d5daa0e3d11f4db5686db9e2ada2a353
   category: main
   optional: false
 - name: pillow
@@ -7028,6 +11239,282 @@ package:
     sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
   category: main
   optional: false
+- name: pixman
+  version: 0.43.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+  hash:
+    md5: 71004cbf7924e19c02746ccde9fd7123
+    sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  category: dev
+  optional: true
+- name: pixman
+  version: 0.43.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  hash:
+    md5: 0308c68e711cd295aaa026a4f8c4b1e5
+    sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  category: dev
+  optional: true
+- name: pixman
+  version: 0.43.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+  hash:
+    md5: b98135614135d5f458b75ab9ebb9558c
+    sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
+  category: dev
+  optional: true
+- name: pkginfo
+  version: 1.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6a3e4fb1396215d0d88b3cc2f09de412
+    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
+  category: dev
+  optional: true
+- name: pkginfo
+  version: 1.11.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6a3e4fb1396215d0d88b3cc2f09de412
+    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
+  category: dev
+  optional: true
+- name: pkginfo
+  version: 1.11.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.11.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 6a3e4fb1396215d0d88b3cc2f09de412
+    sha256: 8eb347932cd42fffe9370e82a31cfbabc40b2149c2b049cf087d4a78f5b3b53c
+  category: dev
+  optional: true
+- name: platformdirs
+  version: 3.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  category: dev
+  optional: true
+- name: platformdirs
+  version: 3.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  category: dev
+  optional: true
+- name: platformdirs
+  version: 3.11.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
+  category: dev
+  optional: true
+- name: pluggy
+  version: 1.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
+    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
+  category: dev
+  optional: true
+- name: pluggy
+  version: 1.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
+    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
+  category: dev
+  optional: true
+- name: pluggy
+  version: 1.5.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
+    sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
+  category: dev
+  optional: true
+- name: pre-commit
+  version: 3.7.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cfgv: '>=2.0.0'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    virtualenv: '>=20.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  hash:
+    md5: 724bc4489c1174fc8e3233b0624fa51f
+    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+  category: dev
+  optional: true
+- name: pre-commit
+  version: 3.7.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cfgv: '>=2.0.0'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    virtualenv: '>=20.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  hash:
+    md5: 724bc4489c1174fc8e3233b0624fa51f
+    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+  category: dev
+  optional: true
+- name: pre-commit
+  version: 3.7.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    cfgv: '>=2.0.0'
+    identify: '>=1.0.0'
+    nodeenv: '>=0.11.1'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
+    virtualenv: '>=20.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  hash:
+    md5: 724bc4489c1174fc8e3233b0624fa51f
+    sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+  category: dev
+  optional: true
+- name: prompt-toolkit
+  version: 3.0.47
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    wcwidth: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+  hash:
+    md5: 1247c861065d227781231950e14fe817
+    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+  category: dev
+  optional: true
+- name: prompt-toolkit
+  version: 3.0.47
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    wcwidth: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+  hash:
+    md5: 1247c861065d227781231950e14fe817
+    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+  category: dev
+  optional: true
+- name: prompt-toolkit
+  version: 3.0.47
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+    wcwidth: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+  hash:
+    md5: 1247c861065d227781231950e14fe817
+    sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+  category: dev
+  optional: true
+- name: prompt_toolkit
+  version: 3.0.47
+  manager: conda
+  platform: linux-64
+  dependencies:
+    prompt-toolkit: '>=3.0.47,<3.0.48.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.47-hd8ed1ab_0.conda
+  hash:
+    md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
+    sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
+  category: dev
+  optional: true
+- name: prompt_toolkit
+  version: 3.0.47
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    prompt-toolkit: '>=3.0.47,<3.0.48.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.47-hd8ed1ab_0.conda
+  hash:
+    md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
+    sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
+  category: dev
+  optional: true
+- name: prompt_toolkit
+  version: 3.0.47
+  manager: conda
+  platform: win-64
+  dependencies:
+    prompt-toolkit: '>=3.0.47,<3.0.48.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.47-hd8ed1ab_0.conda
+  hash:
+    md5: 3e0c82ddcfe27eb4ae77f887cfd9f45b
+    sha256: 081ef6c9fbc280940c8d65683371795a8876cd4994b3fbdd0ccda7cc3ee87f74
+  category: dev
+  optional: true
 - name: psutil
   version: 5.9.8
   manager: conda
@@ -7118,6 +11605,42 @@ package:
     sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
   category: main
   optional: false
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: dev
+  optional: true
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: dev
+  optional: true
+- name: ptyprocess
+  version: 0.7.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  hash:
+    md5: 359eeb6536da0e687af562ed265ec263
+    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  category: dev
+  optional: true
 - name: pyarrow
   version: 16.1.0
   manager: conda
@@ -7328,10 +11851,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
     annotated-types: '>=0.4.0'
     pydantic-core: 2.18.4
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
   hash:
     md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
@@ -7343,10 +11866,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
     annotated-types: '>=0.4.0'
     pydantic-core: 2.18.4
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
   hash:
     md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
@@ -7621,8 +12144,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     cryptography: '>=41.0.5,<43'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
@@ -7634,8 +12157,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     cryptography: '>=41.0.5,<43'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
@@ -7769,6 +12292,60 @@ package:
     sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
   category: main
   optional: false
+- name: pytest
+  version: 8.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    colorama: ''
+    exceptiongroup: '>=1.0.0rc8'
+    iniconfig: ''
+    packaging: ''
+    pluggy: <2.0,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0f3f49c22c7ef3a1195fa61dad3c43be
+    sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
+  category: dev
+  optional: true
+- name: pytest
+  version: 8.2.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    colorama: ''
+    exceptiongroup: '>=1.0.0rc8'
+    iniconfig: ''
+    packaging: ''
+    pluggy: <2.0,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0f3f49c22c7ef3a1195fa61dad3c43be
+    sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
+  category: dev
+  optional: true
+- name: pytest
+  version: 8.2.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    colorama: ''
+    exceptiongroup: '>=1.0.0rc8'
+    iniconfig: ''
+    packaging: ''
+    pluggy: <2.0,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 0f3f49c22c7ef3a1195fa61dad3c43be
+    sha256: 00b7a49b31cf705b59edbd96219d8a67d2b9f51a913aa059fadd921b016965cb
+  category: dev
+  optional: true
 - name: python
   version: 3.11.9
   manager: conda
@@ -7929,6 +12506,55 @@ package:
     sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: main
   optional: false
+- name: python-gssapi
+  version: 1.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    decorator: ''
+    krb5: '>=1.21.2,<1.22.0a0'
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.8.3-py311h0820609_0.conda
+  hash:
+    md5: 84fe6d156520937fd9fc634a88e36a52
+    sha256: eabe93b34fe0b53d3ab1163c2d6904bdd6be22f078c84dc4c5309154fd002763
+  category: dev
+  optional: true
+- name: python-gssapi
+  version: 1.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    decorator: ''
+    krb5: '>=1.21.2,<1.22.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-gssapi-1.8.3-py311hadfd579_0.conda
+  hash:
+    md5: 2e922095f5b48586cbb2c08808cb5b7f
+    sha256: 29c7cf8578fb383366276427efbc2ae9f9bbb5da63b24b7bd56042386e6eb017
+  category: dev
+  optional: true
+- name: python-gssapi
+  version: 1.8.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    decorator: ''
+    krb5: '>=1.21.2,<1.22.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/python-gssapi-1.8.3-py311h8a3cce8_0.conda
+  hash:
+    md5: 384a5a0aee51e2d50e6da34fa9e8303a
+    sha256: b55107429fd288611929d83ac8949d1026b942953303b2beb6b410d803a399e4
+  category: dev
+  optional: true
 - name: python-tzdata
   version: '2024.1'
   manager: conda
@@ -8045,43 +12671,65 @@ package:
   category: main
   optional: false
 - name: pytorch
-  version: 2.3.1
+  version: 2.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    blas: '*'
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
     filelock: ''
+    fsspec: ''
     jinja2: ''
-    llvm-openmp: <16
-    mkl: '>=2018'
+    libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libstdcxx-ng: '>=12'
+    libtorch: 2.1.2.*
+    libuv: '>=1.48.0,<2.0a0'
     networkx: ''
+    nomkl: ''
+    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
-    pytorch-mutex: '1.0'
-    pyyaml: ''
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-2.3.1-py3.11_cpu_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.1.2-cpu_generic_py311h255d53b_4.conda
   hash:
-    md5: 1f7a250b13cfcd4f24562707187da2a1
-    sha256: e526af10fa35f9f39b5c356ee5060a29de132d2ccaea060da5d7b6c42c31f16d
+    md5: 740a2e20304b47db2c9a94f180d5be5d
+    sha256: 5822cc6f4cca0dd09899ef9f0e42ad9d1de4243f770d24b4389d545752ffec96
   category: main
   optional: false
 - name: pytorch
-  version: 2.2.2
+  version: 2.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     filelock: ''
+    fsspec: ''
     jinja2: ''
+    libabseil: '>=20240116.2,<20240117.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=16'
+    liblapack: '>=3.9.0,<4.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libtorch: 2.3.1.*
+    libuv: '>=1.48.0,<2.0a0'
+    llvm-openmp: '>=16.0.6'
     networkx: ''
+    nomkl: ''
+    numpy: '>=1.19,<3'
     python: '>=3.11,<3.12.0a0'
-    pyyaml: ''
+    python_abi: 3.11.*
+    sleef: '>=3.5.1,<4.0a0'
     sympy: ''
     typing_extensions: ''
-  url: https://conda.anaconda.org/pytorch/osx-arm64/pytorch-2.2.2-py3.11_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.3.1-cpu_generic_py311h82099cb_0.conda
   hash:
-    md5: cc4d0ea852c3f0e452b97cdc8a6eecfe
-    sha256: 61c94a761abf75ff132943be5c9f812dcc8fa6209ac74754574d1beacf6ef33f
+    md5: 66234dc95e9ce2ec73f62256a9fd7cbd
+    sha256: d2f8e12fc7d7f42bce69a802735ca20286978e4c4350a3e8af060e338b68965e
   category: main
   optional: false
 - name: pytorch
@@ -8107,15 +12755,28 @@ package:
     sha256: bb24d176b407f69b2e6ebb10059697affa02a05746073cbaf8717559cd4ec1d4
   category: main
   optional: false
-- name: pytorch-mutex
-  version: '1.0'
+- name: pytorch-cpu
+  version: 2.1.2
   manager: conda
   platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
+  dependencies:
+    pytorch: 2.1.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-cpu-2.1.2-cpu_generic_py311h9d11763_4.conda
   hash:
-    md5: 49565ed726991fd28d08a39885caa88d
-    sha256: d48c964188ca49660d750cffd73698d217cf94e694cd51987f9f186425435e76
+    md5: 6b72d7c404e09696c7d5d2e393879019
+    sha256: 71663b22bbab86f02784f63d8d2e29706dee02901818bdb0c2f79caf9a48cc4d
+  category: main
+  optional: false
+- name: pytorch-cpu
+  version: 2.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    pytorch: 2.3.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.3.1-cpu_generic_py311h7a66607_0.conda
+  hash:
+    md5: 62bfc974de77ce58645111e90ca1ebe1
+    sha256: fac6ca96f30d909916c45cfc2344af9a89ce0eef995cbb27c886302838fc4983
   category: main
   optional: false
 - name: pytorch-mutex
@@ -8165,6 +12826,74 @@ package:
     sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   category: main
   optional: false
+- name: pywin32
+  version: '306'
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py311h12c1d0e_2.conda
+  hash:
+    md5: 25df0fc55722ea1a94494f41302e2d1c
+    sha256: 79d942817bdaf384602113e5fcb9158dc45cae4044bed308918a5db97f141fdb
+  category: dev
+  optional: true
+- name: pywin32-ctypes
+  version: 0.2.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py311h1ea47a8_1.conda
+  hash:
+    md5: e1270294a55b716f9b76900340e8fc82
+    sha256: 75a80bda3a87ae9387e8860be7a5271a67846d8929fe8c99799ed40eb085130a
+  category: dev
+  optional: true
+- name: pywin32-on-windows
+  version: 0.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
+  hash:
+    md5: 2807a0becd1d986fe1ef9b7f8135f215
+    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
+  category: dev
+  optional: true
+- name: pywin32-on-windows
+  version: 0.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
+  hash:
+    md5: 2807a0becd1d986fe1ef9b7f8135f215
+    sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
+  category: dev
+  optional: true
+- name: pywin32-on-windows
+  version: 0.1.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2.7'
+    pywin32: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh07e9846_2.tar.bz2
+  hash:
+    md5: 91733394059b880d9cc0d010c20abda0
+    sha256: 09803b75cccc16d8586d2f41ea890658d165f4afc359973fa1c7904a2c140eae
+  category: dev
+  optional: true
 - name: pyyaml
   version: 6.0.1
   manager: conda
@@ -8384,10 +13113,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -8399,10 +13128,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -8557,6 +13286,90 @@ package:
     sha256: 8fb1e5eaf0e25b66be90d14caf87f3643451a0297bfdcbe376f3f49793bbbda4
   category: main
   optional: false
+- name: s3fs
+  version: 2024.5.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
+    fsspec: 2024.5.0
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 69f9f792aa777125aa284263067d1e97
+    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
+  category: dev
+  optional: true
+- name: s3fs
+  version: 2024.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
+    fsspec: 2024.5.0
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 69f9f792aa777125aa284263067d1e97
+    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
+  category: dev
+  optional: true
+- name: s3fs
+  version: 2024.5.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
+    fsspec: 2024.5.0
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 69f9f792aa777125aa284263067d1e97
+    sha256: 6631a94a7e2184733eff81e557ceaabf385f47538f9b3a77656b3fc3284a477d
+  category: dev
+  optional: true
+- name: s3transfer
+  version: 0.10.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a41cafc1fb653ce0e48b9310226e90fd
+    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+  category: dev
+  optional: true
+- name: s3transfer
+  version: 0.10.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a41cafc1fb653ce0e48b9310226e90fd
+    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+  category: dev
+  optional: true
+- name: s3transfer
+  version: 0.10.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: a41cafc1fb653ce0e48b9310226e90fd
+    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+  category: dev
+  optional: true
 - name: safetensors
   version: 0.4.3
   manager: conda
@@ -8662,6 +13475,88 @@ package:
     sha256: d692402c159ab3c23a722d3d168b013f21193ab01ce1a913582e6db7fe2f0ecf
   category: main
   optional: false
+- name: scmrepo
+  version: 3.3.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aiohttp-retry: '>=2.5.0'
+    asyncssh: '>=2.13.1,<3'
+    dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 633f93803051c8eae944808e40c17976
+    sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
+  category: dev
+  optional: true
+- name: scmrepo
+  version: 3.3.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aiohttp-retry: '>=2.5.0'
+    asyncssh: '>=2.13.1,<3'
+    dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 633f93803051c8eae944808e40c17976
+    sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
+  category: dev
+  optional: true
+- name: scmrepo
+  version: 3.3.5
+  manager: conda
+  platform: win-64
+  dependencies:
+    aiohttp-retry: '>=2.5.0'
+    asyncssh: '>=2.13.1,<3'
+    dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
+  hash:
+    md5: 633f93803051c8eae944808e40c17976
+    sha256: 630ded4a97ff4ce5f450d4ea17c3784835b2ec13d770b8f1e41de94c68ae3e6f
+  category: dev
+  optional: true
+- name: secretstorage
+  version: 3.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cryptography: ''
+    dbus: ''
+    jeepney: '>=0.6'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py311h38be061_2.conda
+  hash:
+    md5: 30a57eaa8e72cb0c2c84d6d7db32010c
+    sha256: 45e7d85a3663993e8bffdb7c6040561923c848e3262228b163042663caa4485e
+  category: dev
+  optional: true
 - name: seedbank
   version: 0.1.3
   manager: conda
@@ -8704,6 +13599,42 @@ package:
     sha256: 8ccddbb690e94c8f3ff342b30e1cff0ee82109d151defce6664406df0d6456e9
   category: main
   optional: false
+- name: semver
+  version: 3.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5efb3fccda53974aed800b6d575f72ed
+    sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
+  category: dev
+  optional: true
+- name: semver
+  version: 3.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5efb3fccda53974aed800b6d575f72ed
+    sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
+  category: dev
+  optional: true
+- name: semver
+  version: 3.0.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/semver-3.0.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 5efb3fccda53974aed800b6d575f72ed
+    sha256: 1cd164b2e80ea011b9272a66cc356773086885c447d6f62fed5f30f99bda3cb3
+  category: dev
+  optional: true
 - name: setuptools
   version: 70.0.0
   manager: conda
@@ -8740,6 +13671,114 @@ package:
     sha256: daa4638d288cfdf3b0ecea395d8efa25cafc4ebf4026464a36c797c84541d2be
   category: main
   optional: false
+- name: shellingham
+  version: 1.5.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: d08db09a552699ee9e7eec56b4eb3899
+    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+  category: dev
+  optional: true
+- name: shellingham
+  version: 1.5.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: d08db09a552699ee9e7eec56b4eb3899
+    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+  category: dev
+  optional: true
+- name: shellingham
+  version: 1.5.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: d08db09a552699ee9e7eec56b4eb3899
+    sha256: 3c49a0a101c41b7cf6ac05a1872d7a1f91f1b6d02eecb4a36b605a19517862bb
+  category: dev
+  optional: true
+- name: shortuuid
+  version: 1.0.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/shortuuid-1.0.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 241e47b9e59bd1689ba0c444306fe6b1
+    sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
+  category: dev
+  optional: true
+- name: shortuuid
+  version: 1.0.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/shortuuid-1.0.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 241e47b9e59bd1689ba0c444306fe6b1
+    sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
+  category: dev
+  optional: true
+- name: shortuuid
+  version: 1.0.13
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/shortuuid-1.0.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 241e47b9e59bd1689ba0c444306fe6b1
+    sha256: d6b7459267f43a3ea30291b168505de644cf07e026a83ce3ec7083dd8fad3b1b
+  category: dev
+  optional: true
+- name: shtab
+  version: 1.7.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5cf937409ac178717946edbfa82a5da
+    sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
+  category: dev
+  optional: true
+- name: shtab
+  version: 1.7.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5cf937409ac178717946edbfa82a5da
+    sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
+  category: dev
+  optional: true
+- name: shtab
+  version: 1.7.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5cf937409ac178717946edbfa82a5da
+    sha256: a258670d134b76f474dcd82dfddd8362298b26b4c98b979b8f08d0e891026c03
+  category: dev
+  optional: true
 - name: six
   version: 1.16.0
   manager: conda
@@ -8774,6 +13813,31 @@ package:
   hash:
     md5: e5f25f8dbc060e9a8d912e432202afc2
     sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  category: main
+  optional: false
+- name: sleef
+  version: 3.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _openmp_mutex: '>=4.5'
+    libgcc-ng: '>=9.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.5.1-h9b69904_2.tar.bz2
+  hash:
+    md5: 6e016cf4c525d04a7bd038cee53ad3fd
+    sha256: 77d644a16f682e6d01df63fe9d25315011393498b63cf08c0e548780e46b2170
+  category: main
+  optional: false
+- name: sleef
+  version: 3.5.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    llvm-openmp: '>=12.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.5.1-h156473d_2.tar.bz2
+  hash:
+    md5: bd159e7f04dbf79b06ed2bd37e112458
+    sha256: a3d20bed697aaababfcb53ca2011486cf5e44e20855142c170fa0826df5f952c
   category: main
   optional: false
 - name: smart-open
@@ -8851,6 +13915,42 @@ package:
     sha256: c298144d1b5035bcdaee2e2b363a7fc29d10707b38c62c717d6cfd0657b601d3
   category: main
   optional: false
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: dev
+  optional: true
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: dev
+  optional: true
+- name: smmap
+  version: 5.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 62f26a3d1387acee31322208f0cfa3e0
+    sha256: 23011cb3e064525bdb8787c75126a2e78d2344a72cd6773922006d1da1f2af16
+  category: dev
+  optional: true
 - name: snappy
   version: 1.2.0
   manager: conda
@@ -8890,6 +13990,42 @@ package:
     sha256: de02a222071d6a832ad3b790c8c977725161ad430ec694fd7b35769b6e1104b4
   category: main
   optional: false
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: dev
+  optional: true
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: dev
+  optional: true
+- name: sniffio
+  version: 1.3.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 490730480d76cf9c8f8f2849719c6e2b
+    sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
+  category: dev
+  optional: true
 - name: sortedcontainers
   version: 2.4.0
   manager: conda
@@ -8926,6 +14062,51 @@ package:
     sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
   category: main
   optional: false
+- name: sqltrie
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    attrs: ''
+    orjson: ''
+    pygtrie: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sqltrie-0.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b51fd2979cbda01f74ebaf7e4c2d632b
+    sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
+  category: dev
+  optional: true
+- name: sqltrie
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    attrs: ''
+    orjson: ''
+    pygtrie: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sqltrie-0.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b51fd2979cbda01f74ebaf7e4c2d632b
+    sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
+  category: dev
+  optional: true
+- name: sqltrie
+  version: 0.11.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    attrs: ''
+    orjson: ''
+    pygtrie: ''
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/sqltrie-0.11.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b51fd2979cbda01f74ebaf7e4c2d632b
+    sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
+  category: dev
+  optional: true
 - name: swifter
   version: 1.4.0
   manager: conda
@@ -9017,20 +14198,42 @@ package:
     sha256: cd488f0c44dec1f1f5d0c65144d144ccb5f8325c63bfcc60ab81e557d8bfc2b2
   category: main
   optional: false
-- name: tbb
-  version: 2021.12.0
+- name: tabulate
+  version: 0.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libhwloc: '>=2.10.0,<2.10.1.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h297d8ca_1.conda
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
   hash:
-    md5: 3ff978d8994f591818a506640c6a7071
-    sha256: ab706931ba80e8117995fc838509f044ccd1388a4cd7cc4ff1a55ea904bac723
-  category: main
-  optional: false
+    md5: 4759805cce2d914c38472f70bf4d8bcb
+    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
+  category: dev
+  optional: true
+- name: tabulate
+  version: 0.9.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: 4759805cce2d914c38472f70bf4d8bcb
+    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
+  category: dev
+  optional: true
+- name: tabulate
+  version: 0.9.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+  hash:
+    md5: 4759805cce2d914c38472f70bf4d8bcb
+    sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
+  category: dev
+  optional: true
 - name: tbb
   version: 2021.12.0
   manager: conda
@@ -9170,6 +14373,114 @@ package:
     sha256: bd8058dab28ba1499c8a2cde21ed54399baedc2a5b4da668ba1bb4e49f23b914
   category: main
   optional: false
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  category: dev
+  optional: true
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  category: dev
+  optional: true
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  category: dev
+  optional: true
+- name: tomli-w
+  version: 1.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 73506d1ab4202481841c68c169b7ef6c
+    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
+  category: dev
+  optional: true
+- name: tomli-w
+  version: 1.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 73506d1ab4202481841c68c169b7ef6c
+    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
+  category: dev
+  optional: true
+- name: tomli-w
+  version: 1.0.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 73506d1ab4202481841c68c169b7ef6c
+    sha256: efb5f78a224c4bb14aab04690c9912256ea12c3a8b8413e60167573ce1282b02
+  category: dev
+  optional: true
+- name: tomlkit
+  version: 0.12.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.5-pyha770c72_0.conda
+  hash:
+    md5: e5dde5caf905e9d95895e05f94967e14
+    sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
+  category: dev
+  optional: true
+- name: tomlkit
+  version: 0.12.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.5-pyha770c72_0.conda
+  hash:
+    md5: e5dde5caf905e9d95895e05f94967e14
+    sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
+  category: dev
+  optional: true
+- name: tomlkit
+  version: 0.12.5
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.12.5-pyha770c72_0.conda
+  hash:
+    md5: e5dde5caf905e9d95895e05f94967e14
+    sha256: 5117eff35992d896ca177dfffc08be8a9b3bf3d306ddc3d8bf4b699cdf1e1b79
+  category: dev
+  optional: true
 - name: toolz
   version: 0.12.1
   manager: conda
@@ -9358,6 +14669,165 @@ package:
     sha256: fd8921a42d1d94052c13a2365969a8598280b1986b117c8507abb39a50477711
   category: main
   optional: false
+- name: trove-classifiers
+  version: 2024.5.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: a887538e7f6697ed52a487dbaa0ebff5
+    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+  category: dev
+  optional: true
+- name: trove-classifiers
+  version: 2024.5.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: a887538e7f6697ed52a487dbaa0ebff5
+    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+  category: dev
+  optional: true
+- name: trove-classifiers
+  version: 2024.5.22
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  hash:
+    md5: a887538e7f6697ed52a487dbaa0ebff5
+    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+  category: dev
+  optional: true
+- name: typer
+  version: 0.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    typer-slim-standard: 0.12.3
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 10efd02b22c39c0a46312ef7cb16d237
+    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+  category: dev
+  optional: true
+- name: typer
+  version: 0.12.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+    typer-slim-standard: 0.12.3
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 10efd02b22c39c0a46312ef7cb16d237
+    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+  category: dev
+  optional: true
+- name: typer
+  version: 0.12.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+    typer-slim-standard: 0.12.3
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 10efd02b22c39c0a46312ef7cb16d237
+    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+  category: dev
+  optional: true
+- name: typer-slim
+  version: 0.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    click: '>=8.0.0'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: cf2c3a89f89644c53cadbfeb124914e9
+    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+  category: dev
+  optional: true
+- name: typer-slim
+  version: 0.12.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    click: '>=8.0.0'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: cf2c3a89f89644c53cadbfeb124914e9
+    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+  category: dev
+  optional: true
+- name: typer-slim
+  version: 0.12.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    click: '>=8.0.0'
+    python: '>=3.7'
+    typing_extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: cf2c3a89f89644c53cadbfeb124914e9
+    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+  category: dev
+  optional: true
+- name: typer-slim-standard
+  version: 0.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    rich: ''
+    shellingham: ''
+    typer-slim: 0.12.3
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+  hash:
+    md5: 8e56b98837d17e6ace4dc455d905709a
+    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+  category: dev
+  optional: true
+- name: typer-slim-standard
+  version: 0.12.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    rich: ''
+    shellingham: ''
+    typer-slim: 0.12.3
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+  hash:
+    md5: 8e56b98837d17e6ace4dc455d905709a
+    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+  category: dev
+  optional: true
+- name: typer-slim-standard
+  version: 0.12.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    rich: ''
+    shellingham: ''
+    typer-slim: 0.12.3
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+  hash:
+    md5: 8e56b98837d17e6ace4dc455d905709a
+    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+  category: dev
+  optional: true
 - name: typing-extensions
   version: 4.12.2
   manager: conda
@@ -9474,6 +14944,54 @@ package:
     sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
   category: main
   optional: false
+- name: ukkonen
+  version: 1.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cffi: ''
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311h9547e67_4.conda
+  hash:
+    md5: 586da7df03b68640de14dc3e8bcbf76f
+    sha256: c2d33e998f637b594632eba3727529171a06eb09896e36aa42f1ebcb03779472
+  category: dev
+  optional: true
+- name: ukkonen
+  version: 1.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cffi: ''
+    libcxx: '>=15.0.7'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py311he4fd1f5_4.conda
+  hash:
+    md5: 5d5ab5c5af32931e03608034f4a5fd75
+    sha256: 384fc81a34e248019d43a115386f77859ab63e0e6f12dade486d76359703743f
+  category: dev
+  optional: true
+- name: ukkonen
+  version: 1.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    cffi: ''
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py311h005e61a_4.conda
+  hash:
+    md5: d9988836cc20c90e05901ab05962f496
+    sha256: ef774047df25201a6425fe1ec194505a3cac9ba02e96953360442f59364d12b3
+  category: dev
+  optional: true
 - name: urllib3
   version: 1.26.19
   manager: conda
@@ -9495,6 +15013,7 @@ package:
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -9508,6 +15027,7 @@ package:
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -9617,6 +15137,123 @@ package:
     sha256: af3cfa347e3d7c1277e9b964b0849a9a9f095bff61836cb3c3a89862fbc32e17
   category: main
   optional: false
+- name: vine
+  version: 5.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: af71debe5f1819b065c0ba2b062ae81c
+    sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
+  category: dev
+  optional: true
+- name: vine
+  version: 5.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: af71debe5f1819b065c0ba2b062ae81c
+    sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
+  category: dev
+  optional: true
+- name: vine
+  version: 5.1.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/vine-5.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: af71debe5f1819b065c0ba2b062ae81c
+    sha256: 95a819731659de391ee084d68a1bdee56a5a16d0db95783c6cf115638d372215
+  category: dev
+  optional: true
+- name: virtualenv
+  version: 20.26.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    distlib: <1,>=0.3.7
+    filelock: <4,>=3.12.2
+    platformdirs: <5,>=3.9.1
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7d36e7a485ea2f5829408813bdbbfb38
+    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
+  category: dev
+  optional: true
+- name: virtualenv
+  version: 20.26.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    distlib: <1,>=0.3.7
+    filelock: <4,>=3.12.2
+    platformdirs: <5,>=3.9.1
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7d36e7a485ea2f5829408813bdbbfb38
+    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
+  category: dev
+  optional: true
+- name: virtualenv
+  version: 20.26.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    distlib: <1,>=0.3.7
+    filelock: <4,>=3.12.2
+    platformdirs: <5,>=3.9.1
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7d36e7a485ea2f5829408813bdbbfb38
+    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
+  category: dev
+  optional: true
+- name: voluptuous
+  version: 0.14.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: d61310a459c334702a00a2b7f4fc534c
+    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
+  category: dev
+  optional: true
+- name: voluptuous
+  version: 0.14.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: d61310a459c334702a00a2b7f4fc534c
+    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
+  category: dev
+  optional: true
+- name: voluptuous
+  version: 0.14.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: d61310a459c334702a00a2b7f4fc534c
+    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
+  category: dev
+  optional: true
 - name: vs2015_runtime
   version: 14.40.33810
   manager: conda
@@ -9629,6 +15266,78 @@ package:
     sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
   category: main
   optional: false
+- name: wcwidth
+  version: 0.2.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 68f0738df502a14213624b288c60c9ad
+    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  category: dev
+  optional: true
+- name: wcwidth
+  version: 0.2.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 68f0738df502a14213624b288c60c9ad
+    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  category: dev
+  optional: true
+- name: wcwidth
+  version: 0.2.13
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 68f0738df502a14213624b288c60c9ad
+    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
+  category: dev
+  optional: true
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  category: dev
+  optional: true
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  category: dev
+  optional: true
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  category: dev
+  optional: true
 - name: wheel
   version: 0.43.0
   manager: conda
@@ -9721,6 +15430,117 @@ package:
     sha256: e8209b3ebdde15834b59101fd14a7f293d868d2fbad2dcd634357cc3406f1052
   category: main
   optional: false
+- name: xorg-kbproto
+  version: 1.0.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  hash:
+    md5: 4b230e8381279d76131116660f5a241a
+    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  category: dev
+  optional: true
+- name: xorg-kbproto
+  version: 1.0.7
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-kbproto-1.0.7-hcd874cb_1002.tar.bz2
+  hash:
+    md5: 8d11c1dac4756ca57e78c1bfe173bba4
+    sha256: 5b16e1ca1ecc0d2907f236bc4d8e6ecfd8417db013c862a01afb7f9d78e48c09
+  category: dev
+  optional: true
+- name: xorg-libice
+  version: 1.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+  hash:
+    md5: b462a33c0be1421532f28bfe8f4a7514
+    sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
+  category: dev
+  optional: true
+- name: xorg-libice
+  version: 1.1.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+    m2w64-gcc-libs-core: ''
+    xorg-libx11: '>=1.8.4,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libice-1.1.1-hcd874cb_0.conda
+  hash:
+    md5: 5271e3af4791170e2c55d02818366916
+    sha256: 353e07e311eb10e934f03e0123d0f05d9b3770a70b0c3993e6d11cf74d85689f
+  category: dev
+  optional: true
+- name: xorg-libsm
+  version: 1.2.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libuuid: '>=2.38.1,<3.0a0'
+    xorg-libice: '>=1.1.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+  hash:
+    md5: 93ee23f12bc2e684548181256edd2cf6
+    sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
+  category: dev
+  optional: true
+- name: xorg-libsm
+  version: 1.2.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+    m2w64-gcc-libs-core: ''
+    xorg-libice: '>=1.1.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libsm-1.2.4-hcd874cb_0.conda
+  hash:
+    md5: 25926681339df15918243d9a7cec25a1
+    sha256: 3a8cc151142c379d3ec3ec4420395d3a273873d3a45a94cd3038d143f5a519e8
+  category: dev
+  optional: true
+- name: xorg-libx11
+  version: 1.8.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+    xorg-kbproto: ''
+    xorg-xextproto: '>=7.3.0,<8.0a0'
+    xorg-xproto: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+  hash:
+    md5: 077b6e8ad6a3ddb741fce2496dd01bec
+    sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
+  category: dev
+  optional: true
+- name: xorg-libx11
+  version: 1.8.9
+  manager: conda
+  platform: win-64
+  dependencies:
+    libxcb: '>=1.15,<1.16.0a0'
+    m2w64-gcc-libs: ''
+    m2w64-gcc-libs-core: ''
+    xorg-kbproto: ''
+    xorg-xextproto: '>=7.3.0,<8.0a0'
+    xorg-xproto: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.9-hefa74cf_0.conda
+  hash:
+    md5: 3672e991346895f332af1ebc60b8bca9
+    sha256: 15217b9180ff7d6840762363647fabcb79636517454d2c05dd69cb3fc38a1001
+  category: dev
+  optional: true
 - name: xorg-libxau
   version: 1.0.11
   manager: conda
@@ -9792,6 +15612,144 @@ package:
     sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
   category: main
   optional: false
+- name: xorg-libxext
+  version: 1.3.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    xorg-libx11: '>=1.7.2,<2.0a0'
+    xorg-xextproto: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  hash:
+    md5: 82b6df12252e6f32402b96dacc656fec
+    sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  category: dev
+  optional: true
+- name: xorg-libxext
+  version: 1.3.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+    xorg-libx11: '>=1.7.2,<2.0a0'
+    xorg-xextproto: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxext-1.3.4-hcd874cb_2.conda
+  hash:
+    md5: 2aa695ac3c56193fd8d526e3b511e021
+    sha256: 829320f05866ea1cc51924828427f215f4d0db093e748a662e3bb68b764785a4
+  category: dev
+  optional: true
+- name: xorg-libxpm
+  version: 3.5.17
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+    m2w64-gcc-libs-core: ''
+    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-libxt: '>=1.3.0,<2.0a0'
+    xorg-xextproto: '>=7.3.0,<8.0a0'
+    xorg-xproto: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxpm-3.5.17-hcd874cb_0.conda
+  hash:
+    md5: 029be9b667bf3896fa28bc32adb1bfc3
+    sha256: d5cc2f026658e8b85679813bff35c16c857f873ba02489e6eb6e30d5865dacc4
+  category: dev
+  optional: true
+- name: xorg-libxrender
+  version: 0.9.11
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-renderproto: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+  hash:
+    md5: ed67c36f215b310412b2af935bf3e530
+    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
+  category: dev
+  optional: true
+- name: xorg-libxt
+  version: 1.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+    m2w64-gcc-libs-core: ''
+    xorg-kbproto: ''
+    xorg-libice: '>=1.1.1,<2.0a0'
+    xorg-libsm: '>=1.2.4,<2.0a0'
+    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-xproto: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxt-1.3.0-hcd874cb_1.conda
+  hash:
+    md5: 511a29edd2ff3d973f63e54f19dcc06e
+    sha256: d513e0c627f098ef6655ce188eca79a672eaf763b0bbf37b228cb46dc82a66ca
+  category: dev
+  optional: true
+- name: xorg-renderproto
+  version: 0.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+  hash:
+    md5: 06feff3d2634e3097ce2fe681474b534
+    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+  category: dev
+  optional: true
+- name: xorg-xextproto
+  version: 7.3.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  hash:
+    md5: bce9f945da8ad2ae9b1d7165a64d0f87
+    sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  category: dev
+  optional: true
+- name: xorg-xextproto
+  version: 7.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-xextproto-7.3.0-hcd874cb_1003.conda
+  hash:
+    md5: 6e6c2639620e436bddb7c040cd4f3adb
+    sha256: 04c0a08fd34fa33406c20f729e8f9cc40e8fd898072b952a5c14280fcf26f2e6
+  category: dev
+  optional: true
+- name: xorg-xproto
+  version: 7.0.31
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  hash:
+    md5: b4a4381d54784606820704f7b5f05a15
+    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  category: dev
+  optional: true
+- name: xorg-xproto
+  version: 7.0.31
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: ''
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-xproto-7.0.31-hcd874cb_1007.tar.bz2
+  hash:
+    md5: 88f3c65d2ad13826a9e0b162063be023
+    sha256: b84cacba8479fa14199c9255fb62e005cacc619e90198c53b1653973709ec331
+  category: dev
+  optional: true
 - name: xxhash
   version: 0.8.2
   manager: conda
@@ -9986,6 +15944,45 @@ package:
     sha256: 647a7f6395be44b82a3dd4ad58d02fd1ce56cca19083061cbb118f788c0f31e5
   category: main
   optional: false
+- name: zc.lockfile
+  version: 3.0.post1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=2'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5de65315ad9643b7fb67e985fbb54a9
+    sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
+  category: dev
+  optional: true
+- name: zc.lockfile
+  version: 3.0.post1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=2'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5de65315ad9643b7fb67e985fbb54a9
+    sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
+  category: dev
+  optional: true
+- name: zc.lockfile
+  version: 3.0.post1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2'
+    setuptools: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
+  hash:
+    md5: c5de65315ad9643b7fb67e985fbb54a9
+    sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
+  category: dev
+  optional: true
 - name: zict
   version: 3.0.0
   manager: conda
@@ -10058,6 +16055,93 @@ package:
     sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
   category: main
   optional: false
+- name: zlib
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libzlib: 1.3.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+  hash:
+    md5: 9653f1bf3766164d0e65fa723cabbc54
+    sha256: cee16ab07a11303de721915f0a269e8c7a54a5c834aa52f74b1cc3a59000ade8
+  category: dev
+  optional: true
+- name: zlib
+  version: 1.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: 1.3.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-hfb2fe0b_1.conda
+  hash:
+    md5: f27e021db7862b6ddbc1d3578f10d883
+    sha256: 87360c2dc662916aac37cf01e53324b4f4f78db6f399220818076752b093ede5
+  category: dev
+  optional: true
+- name: zlib
+  version: 1.3.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    libzlib: 1.3.1
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
+  hash:
+    md5: f8e0a35bf6df768ad87ed7bbbc36ab04
+    sha256: 76409556e6c7cb91991cd94d7fc853c9272c2872bd7e3573ff35eb33d6fca5be
+  category: dev
+  optional: true
+- name: zstandard
+  version: 0.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cffi: '>=1.8'
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py311hd4cff14_0.tar.bz2
+  hash:
+    md5: 056b3271f46abaa4673c8c6783283a07
+    sha256: 8aac43cc4fbdcc420fe8a22c764b67f6ac9168b103bfd10d79a82b748304ddf6
+  category: dev
+  optional: true
+- name: zstandard
+  version: 0.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cffi: '>=1.8'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py311he2be06e_0.tar.bz2
+  hash:
+    md5: ece21cb47a93c985aa4b44219c4c8c8b
+    sha256: 43eaee70cd406468d96d1643b75d16e0da3955a9c1d37056767134b91b61d515
+  category: dev
+  optional: true
+- name: zstandard
+  version: 0.19.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    cffi: '>=1.8'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.*
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vs2015_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.19.0-py311ha68e1ae_0.tar.bz2
+  hash:
+    md5: 94114ffe0cad9e1e704e2c0015c8aa87
+    sha256: c687a7d884e98c69f4f1fee8cb9949157bba7c76a54176edeb3262c156e08e71
+  category: dev
+  optional: true
 - name: zstd
   version: 1.5.6
   manager: conda
@@ -10100,49 +16184,19 @@ package:
     sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
   category: main
   optional: false
-- name: annotated-types
-  version: 0.7.0
-  manager: pip
-  platform: linux-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-  hash:
-    sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
-  category: main
-  optional: false
-- name: annotated-types
-  version: 0.7.0
-  manager: pip
-  platform: osx-arm64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-  hash:
-    sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
-  category: main
-  optional: false
-- name: annotated-types
-  version: 0.7.0
-  manager: pip
-  platform: win-64
-  dependencies: {}
-  url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
-  hash:
-    sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
-  category: main
-  optional: false
 - name: poprox-concepts
   version: 0.0.1
   manager: pip
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: c009caed112543095a0a7167d944feca1f96e9da
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -10150,13 +16204,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: c009caed112543095a0a7167d944feca1f96e9da
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -10164,83 +16218,11 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: c009caed112543095a0a7167d944feca1f96e9da
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
-  optional: false
-- name: pydantic
-  version: 2.7.4
-  manager: pip
-  platform: linux-64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.18.4
-    typing-extensions: '>=4.6.1'
-  url: https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl
-  hash:
-    sha256: ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.7.4
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.18.4
-    typing-extensions: '>=4.6.1'
-  url: https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl
-  hash:
-    sha256: ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
-  category: main
-  optional: false
-- name: pydantic
-  version: 2.7.4
-  manager: pip
-  platform: win-64
-  dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.18.4
-    typing-extensions: '>=4.6.1'
-  url: https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl
-  hash:
-    sha256: ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0
-  category: main
-  optional: false
-- name: pydantic-core
-  version: 2.18.4
-  manager: pip
-  platform: linux-64
-  dependencies:
-    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
-  url: https://files.pythonhosted.org/packages/d6/4b/51141c5ea1874e7204efac93899eefcb690ff6772a92c9a6521b32e5b71f/pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  hash:
-    sha256: 0fbbdc827fe5e42e4d196c746b890b3d72876bdbf160b0eafe9f0334525119c8
-  category: main
-  optional: false
-- name: pydantic-core
-  version: 2.18.4
-  manager: pip
-  platform: osx-arm64
-  dependencies:
-    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
-  url: https://files.pythonhosted.org/packages/6c/a2/229dbee765ce711cd42c056da497ca26f7267384362e6767ab3bcdafca79/pydantic_core-2.18.4-cp311-cp311-macosx_11_0_arm64.whl
-  hash:
-    sha256: b2ebef0e0b4454320274f5e83a41844c63438fdc874ea40a8b5b4ecb7693f1c4
-  category: main
-  optional: false
-- name: pydantic-core
-  version: 2.18.4
-  manager: pip
-  platform: win-64
-  dependencies:
-    typing-extensions: '>=4.6.0,<4.7.0 || >4.7.0'
-  url: https://files.pythonhosted.org/packages/00/29/62236e5e19b92c1b908089589300e5834a8fcb5f870ae4f2a08b17782142/pydantic_core-2.18.4-cp311-none-win_amd64.whl
-  hash:
-    sha256: 8a7164fe2005d03c64fd3b85649891cd4953a8de53107940bf272500ba8a788b
-  category: main
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -240,7 +240,7 @@ def generate_recommendations(
         for interest in interest_profile.onboarding_topics:
             topic_preferences[interest.entity_name] = max(interest.preference - 1, 0)
 
-        for topic, click_count in interest_profile.click_topics.items():
+        for topic, click_count in interest_profile.click_topic_counts.items():
             topic_preferences[topic] = click_count
 
         normalized_topic_prefs = normalized_topic_count(topic_preferences)
@@ -350,7 +350,7 @@ def select_articles(
     _, todays_article_vectors = build_article_embeddings(todays_article_features, MODEL, DEVICE)
     similarity_matrix = compute_similarity_matrix(todays_article_vectors)
 
-    interest_profile.click_topics = user_topic_preference(past_articles, interest_profile.click_history)
+    interest_profile.click_topic_counts = user_topic_preference(past_articles, interest_profile.click_history)
 
     recommendations = {}
     account_id = click_history.account_id

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -16,7 +16,7 @@ from safetensors.torch import load_file
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
-from poprox_concepts import Article, ClickHistory
+from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
 from poprox_recommender.topics import extract_general_topic
@@ -170,7 +170,7 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
     return S
 
 
-def pfar_diversification(user, rewards, articles, user_preference_dict, lamb, tau, topk):
+def pfar_diversification(rewards, articles, topic_preferences, lamb, tau, topk):
     # p(v|u) + lamb*tau \sum_{d \in D} P(d|u)I{v \in d} \prod_{i \in S} I{i \in d} for each user
 
     S = []  # final recommendation LIST[candidate index]
@@ -198,8 +198,8 @@ def pfar_diversification(user, rewards, articles, user_preference_dict, lamb, ta
                     break
 
             for topic in candidate_topic:
-                if topic in user_preference_dict[user]:
-                    summation += user_preference_dict[user][topic]
+                if topic in topic_preferences:
+                    summation += topic_preferences[topic]
 
             PFAR_i = reward_i + lamb * tau * summation * product
 
@@ -219,28 +219,25 @@ def generate_recommendations(
     articles,
     article_vectors,
     similarity_matrix,
-    user_embeddings,
+    user_embedding,
+    topics,
     num_slots: int = 10,
     algo_params: dict[str, Any] | None = None,
-):
+) -> list[Article]:
     algo_params = algo_params or {}
     theta = float(algo_params.get("theta", 0.8))
     lamb = float(algo_params.get("pfar_lamb", 1))
     tau = float(algo_params.get("pfar_tau", 1))
     diversify = str(algo_params.get("diversity_algo", "mmr"))
 
-    recommendations = {}
-    for user, user_vector in user_embeddings.items():
-        pred = model.get_prediction(article_vectors, user_vector.squeeze())
-        pred = pred.cpu().detach().numpy()
-        if diversify == "mmr":
-            recs = mmr_diversification(pred, similarity_matrix, theta=theta, topk=num_slots)
-        if diversify == "pfar":
-            user_preference_dict = algo_params.get("user_topic_preference")
-            recs = pfar_diversification(user, pred, articles, user_preference_dict, lamb, tau, topk=num_slots)
+    pred = model.get_prediction(article_vectors, user_embedding.squeeze())
+    pred = pred.cpu().detach().numpy()
+    if diversify == "mmr":
+        recs = mmr_diversification(pred, similarity_matrix, theta=theta, topk=num_slots)
+    if diversify == "pfar":
+        recs = pfar_diversification(pred, articles, topics, lamb, tau, topk=num_slots)
 
-        recommendations[user] = [articles[int(rec)] for rec in recs]
-    return recommendations
+    return [articles[int(rec)] for rec in recs]
 
 
 def select_with_model(
@@ -248,7 +245,7 @@ def select_with_model(
     todays_article_vectors: list[Article],
     article_similarity_matrix,
     past_article_features,
-    click_history: ClickHistory,
+    interest_profile: InterestProfile,
     model,
     model_device,
     num_slots: int = 10,
@@ -258,8 +255,12 @@ def select_with_model(
     # Build embedding tables
     past_article_embeddings, _ = build_article_embeddings(past_article_features, model, model_device)
 
-    user_embeddings = build_user_embedding(
-        click_history, past_article_embeddings, model, model_device, max_clicks_per_user
+    user_embedding = build_user_embedding(
+        interest_profile.click_history,
+        past_article_embeddings,
+        model,
+        model_device,
+        max_clicks_per_user,
     )
 
     recommendations = generate_recommendations(
@@ -267,7 +268,8 @@ def select_with_model(
         todays_articles,
         todays_article_vectors,
         article_similarity_matrix,
-        user_embeddings,
+        user_embedding,
+        interest_profile.onboarding_topics,
         num_slots=num_slots,
         algo_params=algo_params,
     )
@@ -300,40 +302,33 @@ def normalized_topic_count(topic_counts: dict[str, int]):
     return normalized_counts
 
 
-def user_topic_preference(past_articles: list[Article], click_histories: list[ClickHistory]):
+def user_topic_preference(past_articles: list[Article], click_history: ClickHistory) -> dict[str, int]:
     """Topic preference only based on click history"""
-    user_preference_dict = {}
-    for click_history in click_histories:
-        account_id = click_history.account_id
-        clicked_articles = click_history.article_ids  # List[UUID]
+    clicked_articles = click_history.article_ids  # List[UUID]
 
-        topic_count_dict = defaultdict(int)
+    topic_count_dict = defaultdict(int)
 
-        for article_id in clicked_articles:
-            clicked_topics = find_topic(past_articles, article_id)
-            for topic in clicked_topics:
-                topic_count_dict[topic] += 1
+    for article_id in clicked_articles:
+        clicked_topics = find_topic(past_articles, article_id)
+        for topic in clicked_topics:
+            topic_count_dict[topic] += 1
 
-        user_preference_dict[str(account_id)] = normalized_topic_count(topic_count_dict)
-    return user_preference_dict
+    return normalized_topic_count(topic_count_dict)
 
 
 def select_articles(
     todays_articles: list[Article],
     past_articles: list[Article],
-    click_histories: list[ClickHistory],
+    interest_profile: InterestProfile,
     num_slots: int,
     algo_params: dict[str, Any] | None = None,
 ) -> dict[UUID, list[Article]]:
+    click_history = interest_profile.click_history
+
     # Transform news to model features
     todays_article_features = transform_article_features(todays_articles, TOKENIZER)
 
-    # Extract the set of articles that have actually been clicked
-    clicked_article_ids = set()
-    for history in click_histories:
-        clicked_article_ids.update(history.article_ids)
-
-    clicked_articles = [article for article in past_articles if article.article_id in clicked_article_ids]
+    clicked_articles = filter(lambda a: a.article_id in set(click_history.article_ids), past_articles)
 
     # Convert clicked article attributes into model features
     past_article_features = transform_article_features(
@@ -344,25 +339,24 @@ def select_articles(
     # Compute today's article similarity matrix
     _, todays_article_vectors = build_article_embeddings(todays_article_features, MODEL, DEVICE)
     similarity_matrix = compute_similarity_matrix(todays_article_vectors)
-    user_preference_dict = user_topic_preference(past_articles, click_histories)  # noqa: F841
+    user_click_topics = user_topic_preference(past_articles, interest_profile.click_history)  # noqa: F841
 
     recommendations = {}
-    for click_history in click_histories:
-        account_id = click_history.account_id
-        if MODEL and TOKENIZER and click_history.article_ids:
-            user_recs = select_with_model(
-                todays_articles,
-                todays_article_vectors,
-                similarity_matrix,
-                past_article_features,
-                click_history,
-                MODEL,
-                DEVICE,
-                num_slots=num_slots,
-                algo_params=algo_params,
-            )
-            recommendations[account_id] = user_recs[str(account_id)]
-        else:
-            recommendations[account_id] = random.sample(todays_articles, num_slots)
+    account_id = click_history.account_id
+    if MODEL and TOKENIZER and click_history.article_ids:
+        user_recs = select_with_model(
+            todays_articles,
+            todays_article_vectors,
+            similarity_matrix,
+            past_article_features,
+            interest_profile,
+            MODEL,
+            DEVICE,
+            num_slots=num_slots,
+            algo_params=algo_params,
+        )
+        recommendations[account_id] = user_recs
+    else:
+        recommendations[account_id] = random.sample(todays_articles, num_slots)
 
     return recommendations

--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -32,7 +32,7 @@ def generate_recs(event, context):
     recommendations = select_articles(
         req.todays_articles,
         req.past_articles,
-        req.click_histories,
+        req.interest_profile,
         req.num_recs,
         algo_params,
     )

--- a/src/poprox_recommender/topics.py
+++ b/src/poprox_recommender/topics.py
@@ -2,28 +2,12 @@ from torch.nn.functional import cosine_similarity
 from transformers import AutoModel, AutoTokenizer
 
 from poprox_concepts import Article
-
-general_topics = [
-    "US News",
-    "World News",
-    "Politics",
-    "Business",
-    "Entertainment",
-    "Sports",
-    "Health",
-    "Science",
-    "Tech ",
-    "Lifestyle",
-    "Religion",
-    "Climate",
-    "Education",
-    "Oddities",
-]
+from poprox_concepts.domain.topics import GENERAL_TOPICS
 
 
 def extract_general_topic(article: Article):
     article_topics = set([mention.entity.name for mention in article.mentions])
-    return article_topics.intersection(set(general_topics))
+    return article_topics.intersection(GENERAL_TOPICS)
 
 
 def classify_news_topic(model, tokenizer, general_topics, topic):
@@ -59,7 +43,7 @@ def match_news_topics_to_general(articles: list[Article]):
         article_topic = set()
         for topic in news_topics:
             if topic not in topic_matched_dict:
-                matched_general_topics = classify_news_topic(model, tokenizer, general_topics, topic)
+                matched_general_topics = classify_news_topic(model, tokenizer, GENERAL_TOPICS, topic)
                 topic_matched_dict[topic] = matched_general_topics  # again, we can store this into db
                 for t in matched_general_topics:
                     article_topic.add(t)

--- a/tests/basic-request.json
+++ b/tests/basic-request.json
@@ -15,13 +15,14 @@
             "url": "url 2"
         }
     ],
-    "click_histories": [
-        {
+    "interest_profile": {
+        "click_history": {
             "account_id": "977a3c88-937a-46fb-bbfe-94dc5dcb68c8",
             "article_ids": [
                 "e7605f12-a37a-4326-bf3c-3f9b72d0738d"
             ]
-        }
-    ],
+        },
+        "onboarding_topics": []
+    },
     "num_recs": 1
 }

--- a/tests/test_pfar.py
+++ b/tests/test_pfar.py
@@ -10,7 +10,7 @@ from safetensors.torch import load_file
 
 from poprox_concepts import Article, ClickHistory
 from poprox_recommender.default import select_articles, user_topic_preference
-from poprox_recommender.topics import extract_general_topic, general_topics, match_news_topics_to_general
+from poprox_recommender.topics import GENERAL_TOPICS, extract_general_topic, match_news_topics_to_general
 
 try:
     import pytest
@@ -51,7 +51,7 @@ def test_extract_generalized_topic():
     for article in todays_articles:
         generalized_topics = extract_general_topic(article)
         for topic in generalized_topics:
-            assert topic in general_topics
+            assert topic in GENERAL_TOPICS
 
 
 def load_model(device_name=None):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -20,7 +20,7 @@ def test_direct_basic_request():
     recs = select_articles(
         req.todays_articles,
         req.past_articles,
-        req.click_histories,
+        req.interest_profile,
         req.num_recs,
     )
     # do we get recommendations?


### PR DESCRIPTION
Companion PRs:
* https://github.com/CCRI-POPROX/poprox-concepts/pull/6
* https://github.com/CCRI-POPROX/poprox-platform/pull/78

This combines onboarding selections and the topics of clicked articles into a single topic distribution. The five-point scale presented during onboarding is adjusted so that the lowest interest level counts as zero clicks and the highest counts as four clicks, which are then summed with the topics from clicked articles and then normalized before being passed into the PFAR implementation.