### PR TITLE
Pass relevance scores through a sigmoid before PFAR

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -231,10 +231,14 @@ def generate_recommendations(
     diversify = str(algo_params.get("diversity_algo", "mmr"))
 
     pred = model.get_prediction(article_vectors, user_embedding.squeeze())
-    pred = pred.cpu().detach().numpy()
+
     if diversify == "mmr":
+        pred = pred.cpu().detach().numpy()
         recs = mmr_diversification(pred, similarity_matrix, theta=theta, topk=num_slots)
-    if diversify == "pfar":
+
+    elif diversify == "pfar":
+        pred = th.sigmoid(pred).cpu().detach().numpy()
+
         topic_preferences: dict[str, int] = {}
 
         for interest in interest_profile.onboarding_topics:


### PR DESCRIPTION
PFAR is expecting probabilities in the range 0 to 1, and the tuning parameters don't quite work as expected otherwise. One option is to squash our dot products into that range with a sigmoid and interpret the result as a probability that a user is interested in an item