### PR TITLE
Add script to automate reliable relocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ To get the data and models, there are two steps:
 1.  Obtain the credentials for the S3 bucket and put them in `.env` (the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
 2.  `dvc pull`
 
+### Dependency Updates
+
+If you update the dependencies in poprox-recommender, or add code that requires
+a newer version of `poprox-concepts`, you need to regenerate the lock file:
+
+```console
+./dev/update-dep-lock.sh
+```
+
+> [!NOTE]
+> If you are trying to re-lock the dependencies on Windows, you should run the
+> shell script from within a Git Bash or MSYS2 environment.
+
 ## Local Endpoint Development
 
 Local endpoint development also requires some Node-based tools in addition to the tools above:

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -15,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    win-64: 6c39a44d5438e1d79a4ac8a3e8c23955965213027b7de274e4a3396f9c549f2d
-    linux-64: 1d9d1e71aad10c004459c5d8d5fb9bd9122069605cdd1b2a6051985b0cc81d1b
-    osx-arm64: 3abb80be54e0525ff04b6ec2344661ed714e6733003e259d9851727a0d8e222c
+    win-64: 59e314b4ba0bca5d657dd648996370be325c9d922104fafd8f61025611d90cec
+    linux-64: ab396931007a24d1a35129393f752681009e22db348a4d4fb86c190819aa70f3
+    osx-arm64: bbe4bf4d9b7d6d8d0857e0fea55550ea3a030419e58ff130c77dcb72e86d8baa
   channels:
   - url: pytorch
     used_env_vars: []
@@ -329,8 +329,8 @@ package:
   hash:
     md5: 7e9f4612544c8edbfd6afad17f1bd045
     sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -342,8 +342,8 @@ package:
   hash:
     md5: 7e9f4612544c8edbfd6afad17f1bd045
     sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: annotated-types
   version: 0.7.0
   manager: conda
@@ -355,8 +355,8 @@ package:
   hash:
     md5: 7e9f4612544c8edbfd6afad17f1bd045
     sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: antlr-python-runtime
   version: 4.9.3
   manager: conda
@@ -1893,13 +1893,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    msgpack-python: '>=0.5.2'
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: a661c39e223bf3038b38126b0bbf43d9
-    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
+    md5: a54e449940b3e4bb2129b8daae0c1f65
+    sha256: 8d8dadbea881c690037e432075357ad6629f7b050e129a5944a0402d674fd754
   category: dev
   optional: true
 - name: cachecontrol
@@ -1908,12 +1908,12 @@ package:
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-    msgpack-python: '>=0.5.2'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
+    msgpack-python: '>=0.5.2,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: a661c39e223bf3038b38126b0bbf43d9
-    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
+    md5: a54e449940b3e4bb2129b8daae0c1f65
+    sha256: 8d8dadbea881c690037e432075357ad6629f7b050e129a5944a0402d674fd754
   category: dev
   optional: true
 - name: cachecontrol
@@ -1922,12 +1922,12 @@ package:
   platform: win-64
   dependencies:
     python: '>=3.7'
-    msgpack-python: '>=0.5.2'
     requests: '>=2.16.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_0.conda
+    msgpack-python: '>=0.5.2,<2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: a661c39e223bf3038b38126b0bbf43d9
-    sha256: 3318732d60456c5ecc0db14a7343a320ea88e05ae168aea4164d7f9ec7907142
+    md5: a54e449940b3e4bb2129b8daae0c1f65
+    sha256: 8d8dadbea881c690037e432075357ad6629f7b050e129a5944a0402d674fd754
   category: dev
   optional: true
 - name: cachecontrol-with-filecache
@@ -1938,10 +1938,10 @@ package:
     cachecontrol: 0.14.0
     filelock: '>=3.8.0'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
-    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
+    md5: 42a12b0b21d64b36a9ab9a24a04eb910
+    sha256: 482d0f3ce8dad6b881f76620ee18152755c61bb968039dcbc0ad45689c70b0d5
   category: dev
   optional: true
 - name: cachecontrol-with-filecache
@@ -1952,10 +1952,10 @@ package:
     python: '>=3.7'
     filelock: '>=3.8.0'
     cachecontrol: 0.14.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
-    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
+    md5: 42a12b0b21d64b36a9ab9a24a04eb910
+    sha256: 482d0f3ce8dad6b881f76620ee18152755c61bb968039dcbc0ad45689c70b0d5
   category: dev
   optional: true
 - name: cachecontrol-with-filecache
@@ -1966,10 +1966,10 @@ package:
     python: '>=3.7'
     filelock: '>=3.8.0'
     cachecontrol: 0.14.0
-  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 4c08fa6e7d1d3f124ad815e21b2210e9
-    sha256: 89a9061aafc28c0e0e2db49a5b99e99797ed3a7127c31deda0cceb4696ae627f
+    md5: 42a12b0b21d64b36a9ab9a24a04eb910
+    sha256: 482d0f3ce8dad6b881f76620ee18152755c61bb968039dcbc0ad45689c70b0d5
   category: dev
   optional: true
 - name: cachy
@@ -3270,8 +3270,8 @@ package:
     huggingface_hub: '>=0.21.2'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    fsspec: '>=2023.1.0,<=2024.5.0'
     pyarrow: '>=15.0.0'
+    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3297,8 +3297,8 @@ package:
     huggingface_hub: '>=0.21.2'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    fsspec: '>=2023.1.0,<=2024.5.0'
     pyarrow: '>=15.0.0'
+    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3808,8 +3808,8 @@ package:
     pygtrie: '>=2.3.2'
     networkx: '>=2.5'
     tabulate: '>=0.8.7'
-    configobj: '>=5.0.6'
     requests: '>=2.22'
+    configobj: '>=5.0.6'
     colorama: '>=0.3.9'
     pathspec: '>=0.10.3'
     packaging: '>=19'
@@ -3862,8 +3862,8 @@ package:
     pygtrie: '>=2.3.2'
     networkx: '>=2.5'
     tabulate: '>=0.8.7'
-    configobj: '>=5.0.6'
     requests: '>=2.22'
+    configobj: '>=5.0.6'
     colorama: '>=0.3.9'
     pathspec: '>=0.10.3'
     packaging: '>=19'
@@ -6097,7 +6097,7 @@ package:
   category: dev
   optional: true
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -6109,14 +6109,14 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6128,14 +6128,14 @@ package:
     typing-extensions: '>=3.7.4.3'
     fsspec: '>=2023.5.0'
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: win-64
   dependencies:
@@ -6147,10 +6147,10 @@ package:
     typing-extensions: '>=3.7.4.3'
     fsspec: '>=2023.5.0'
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: hydra-core
@@ -11889,8 +11889,8 @@ package:
   hash:
     md5: c4de9699f095e3049dc02bcf811497b7
     sha256: 2c34d272a1afe39afbf4713a7f96366a579cb628a0321159e3015695b1e54913
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: pydantic-core
   version: 2.18.4
   manager: conda
@@ -11904,8 +11904,8 @@ package:
   hash:
     md5: d7a6b069772e61897ab8ade15d268dde
     sha256: ca8342ba184e1e9ce1367c7225cbd837516b3d69381a17fc53c434bb2a2a1f0f
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: pydantic-core
   version: 2.18.4
   manager: conda
@@ -11921,8 +11921,8 @@ package:
   hash:
     md5: e91b2e309604559af562f15b19e39917
     sha256: 675d5c219b68d82af3649564f12e882c49cfafc4a6cc394d3a3ee00f6d14a047
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: pydot
   version: 2.0.0
   manager: conda
@@ -12202,7 +12202,7 @@ package:
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.367
+  version: 1.1.368
   manager: conda
   platform: linux-64
   dependencies:
@@ -12212,14 +12212,14 @@ package:
     nodejs: ''
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.367-py311h61187de_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.368-py311h61187de_0.conda
   hash:
-    md5: 74d20949d6fe2a207b2d9632d8e2a822
-    sha256: 2dd3cab564c910200ce7482481e259bf5ab1d262e58d90d522bc9ab792bd55b9
+    md5: 0e6287fb6961d5cf4e379638bee7bc40
+    sha256: 833cf0f0fe92986959b07fcee64d0ab77372c5988874247f4207cf4838e9502f
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.367
+  version: 1.1.368
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12228,14 +12228,14 @@ package:
     nodejs: ''
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.367-py311hd3f4193_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.368-py311hd3f4193_0.conda
   hash:
-    md5: f041b08ae8b5c64bdddda8357496d5c8
-    sha256: ce4be02303942a7a16d3a10d3bb8cf6da4adedf4da2f98eb3db676ec433be71e
+    md5: ba7122fe4f42630d428328b557fb0af9
+    sha256: bc8ec4a71d37ca11141f3f9d1e2156d0baba960ee3e1d54a6cc502d33db9ea81
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.367
+  version: 1.1.368
   manager: conda
   platform: win-64
   dependencies:
@@ -12246,10 +12246,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.367-py311he736701_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.368-py311he736701_0.conda
   hash:
-    md5: 4c51e348d47dc9a5d0351d113ef32a60
-    sha256: f02e99e4193ed742a3ceb8486dc6d398a0005a4f873e3a647eb6f3ddb9dae276
+    md5: 87d5c6817387505ba97e1dd705f04638
+    sha256: 6c0092cb8b4c68c26cfdc40419c10b905bc3a46f1631b778175c7b135c50a579
   category: dev
   optional: true
 - name: pysocks
@@ -13058,8 +13058,8 @@ package:
   hash:
     md5: 5ede4753180c7a550a443c430dc8ab52
     sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: requests
   version: 2.32.3
   manager: conda
@@ -13074,8 +13074,8 @@ package:
   hash:
     md5: 5ede4753180c7a550a443c430dc8ab52
     sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: requests
   version: 2.32.3
   manager: conda
@@ -13090,8 +13090,8 @@ package:
   hash:
     md5: 5ede4753180c7a550a443c430dc8ab52
     sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: rich
   version: 13.7.1
   manager: conda
@@ -14992,45 +14992,45 @@ package:
   category: dev
   optional: true
 - name: urllib3
-  version: 1.26.18
+  version: 1.26.19
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.18
+  version: 1.26.19
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.18
+  version: 1.26.19
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: userpath
@@ -15073,43 +15073,43 @@ package:
   category: dev
   optional: true
 - name: uv
-  version: 0.2.6
+  version: 0.2.13
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.6-h0ea3d13_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.13-h0ea3d13_0.conda
   hash:
-    md5: 59b5b6fd31fe993afe844687c36f64b5
-    sha256: a3476e0af359a15fcc4e575b106cd4d44d9633de43f83687c82a2b3b657ecb54
+    md5: 7d09e1e02f5207d63b2a77f90f937071
+    sha256: 451be34c3b33ccdec2e9031b60f32b892e0d66a1a62ddc14d3e4ab95255a3137
   category: dev
   optional: true
 - name: uv
-  version: 0.2.6
+  version: 0.2.13
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.6-hc069d6b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.13-hc069d6b_0.conda
   hash:
-    md5: d02bbc69d6ddfbcd822f64643360ec81
-    sha256: be826015f52a30931940291ceafea4b57d8cb539bae21974fe252cf5b3dc8486
+    md5: 5d29bcbc10048cea9a87b55e7ac8a5a7
+    sha256: 698da5451e73c916be54bf01fce57408030c8431512fe5537db33ac2fa80fff2
   category: dev
   optional: true
 - name: uv
-  version: 0.2.6
+  version: 0.2.13
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.6-ha08ef0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.13-ha08ef0e_0.conda
   hash:
-    md5: 434644f2e1bc03498baf906a4f318ee7
-    sha256: 7884ae5d1027c20d79242a633ba0e6578c28f628f0c6c8e4e56f95dcc8667c96
+    md5: 202dc492efb130cc17a8f12671c42c31
+    sha256: e47472c428a2b55ad18cf0f62d5f0722cd9c4a16c5fb292ccaf9fa9b94d23141
   category: dev
   optional: true
 - name: vc
@@ -16189,13 +16189,13 @@ package:
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c009caed112543095a0a7167d944feca1f96e9da
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16203,13 +16203,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c009caed112543095a0a7167d944feca1f96e9da
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16217,11 +16217,11 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c009caed112543095a0a7167d944feca1f96e9da
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009caed112543095a0a7167d944feca1f96e9da
   optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3270,8 +3270,8 @@ package:
     huggingface_hub: '>=0.21.2'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    fsspec: '>=2023.1.0,<=2024.5.0'
     pyarrow: '>=15.0.0'
+    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3297,8 +3297,8 @@ package:
     huggingface_hub: '>=0.21.2'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    fsspec: '>=2023.1.0,<=2024.5.0'
     pyarrow: '>=15.0.0'
+    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3808,8 +3808,8 @@ package:
     pygtrie: '>=2.3.2'
     networkx: '>=2.5'
     tabulate: '>=0.8.7'
-    configobj: '>=5.0.6'
     requests: '>=2.22'
+    configobj: '>=5.0.6'
     colorama: '>=0.3.9'
     pathspec: '>=0.10.3'
     packaging: '>=19'
@@ -3862,8 +3862,8 @@ package:
     pygtrie: '>=2.3.2'
     networkx: '>=2.5'
     tabulate: '>=0.8.7'
-    configobj: '>=5.0.6'
     requests: '>=2.22'
+    configobj: '>=5.0.6'
     colorama: '>=0.3.9'
     pathspec: '>=0.10.3'
     packaging: '>=19'
@@ -6097,7 +6097,7 @@ package:
   category: dev
   optional: true
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -6109,14 +6109,14 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6128,14 +6128,14 @@ package:
     typing-extensions: '>=3.7.4.3'
     fsspec: '>=2023.5.0'
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.3
+  version: 0.23.4
   manager: conda
   platform: win-64
   dependencies:
@@ -6147,10 +6147,10 @@ package:
     typing-extensions: '>=3.7.4.3'
     fsspec: '>=2023.5.0'
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 57f751bd93c2ea0f2df7de6a49630f2f
-    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
+    md5: 759dfbd44e93d75a23b203fe50dade8d
+    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
   category: main
   optional: false
 - name: hydra-core
@@ -14992,45 +14992,45 @@ package:
   category: dev
   optional: true
 - name: urllib3
-  version: 1.26.18
+  version: 1.26.19
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.18
+  version: 1.26.19
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.18
+  version: 1.26.19
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
-    md5: bf61cfd2a7f212efba378167a07d4a6a
-    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
+    md5: 6bb37c314b3cc1515dcf086ffe01c46e
+    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   category: main
   optional: false
 - name: userpath
@@ -15073,43 +15073,43 @@ package:
   category: dev
   optional: true
 - name: uv
-  version: 0.2.6
+  version: 0.2.13
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.6-h0ea3d13_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.13-h0ea3d13_0.conda
   hash:
-    md5: 59b5b6fd31fe993afe844687c36f64b5
-    sha256: a3476e0af359a15fcc4e575b106cd4d44d9633de43f83687c82a2b3b657ecb54
+    md5: 7d09e1e02f5207d63b2a77f90f937071
+    sha256: 451be34c3b33ccdec2e9031b60f32b892e0d66a1a62ddc14d3e4ab95255a3137
   category: dev
   optional: true
 - name: uv
-  version: 0.2.6
+  version: 0.2.13
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.6-hc069d6b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.13-hc069d6b_0.conda
   hash:
-    md5: d02bbc69d6ddfbcd822f64643360ec81
-    sha256: be826015f52a30931940291ceafea4b57d8cb539bae21974fe252cf5b3dc8486
+    md5: 5d29bcbc10048cea9a87b55e7ac8a5a7
+    sha256: 698da5451e73c916be54bf01fce57408030c8431512fe5537db33ac2fa80fff2
   category: dev
   optional: true
 - name: uv
-  version: 0.2.6
+  version: 0.2.13
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.6-ha08ef0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.13-ha08ef0e_0.conda
   hash:
-    md5: 434644f2e1bc03498baf906a4f318ee7
-    sha256: 7884ae5d1027c20d79242a633ba0e6578c28f628f0c6c8e4e56f95dcc8667c96
+    md5: 202dc492efb130cc17a8f12671c42c31
+    sha256: e47472c428a2b55ad18cf0f62d5f0722cd9c4a16c5fb292ccaf9fa9b94d23141
   category: dev
   optional: true
 - name: vc
@@ -16189,13 +16189,13 @@ package:
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16203,13 +16203,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16217,11 +16217,11 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   hash:
-    sha256: 353ecb9146086937463f7391d1de0637939999d5
+    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
   optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -3270,8 +3270,8 @@ package:
     huggingface_hub: '>=0.21.2'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    pyarrow: '>=15.0.0'
     fsspec: '>=2023.1.0,<=2024.5.0'
+    pyarrow: '>=15.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3297,8 +3297,8 @@ package:
     huggingface_hub: '>=0.21.2'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    pyarrow: '>=15.0.0'
     fsspec: '>=2023.1.0,<=2024.5.0'
+    pyarrow: '>=15.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3808,8 +3808,8 @@ package:
     pygtrie: '>=2.3.2'
     networkx: '>=2.5'
     tabulate: '>=0.8.7'
-    requests: '>=2.22'
     configobj: '>=5.0.6'
+    requests: '>=2.22'
     colorama: '>=0.3.9'
     pathspec: '>=0.10.3'
     packaging: '>=19'
@@ -3862,8 +3862,8 @@ package:
     pygtrie: '>=2.3.2'
     networkx: '>=2.5'
     tabulate: '>=0.8.7'
-    requests: '>=2.22'
     configobj: '>=5.0.6'
+    requests: '>=2.22'
     colorama: '>=0.3.9'
     pathspec: '>=0.10.3'
     packaging: '>=19'
@@ -6097,7 +6097,7 @@ package:
   category: dev
   optional: true
 - name: huggingface_hub
-  version: 0.23.4
+  version: 0.23.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -6109,14 +6109,14 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 759dfbd44e93d75a23b203fe50dade8d
-    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
+    md5: 57f751bd93c2ea0f2df7de6a49630f2f
+    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.4
+  version: 0.23.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6128,14 +6128,14 @@ package:
     typing-extensions: '>=3.7.4.3'
     fsspec: '>=2023.5.0'
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 759dfbd44e93d75a23b203fe50dade8d
-    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
+    md5: 57f751bd93c2ea0f2df7de6a49630f2f
+    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.23.4
+  version: 0.23.3
   manager: conda
   platform: win-64
   dependencies:
@@ -6147,10 +6147,10 @@ package:
     typing-extensions: '>=3.7.4.3'
     fsspec: '>=2023.5.0'
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 759dfbd44e93d75a23b203fe50dade8d
-    sha256: 298cf27a319a97f70e826364fcc92aeccb3197e462d40b28297e5ced0cbd753d
+    md5: 57f751bd93c2ea0f2df7de6a49630f2f
+    sha256: c58baec87c083a084d9c45b365df10dc7aa1dd5cfc28108d5ac94e90c8bae832
   category: main
   optional: false
 - name: hydra-core
@@ -14992,45 +14992,45 @@ package:
   category: dev
   optional: true
 - name: urllib3
-  version: 1.26.19
+  version: 1.26.18
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
   hash:
-    md5: 6bb37c314b3cc1515dcf086ffe01c46e
-    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
+    md5: bf61cfd2a7f212efba378167a07d4a6a
+    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.19
+  version: 1.26.18
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
   hash:
-    md5: 6bb37c314b3cc1515dcf086ffe01c46e
-    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
+    md5: bf61cfd2a7f212efba378167a07d4a6a
+    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
   category: main
   optional: false
 - name: urllib3
-  version: 1.26.19
+  version: 1.26.18
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.18-pyhd8ed1ab_0.conda
   hash:
-    md5: 6bb37c314b3cc1515dcf086ffe01c46e
-    sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
+    md5: bf61cfd2a7f212efba378167a07d4a6a
+    sha256: 1cc0bab65a6ad0f5a8bd7657760a4fb4e670d30377f9dab88b792977cb3687e7
   category: main
   optional: false
 - name: userpath
@@ -15073,43 +15073,43 @@ package:
   category: dev
   optional: true
 - name: uv
-  version: 0.2.13
+  version: 0.2.6
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.13-h0ea3d13_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.6-h0ea3d13_0.conda
   hash:
-    md5: 7d09e1e02f5207d63b2a77f90f937071
-    sha256: 451be34c3b33ccdec2e9031b60f32b892e0d66a1a62ddc14d3e4ab95255a3137
+    md5: 59b5b6fd31fe993afe844687c36f64b5
+    sha256: a3476e0af359a15fcc4e575b106cd4d44d9633de43f83687c82a2b3b657ecb54
   category: dev
   optional: true
 - name: uv
-  version: 0.2.13
+  version: 0.2.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.13-hc069d6b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.6-hc069d6b_0.conda
   hash:
-    md5: 5d29bcbc10048cea9a87b55e7ac8a5a7
-    sha256: 698da5451e73c916be54bf01fce57408030c8431512fe5537db33ac2fa80fff2
+    md5: d02bbc69d6ddfbcd822f64643360ec81
+    sha256: be826015f52a30931940291ceafea4b57d8cb539bae21974fe252cf5b3dc8486
   category: dev
   optional: true
 - name: uv
-  version: 0.2.13
+  version: 0.2.6
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.13-ha08ef0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.6-ha08ef0e_0.conda
   hash:
-    md5: 202dc492efb130cc17a8f12671c42c31
-    sha256: e47472c428a2b55ad18cf0f62d5f0722cd9c4a16c5fb292ccaf9fa9b94d23141
+    md5: 434644f2e1bc03498baf906a4f318ee7
+    sha256: 7884ae5d1027c20d79242a633ba0e6578c28f628f0c6c8e4e56f95dcc8667c96
   category: dev
   optional: true
 - name: vc
@@ -16189,13 +16189,13 @@ package:
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
   hash:
-    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
+    sha256: 353ecb9146086937463f7391d1de0637939999d5
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16203,13 +16203,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
   hash:
-    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
+    sha256: 353ecb9146086937463f7391d1de0637939999d5
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -16217,11 +16217,11 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
   hash:
-    sha256: c0552428f046dcb1f706f421b3ae637e8022d9a6
+    sha256: 353ecb9146086937463f7391d1de0637939999d5
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0552428f046dcb1f706f421b3ae637e8022d9a6
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@353ecb9146086937463f7391d1de0637939999d5
   optional: false

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -12,7 +12,8 @@ dependencies:
   - hatch
   # dependencies for development scripts
   - docopt >=0.6
-  - requests >=2.31,<3
+  # requests is a pulled in by other things. omit here to avoid screwing up categories.
+  # - requests >=2.31,<3
   # dependencies for tests
   - pytest >=7
   - coverage >=6.5

--- a/dev/update-dep-lock.sh
+++ b/dev/update-dep-lock.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export CONDA_CHANNEL_PRIORITY=flexible
+if [ ! -f pyproject.toml ]; then
+    echo "this script must be run from the project root" >&2
+    exit 64
+fi
+
+exec conda-lock lock -f pyproject.toml -f dev/environment.yml -f dev/constraints.yml

--- a/dev/update-dep-lock.sh
+++ b/dev/update-dep-lock.sh
@@ -3,10 +3,17 @@
 # TODO: add option to update only our dependencies once conda-lock bug is fixed
 # bug url: https://github.com/conda/conda-lock/issues/652
 
-export CONDA_CHANNEL_PRIORITY=flexible
+# make sure we're in the right directory
 if [ ! -f pyproject.toml ]; then
     echo "this script must be run from the project root" >&2
     exit 64
 fi
 
+# our dependencies require flexible resolution to work on Windows, because
+# conda-forge does not ship Windows binaries for current Torch versions.
+# If users have followed the Conda recommended defaults to enable strict
+# channel priority, locking will fail, so we override that setting here.
+export CONDA_CHANNEL_PRIORITY=flexible
+
+# and run conda-lock
 exec conda-lock lock -f pyproject.toml -f dev/environment.yml -f dev/constraints.yml

--- a/dev/update-dep-lock.sh
+++ b/dev/update-dep-lock.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# TODO: add option to update only our dependencies once conda-lock bug is fixed
+# bug url: https://github.com/conda/conda-lock/issues/652
+
 export CONDA_CHANNEL_PRIORITY=flexible
 if [ ! -f pyproject.toml ]; then
     echo "this script must be run from the project root" >&2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ python = "3.11"
 # keep these dependencies in sync with dev/dev-environment.yml
 dependencies = [
   "dvc[s3] ~=3.51",
-  "conda-lock ~=2.5",
   "docopt~=0.6",
   "requests~=2.13",
   "coverage[toml]>=6.5",
@@ -47,7 +46,6 @@ dependencies = [
   "pexpect~=4.9",
 ]
 [tool.hatch.envs.default.scripts]
-lock-deps = "conda-lock -f pyproject.toml -f dev/constraints.yml -f dev/environment.yml"
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "smart_open==7.*",
   "safetensors>=0.4,<1",
   "transformers>=4.41,<5",
-  "poprox-concepts@git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009cae",
+  "poprox-concepts@git+https://github.com/CCRI-POPROX/poprox-concepts.git@main",
   # direct dep on Pydantic to ensure it is in lockfile
   # this is necessary because conda-lock doesn't look into poprox-concepts to
   # find conda deps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ dependencies = [
   "smart_open==7.*",
   "safetensors>=0.4,<1",
   "transformers>=4.41,<5",
-  "poprox-concepts@git+https://github.com/CCRI-POPROX/poprox-concepts.git@main",
+  "poprox-concepts@git+https://github.com/CCRI-POPROX/poprox-concepts.git@c009cae",
+  # direct dep on Pydantic to ensure it is in lockfile
+  # this is necessary because conda-lock doesn't look into poprox-concepts to
+  # find conda deps
+  "pydantic~=2.7.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
This adds a shell script that runs `conda-lock` with the correct inputs and environment variables to ensure that locking is successful regardless of the user's local Conda configuration. It also tweaks a couple of dependency specifications to make sure that the `main` category contains a closure (`conda-lock` is not 100% on achieving that).

Once the upstream conda-lock bug is fixed, we can update this script to add the ability to update only our dependencies.