### PR TITLE
Use the high-level general topics that match onboarding to diversify

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -19,7 +19,7 @@ from transformers import AutoTokenizer
 from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
-from poprox_recommender.topics import extract_general_topic
+from poprox_recommender.topics import extract_general_topics
 
 
 @dataclass
@@ -179,7 +179,7 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
 
     S_topic = set()
     article = articles[int(initial_item)]
-    S_topic.update([mention.entity.name for mention in article.mentions])
+    S_topic.update(extract_general_topics(article))
 
     for k in range(topk - 1):
         candidate_idx = None
@@ -191,7 +191,8 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
             product = 1
             summation = 0
 
-            candidate_topics = [mention.entity.name for mention in articles[int(i)].mentions]
+            candidate_topics = set(extract_general_topics(articles[int(i)]))
+
             for topic in candidate_topics:
                 if topic in S_topic:
                     product = 0
@@ -208,8 +209,9 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
                 candidate_idx = i
 
         if candidate_idx is not None:
+            candidate_topics = set(extract_general_topics(articles[int(candidate_idx)]))
             S.append(candidate_idx)
-            S_topic.update([mention.entity.name for mention in articles[candidate_idx].mentions])
+            S_topic.update(candidate_topics)
 
     return S  # LIST(candidate index)
 
@@ -303,7 +305,7 @@ def find_topic(past_articles: list[Article], article_id: UUID):
     # each article might correspond to multiple topic
     for article in past_articles:
         if article.article_id == article_id:
-            return extract_general_topic(article)
+            return extract_general_topics(article)
 
 
 def normalized_topic_count(topic_counts: dict[str, int]):

--- a/src/poprox_recommender/topics.py
+++ b/src/poprox_recommender/topics.py
@@ -5,7 +5,7 @@ from poprox_concepts import Article
 from poprox_concepts.domain.topics import GENERAL_TOPICS
 
 
-def extract_general_topic(article: Article):
+def extract_general_topics(article: Article):
     article_topics = set([mention.entity.name for mention in article.mentions])
     return article_topics.intersection(GENERAL_TOPICS)
 

--- a/tests/test_pfar.py
+++ b/tests/test_pfar.py
@@ -10,7 +10,7 @@ from safetensors.torch import load_file
 
 from poprox_concepts import Article, ClickHistory
 from poprox_recommender.default import select_articles, user_topic_preference
-from poprox_recommender.topics import GENERAL_TOPICS, extract_general_topic, match_news_topics_to_general
+from poprox_recommender.topics import GENERAL_TOPICS, extract_general_topics, match_news_topics_to_general
 
 try:
     import pytest
@@ -49,7 +49,7 @@ def test_topic_classification():
 def test_extract_generalized_topic():
     todays_articles, _, _, _ = load_test_articles()
     for article in todays_articles:
-        generalized_topics = extract_general_topic(article)
+        generalized_topics = extract_general_topics(article)
         for topic in generalized_topics:
             assert topic in GENERAL_TOPICS
 


### PR DESCRIPTION
The long list of AP topics has a bunch of very fine-grained stuff in it that makes articles look more topically diverse than they really are, but we know that our short list of high-level topics has close to 100% coverage of the stories we've seen so we can use it here to diversify over a narrower set.