### PR TITLE
Use Conda to build Docker image from locked dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,52 @@
 ARG LOG_LEVEL=INFO
-# Use Lambda Python base image for the build container
-FROM public.ecr.aws/lambda/python:3.11 as build
+# Use Lambda "Provided" base image for the build container
+FROM public.ecr.aws/lambda/provided:al2 as build
 
-# Install prerequisite packages
-RUN yum -y install git gcc python3-devel
+# install necessary system packages
+RUN yum -y install git-core
 
-# Install Python dependencies w/ special requirements
-RUN pip install torch --index-url https://download.pytorch.org/whl/cpu
-RUN pip install nltk && python -m nltk.downloader -d /var/lang/nltk_data punkt
+# Fetch the micromamba executable from GitHub
+ADD --chmod=0755 https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64 /usr/local/bin/micromamba
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
 
-# Install our package
-COPY ./ ${LAMBDA_TASK_ROOT}/poprox_recommender
-RUN pip install ${LAMBDA_TASK_ROOT}/poprox_recommender
+# Copy dependency lockfile and install deps
+COPY conda-lock.yml /src/poprox-recommender/
+RUN micromamba create -y --always-copy -p /opt/poprox -f /src/poprox-recommender/conda-lock.yml
+# Download the punkt NLTK data
+RUN micromamba run -p /opt/poprox python -m nltk.downloader -d /opt/poprox/nltk_data punkt
+# Install the Lambda runtime bridge
+RUN micromamba install -p /opt/poprox -c conda-forge awslambdaric
 
+# Copy the soure code into the image to install it
+# TODO do we want to copy the sdist or wheel instead?
+COPY pyproject.toml README.md /src/poprox-recommender/
+COPY src/ /src/poprox-recommender/src/
+WORKDIR /src/poprox-recommender
+# Install the poprox-recommender module
+RUN micromamba run -p /opt/poprox pip install --no-deps .
 
-# Use Lambda Python base image for the deployment container
-FROM public.ecr.aws/lambda/python:3.11
+# Use Lambda "Provided" base image for the deployment container
+# We installed Python ourselves
+FROM public.ecr.aws/lambda/provided:al2
 
-# Copy the installed packages from the build container
-COPY --from=build /var/lang/lib/python3.11/site-packages /var/lang/lib/python3.11/site-packages
-COPY --from=build /var/lang/nltk_data /var/lang/nltk_data
-COPY ./models/ /var/lang/poprox-models
-ENV POPROX_MODELS /var/lang/poprox-models
+# Copy the installed packages and data from the build container
+COPY --from=build /usr/local/bin/micromamba /usr/local/bin/micromamba
+COPY --from=build /opt/poprox /opt/poprox
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+
+# Bake the model data into the image
+COPY models/ /opt/poprox/models/
+ENV POPROX_MODELS=/opt/poprox/models
+
+# Make sure we can import the recommender
+RUN micromamba run -p /opt/poprox python -m poprox_recommender.handler
+
+# Copy the bootstrap script
+COPY --chmod=0555 lambda-bootstrap.sh /var/runtime/bootstrap
 
 # Set the transformers cache to a writeable directory
-ENV TRANSFORMERS_CACHE=/tmp/.transformers
+ENV TRANSFORMERS_CACHE /tmp/.transformers
 ENV AWS_LAMBDA_LOG_LEVEL=${LOG_LEVEL}
-# Set entry point function
+
+# Run the bootstrap with our handler by default
 CMD ["poprox_recommender.handler.generate_recs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN micromamba run -p /opt/poprox python -m poprox_recommender.handler
 COPY --chmod=0555 lambda-bootstrap.sh /var/runtime/bootstrap
 
 # Set the transformers cache to a writeable directory
-ENV TRANSFORMERS_CACHE /tmp/.transformers
+ENV TRANSFORMERS_CACHE=/tmp/.transformers
 ENV AWS_LAMBDA_LOG_LEVEL=${LOG_LEVEL}
 
 # Run the bootstrap with our handler by default

--- a/lambda-bootstrap.sh
+++ b/lambda-bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Installed as /var/runtime/bootstrap, which the Lambda image
+# entrypoint expects to bootstrap and run the handler software.
+
+# set up the Conda environment
+eval "$(micromamba shell activate -s dash -p /opt/poprox)"
+# run our code through the Lambda RIC handler
+exec /opt/poprox/bin/python -m awslambdaric "$_HANDLER"


### PR DESCRIPTION
This PR updates our Docker build to use Conda to build the image from the locked dependencies.

This solves the problem that our main builds are not using locked dependencies for deployment, so it is possible for deployment of `main` to succeed one day but fail later because of external dependency updates. By using locked dependencies, it ensures (mostly) reproducible and durable deployability of the main branch.