### PR TITLE
Break the recommendation process apart into independent-ish components

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -1,6 +1,5 @@
 import random
 import sys
-from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -1,7 +1,6 @@
 import math
 import random
 import sys
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
@@ -17,7 +16,7 @@ from transformers import AutoTokenizer
 from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
-from poprox_recommender.topics import extract_general_topics
+from poprox_recommender.topics import normalized_topic_count, user_topic_preference
 
 
 @dataclass
@@ -288,33 +287,6 @@ def compute_similarity_matrix(todays_article_vectors):
                 value2 = value2.detach().cpu()
                 similarity_matrix[i, j] = similarity_matrix[j, i] = np.dot(value1, value2)
     return similarity_matrix
-
-
-def find_topic(past_articles: list[Article], article_id: UUID):
-    # each article might correspond to multiple topic
-    for article in past_articles:
-        if article.article_id == article_id:
-            return extract_general_topics(article)
-
-
-def normalized_topic_count(topic_counts: dict[str, int]):
-    total_count = sum(topic_counts.values())
-    normalized_counts = {key: value / total_count for key, value in topic_counts.items()}
-    return normalized_counts
-
-
-def user_topic_preference(past_articles: list[Article], click_history: ClickHistory) -> dict[str, int]:
-    """Topic preference only based on click history"""
-    clicked_articles = click_history.article_ids  # List[UUID]
-
-    topic_count_dict = defaultdict(int)
-
-    for article_id in clicked_articles:
-        clicked_topics = find_topic(past_articles, article_id)
-        for topic in clicked_topics:
-            topic_count_dict[topic] += 1
-
-    return topic_count_dict
 
 
 def select_articles(

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -88,19 +88,20 @@ def select_articles(
     num_slots: int,
     algo_params: dict[str, Any] | None = None,
 ) -> dict[UUID, list[Article]]:
-    article_embedder = ArticleEmbedder(MODEL, TOKENIZER, DEVICE)
-
     click_history = interest_profile.click_history
-    clicked_articles = filter(lambda a: a.article_id in set(click_history.article_ids), past_articles)
-
-    todays_article_lookup, todays_article_tensor = article_embedder(todays_articles)
-    clicked_article_lookup, clicked_article_tensor = article_embedder(clicked_articles)
-
-    interest_profile.click_topic_counts = user_topic_preference(past_articles, interest_profile.click_history)
-
-    recommendations = {}
-    account_id = click_history.account_id
     if MODEL and TOKENIZER and click_history.article_ids:
+        article_embedder = ArticleEmbedder(MODEL, TOKENIZER, DEVICE)
+
+        clicked_articles = filter(lambda a: a.article_id in set(click_history.article_ids), past_articles)
+
+        todays_article_lookup, todays_article_tensor = article_embedder(todays_articles)
+        clicked_article_lookup, clicked_article_tensor = article_embedder(clicked_articles)
+
+        interest_profile.click_topic_counts = user_topic_preference(past_articles, interest_profile.click_history)
+
+        recommendations = {}
+        account_id = click_history.account_id
+
         max_clicks_per_user: int = 50
 
         user_embedding = build_user_embedding(

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -5,8 +5,7 @@ from uuid import UUID
 import torch as th
 
 from poprox_concepts import Article, InterestProfile
-from poprox_recommender.diversifiers import mmr_diversification, pfar_diversification
-from poprox_recommender.diversifiers.mmr import compute_similarity_matrix
+from poprox_recommender.diversifiers import MMRDiversifier, pfar_diversification
 from poprox_recommender.embedders import ArticleEmbedder, UserEmbedder
 from poprox_recommender.model import DEVICE, MODEL, TOKENIZER
 from poprox_recommender.scorers import ArticleScorer
@@ -41,12 +40,8 @@ def select_articles(
         article_scores = article_scorer(candidate_article_tensor, user_embedding)
 
         if diversify == "mmr":
-            theta = float(algo_params.get("theta", 0.8))
-
-            # Compute today's article similarity matrix
-            similarity_matrix = compute_similarity_matrix(candidate_article_tensor)
-
-            recs = mmr_diversification(article_scores, similarity_matrix, theta=theta, topk=num_slots)
+            diversifier = MMRDiversifier(algo_params)
+            recs = diversifier(article_scores, candidate_article_tensor, num_slots)
 
         elif diversify == "pfar":
             lamb = float(algo_params.get("pfar_lamb", 1))

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -3,14 +3,12 @@ import sys
 from typing import Any
 from uuid import UUID
 
-import numpy as np
 import torch as th
 
 sys.path.append("../")
-from tqdm import tqdm
 
 from poprox_concepts import Article, ClickHistory, InterestProfile
-from poprox_recommender.diversifiers.mmr import mmr_diversification
+from poprox_recommender.diversifiers.mmr import compute_similarity_matrix, mmr_diversification
 from poprox_recommender.diversifiers.pfar import pfar_diversification
 from poprox_recommender.model import DEVICE, MODEL, TOKENIZER
 from poprox_recommender.topics import normalized_topic_count, user_topic_preference
@@ -143,18 +141,6 @@ def select_with_model(
     )
 
     return recommendations
-
-
-def compute_similarity_matrix(todays_article_vectors):
-    num_values = len(todays_article_vectors)
-    similarity_matrix = np.zeros((num_values, num_values))
-    for i, value1 in tqdm(enumerate(todays_article_vectors), total=num_values):
-        value1 = value1.detach().cpu()
-        for j, value2 in enumerate(todays_article_vectors):
-            if i <= j:
-                value2 = value2.detach().cpu()
-                similarity_matrix[i, j] = similarity_matrix[j, i] = np.dot(value1, value2)
-    return similarity_matrix
 
 
 def select_articles(

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -42,7 +42,6 @@ def generate_recommendations(
     model,
     candidate_articles: list[Article],
     candidate_article_tensor: th.Tensor,
-    similarity_matrix,
     user_embedding,
     interest_profile: InterestProfile,
     num_slots: int = 10,

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -8,59 +8,13 @@ import numpy as np
 import torch as th
 
 sys.path.append("../")
-from safetensors.torch import load_file
 from tqdm import tqdm
-from transformers import AutoTokenizer
 
 from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.diversifiers.mmr import mmr_diversification
 from poprox_recommender.diversifiers.pfar import pfar_diversification
-from poprox_recommender.model.nrms import NRMS
-from poprox_recommender.paths import model_file_path
+from poprox_recommender.model import DEVICE, MODEL, TOKENIZER
 from poprox_recommender.topics import normalized_topic_count, user_topic_preference
-
-
-@dataclass
-class ModelConfig:
-    num_epochs: float = 10
-
-    num_clicked_news_a_user: float = 50
-    word_freq_threshold: float = 1
-    dropout_probability: float = 0.2
-    word_embedding_dim: float = 300
-    category_embedding_dim: float = 100
-    query_vector_dim: float = 200
-    additive_attn_hidden_dim: float = 200
-    num_attention_heads: float = 16
-    hidden_size: int = 768
-
-    pretrained_model = "distilbert-base-uncased"
-
-
-def load_checkpoint(device_name=None):
-    checkpoint = None
-
-    if device_name is None:
-        # device_name = "cuda" if th.cuda.is_available() else "cpu"
-        device_name = "cpu"
-
-    load_path = model_file_path("model.safetensors")
-
-    checkpoint = load_file(load_path)
-    return checkpoint, device_name
-
-
-def load_model(checkpoint, device):
-    model = NRMS(ModelConfig()).to(device)
-    model.load_state_dict(checkpoint)
-    model.eval()
-
-    return model
-
-
-TOKENIZER = AutoTokenizer.from_pretrained("distilbert-base-uncased", cache_dir="/tmp/")
-CHECKPOINT, DEVICE = load_checkpoint()
-MODEL = load_model(CHECKPOINT, DEVICE)
 
 
 def transform_article_features(articles: list[Article], tokenizer) -> dict[str, list]:

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -5,8 +5,8 @@ from uuid import UUID
 import torch as th
 
 from poprox_concepts import Article, ClickHistory, InterestProfile
-from poprox_recommender.diversifiers.mmr import compute_similarity_matrix, mmr_diversification
-from poprox_recommender.diversifiers.pfar import pfar_diversification
+from poprox_recommender.diversifiers import mmr_diversification, pfar_diversification
+from poprox_recommender.diversifiers.mmr import compute_similarity_matrix
 from poprox_recommender.embedders import ArticleEmbedder
 from poprox_recommender.model import DEVICE, MODEL, TOKENIZER
 from poprox_recommender.topics import normalized_topic_count, user_topic_preference

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -7,34 +7,9 @@ import torch as th
 from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.diversifiers.mmr import compute_similarity_matrix, mmr_diversification
 from poprox_recommender.diversifiers.pfar import pfar_diversification
+from poprox_recommender.embedders import ArticleEmbedder
 from poprox_recommender.model import DEVICE, MODEL, TOKENIZER
 from poprox_recommender.topics import normalized_topic_count, user_topic_preference
-
-
-def transform_article_features(articles: list[Article], tokenizer) -> dict[str, list]:
-    tokenized_titles = {}
-    for article in articles:
-        tokenized_titles[article.article_id] = tokenizer.encode(
-            article.title, padding="max_length", max_length=30, truncation=True
-        )
-
-    return tokenized_titles
-
-
-# Compute a vector for each news story
-def build_article_embeddings(article_features, model, device) -> tuple[dict[str, th.Tensor], th.Tensor]:
-    articles = {
-        "id": list(article_features.keys()),
-        "title": th.tensor(list(article_features.values())),
-    }
-    article_embeddings = {}
-    article_vectors = model.get_news_vector(articles["title"].to(device))
-    for article_id, article_vector in zip(articles["id"], article_vectors, strict=False):
-        if article_id not in article_embeddings:
-            article_embeddings[article_id] = article_vector
-
-    article_embeddings["PADDED_NEWS"] = th.zeros(list(article_embeddings.values())[0].size(), device=device)
-    return article_embeddings, article_vectors
 
 
 # Compute a vector for each user
@@ -136,19 +111,6 @@ def select_with_model(
     )
 
     return recommendations
-
-
-class ArticleEmbedder:
-    def __init__(self, model, tokenizer, device):
-        self.model = model
-        self.tokenizer = tokenizer
-        self.device = device
-
-    def __call__(self, articles: list[Article]):
-        article_features = transform_article_features(articles, self.tokenizer)
-        article_lookup, article_tensor = build_article_embeddings(article_features, self.model, self.device)
-
-        return article_lookup, article_tensor
 
 
 def select_articles(

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -48,7 +48,7 @@ def select_articles(
         recommendations[account_id] = [candidate_articles[int(rec)] for rec in recs]
     else:
         recommendations[account_id] = select_by_topic(
-            todays_articles,
+            candidate_articles,
             interest_profile,
             num_slots,
         )

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -1,4 +1,3 @@
-import math
 import random
 import sys
 from dataclasses import dataclass
@@ -15,6 +14,7 @@ from transformers import AutoTokenizer
 
 from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.diversifiers.mmr import mmr_diversification
+from poprox_recommender.diversifiers.pfar import pfar_diversification
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
 from poprox_recommender.topics import normalized_topic_count, user_topic_preference
@@ -113,60 +113,6 @@ def build_user_embedding(click_history: ClickHistory, article_embeddings, model,
     )
 
     return model.get_user_vector(clicked_news_vector)
-
-
-def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, tau, topk):
-    # p(v|u) + lamb*tau \sum_{d \in D} P(d|u)I{v \in d} \prod_{i \in S} I{i \in d} for each user
-
-    if tau is None:
-        tau = 0
-        for topic, weight in topic_preferences.items():
-            if weight > 0:
-                tau -= weight * math.log(weight)
-    else:
-        tau = float(tau)
-
-    S = []  # final recommendation LIST[candidate index]
-    initial_item = relevance_scores.argmax()
-    S.append(initial_item)
-
-    S_topic = set()
-    article = articles[int(initial_item)]
-    S_topic.update(extract_general_topics(article))
-
-    for k in range(topk - 1):
-        candidate_idx = None
-        best_score = float("-inf")
-
-        for i, relevance_i in enumerate(relevance_scores):  # iterate R for next item
-            if i in S:
-                continue
-            product = 1
-            summation = 0
-
-            candidate_topics = set(extract_general_topics(articles[int(i)]))
-
-            for topic in candidate_topics:
-                if topic in S_topic:
-                    product = 0
-                    break
-
-            for topic in candidate_topics:
-                if topic in topic_preferences:
-                    summation += topic_preferences[topic]
-
-            pfar_score_i = relevance_i + lamb * tau * summation * product
-
-            if pfar_score_i > best_score:
-                best_score = pfar_score_i
-                candidate_idx = i
-
-        if candidate_idx is not None:
-            candidate_topics = set(extract_general_topics(articles[int(candidate_idx)]))
-            S.append(candidate_idx)
-            S_topic.update(candidate_topics)
-
-    return S  # LIST(candidate index)
 
 
 def generate_recommendations(

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -1,11 +1,8 @@
 import random
-import sys
 from typing import Any
 from uuid import UUID
 
 import torch as th
-
-sys.path.append("../")
 
 from poprox_concepts import Article, ClickHistory, InterestProfile
 from poprox_recommender.diversifiers.mmr import compute_similarity_matrix, mmr_diversification

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -63,21 +63,19 @@ def select_articles(
     algo_params: dict[str, Any] | None = None,
 ) -> dict[UUID, list[Article]]:
     click_history = interest_profile.click_history
+    clicked_articles = filter(lambda a: a.article_id in set(click_history.article_ids), past_articles)
+    interest_profile.click_topic_counts = user_topic_preference(past_articles, interest_profile.click_history)
+    account_id = click_history.account_id
+
+    recommendations = {}
     if MODEL and TOKENIZER and click_history.article_ids:
         article_embedder = ArticleEmbedder(MODEL, TOKENIZER, DEVICE)
         user_embedder = UserEmbedder(MODEL, DEVICE)
-
-        clicked_articles = filter(lambda a: a.article_id in set(click_history.article_ids), past_articles)
 
         todays_article_lookup, todays_article_tensor = article_embedder(todays_articles)
         clicked_article_lookup, clicked_article_tensor = article_embedder(clicked_articles)
 
         user_embedding = user_embedder(interest_profile, clicked_article_lookup)
-
-        interest_profile.click_topic_counts = user_topic_preference(past_articles, interest_profile.click_history)
-
-        recommendations = {}
-        account_id = click_history.account_id
 
         user_recs = generate_recommendations(
             MODEL,

--- a/src/poprox_recommender/diversifiers/__init__.py
+++ b/src/poprox_recommender/diversifiers/__init__.py
@@ -1,4 +1,4 @@
-from poprox_recommender.diversifiers.mmr import mmr_diversification
+from poprox_recommender.diversifiers.mmr import MMRDiversifier
 from poprox_recommender.diversifiers.pfar import pfar_diversification
 
-__all__ = ["mmr_diversification", "pfar_diversification"]
+__all__ = ["MMRDiversifier", "pfar_diversification"]

--- a/src/poprox_recommender/diversifiers/__init__.py
+++ b/src/poprox_recommender/diversifiers/__init__.py
@@ -1,0 +1,4 @@
+from poprox_recommender.diversifiers.mmr import mmr_diversification
+from poprox_recommender.diversifiers.pfar import pfar_diversification
+
+__all__ = ["mmr_diversification", "pfar_diversification"]

--- a/src/poprox_recommender/diversifiers/__init__.py
+++ b/src/poprox_recommender/diversifiers/__init__.py
@@ -1,4 +1,4 @@
 from poprox_recommender.diversifiers.mmr import MMRDiversifier
-from poprox_recommender.diversifiers.pfar import pfar_diversification
+from poprox_recommender.diversifiers.pfar import PFARDiversifier
 
-__all__ = ["MMRDiversifier", "pfar_diversification"]
+__all__ = ["MMRDiversifier", "PFARDiversifier"]

--- a/src/poprox_recommender/diversifiers/mmr.py
+++ b/src/poprox_recommender/diversifiers/mmr.py
@@ -1,5 +1,17 @@
+from typing import Any
+
 import numpy as np
 from tqdm import tqdm
+
+
+class MMRDiversifier:
+    def __init__(self, algo_params: dict[str, Any]):
+        self.theta = float(algo_params.get("theta", 0.8))
+
+    def __call__(self, article_scores, candidate_article_tensor, topk):
+        similarity_matrix = compute_similarity_matrix(candidate_article_tensor)
+
+        return mmr_diversification(article_scores, similarity_matrix, theta=self.theta, topk=topk)
 
 
 def compute_similarity_matrix(todays_article_vectors):

--- a/src/poprox_recommender/diversifiers/mmr.py
+++ b/src/poprox_recommender/diversifiers/mmr.py
@@ -1,0 +1,30 @@
+def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
+    # MR_i = \theta * reward_i - (1 - \theta)*max_{j \in S} sim(i, j) # S us
+    # R is all candidates (not selected yet)
+
+    S = []  # final recommendation (topk index)
+    # first recommended item
+    S.append(rewards.argmax())
+
+    for k in range(topk - 1):
+        candidate = None  # next item
+        best_MR = float("-inf")
+
+        for i, reward_i in enumerate(rewards):  # iterate R for next item
+            if i in S:
+                continue
+            max_sim = float("-inf")
+
+            for j in S:
+                sim = similarity_matrix[i][j]
+                if sim > max_sim:
+                    max_sim = sim
+
+            mr_i = theta * reward_i - (1 - theta) * max_sim
+            if mr_i > best_MR:
+                best_MR = mr_i
+                candidate = i
+
+        if candidate is not None:
+            S.append(candidate)
+    return S

--- a/src/poprox_recommender/diversifiers/mmr.py
+++ b/src/poprox_recommender/diversifiers/mmr.py
@@ -1,3 +1,19 @@
+import numpy as np
+from tqdm import tqdm
+
+
+def compute_similarity_matrix(todays_article_vectors):
+    num_values = len(todays_article_vectors)
+    similarity_matrix = np.zeros((num_values, num_values))
+    for i, value1 in tqdm(enumerate(todays_article_vectors), total=num_values):
+        value1 = value1.detach().cpu()
+        for j, value2 in enumerate(todays_article_vectors):
+            if i <= j:
+                value2 = value2.detach().cpu()
+                similarity_matrix[i, j] = similarity_matrix[j, i] = np.dot(value1, value2)
+    return similarity_matrix
+
+
 def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
     # MR_i = \theta * reward_i - (1 - \theta)*max_{j \in S} sim(i, j) # S us
     # R is all candidates (not selected yet)

--- a/src/poprox_recommender/diversifiers/pfar.py
+++ b/src/poprox_recommender/diversifiers/pfar.py
@@ -1,0 +1,53 @@
+import math
+
+
+def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, tau, topk):
+    # p(v|u) + lamb*tau \sum_{d \in D} P(d|u)I{v \in d} \prod_{i \in S} I{i \in d} for each user
+
+    if tau is None:
+        tau = 0
+        for topic, weight in topic_preferences.items():
+            if weight > 0:
+                tau -= weight * math.log(weight)
+    else:
+        tau = float(tau)
+
+    S = []  # final recommendation LIST[candidate index]
+    initial_item = relevance_scores.argmax()
+    S.append(initial_item)
+
+    S_topic = set()
+    article = articles[int(initial_item)]
+    S_topic.update([mention.entity.name for mention in article.mentions])
+
+    for k in range(topk - 1):
+        candidate_idx = None
+        best_score = float("-inf")
+
+        for i, relevance_i in enumerate(relevance_scores):  # iterate R for next item
+            if i in S:
+                continue
+            product = 1
+            summation = 0
+
+            candidate_topics = [mention.entity.name for mention in articles[int(i)].mentions]
+            for topic in candidate_topics:
+                if topic in S_topic:
+                    product = 0
+                    break
+
+            for topic in candidate_topics:
+                if topic in topic_preferences:
+                    summation += topic_preferences[topic]
+
+            pfar_score_i = relevance_i + lamb * tau * summation * product
+
+            if pfar_score_i > best_score:
+                best_score = pfar_score_i
+                candidate_idx = i
+
+        if candidate_idx is not None:
+            S.append(candidate_idx)
+            S_topic.update([mention.entity.name for mention in articles[candidate_idx].mentions])
+
+    return S  # LIST(candidate index)

--- a/src/poprox_recommender/diversifiers/pfar.py
+++ b/src/poprox_recommender/diversifiers/pfar.py
@@ -1,5 +1,34 @@
 import math
 
+import torch as th
+
+from poprox_recommender.topics import extract_general_topics, normalized_topic_count
+
+
+class PFARDiversifier:
+    def __init__(self, algo_params):
+        self.lamb = float(algo_params.get("pfar_lamb", 1))
+        self.tau = algo_params.get("pfar_tau", None)
+
+    def __call__(self, article_scores, interest_profile, candidate_articles, topk):
+        article_scores = th.sigmoid(th.tensor(article_scores)).cpu().detach().numpy()
+
+        topic_preferences: dict[str, int] = {}
+
+        for interest in interest_profile.onboarding_topics:
+            topic_preferences[interest.entity_name] = max(interest.preference - 1, 0)
+
+        for topic, click_count in interest_profile.click_topic_counts.items():
+            topic_preferences[topic] = click_count
+
+        normalized_topic_prefs = normalized_topic_count(topic_preferences)
+
+        recs = pfar_diversification(
+            article_scores, candidate_articles, normalized_topic_prefs, self.lamb, self.tau, topk=topk
+        )
+
+        return recs
+
 
 def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, tau, topk):
     # p(v|u) + lamb*tau \sum_{d \in D} P(d|u)I{v \in d} \prod_{i \in S} I{i \in d} for each user
@@ -18,7 +47,7 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
 
     S_topic = set()
     article = articles[int(initial_item)]
-    S_topic.update([mention.entity.name for mention in article.mentions])
+    S_topic.update(extract_general_topics(article))
 
     for k in range(topk - 1):
         candidate_idx = None
@@ -30,7 +59,8 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
             product = 1
             summation = 0
 
-            candidate_topics = [mention.entity.name for mention in articles[int(i)].mentions]
+            candidate_topics = set(extract_general_topics(articles[int(i)]))
+
             for topic in candidate_topics:
                 if topic in S_topic:
                     product = 0
@@ -47,7 +77,8 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
                 candidate_idx = i
 
         if candidate_idx is not None:
+            candidate_topics = set(extract_general_topics(articles[int(candidate_idx)]))
             S.append(candidate_idx)
-            S_topic.update([mention.entity.name for mention in articles[candidate_idx].mentions])
+            S_topic.update(candidate_topics)
 
     return S  # LIST(candidate index)

--- a/src/poprox_recommender/embedders/__init__.py
+++ b/src/poprox_recommender/embedders/__init__.py
@@ -1,3 +1,4 @@
 from poprox_recommender.embedders.article import ArticleEmbedder
+from poprox_recommender.embedders.user import UserEmbedder
 
-__all__ = ["ArticleEmbedder"]
+__all__ = ["ArticleEmbedder", "UserEmbedder"]

--- a/src/poprox_recommender/embedders/__init__.py
+++ b/src/poprox_recommender/embedders/__init__.py
@@ -1,0 +1,3 @@
+from poprox_recommender.embedders.article import ArticleEmbedder
+
+__all__ = ["ArticleEmbedder"]

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -1,0 +1,42 @@
+import torch as th
+
+from poprox_concepts import Article
+
+
+class ArticleEmbedder:
+    def __init__(self, model, tokenizer, device):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+
+    def __call__(self, articles: list[Article]):
+        article_features = transform_article_features(articles, self.tokenizer)
+        article_lookup, article_tensor = build_article_embeddings(article_features, self.model, self.device)
+
+        return article_lookup, article_tensor
+
+
+def transform_article_features(articles: list[Article], tokenizer) -> dict[str, list]:
+    tokenized_titles = {}
+    for article in articles:
+        tokenized_titles[article.article_id] = tokenizer.encode(
+            article.title, padding="max_length", max_length=30, truncation=True
+        )
+
+    return tokenized_titles
+
+
+# Compute a vector for each news story
+def build_article_embeddings(article_features, model, device) -> tuple[dict[str, th.Tensor], th.Tensor]:
+    articles = {
+        "id": list(article_features.keys()),
+        "title": th.tensor(list(article_features.values())),
+    }
+    article_embeddings = {}
+    article_vectors = model.get_news_vector(articles["title"].to(device))
+    for article_id, article_vector in zip(articles["id"], article_vectors, strict=False):
+        if article_id not in article_embeddings:
+            article_embeddings[article_id] = article_vector
+
+    article_embeddings["PADDED_NEWS"] = th.zeros(list(article_embeddings.values())[0].size(), device=device)
+    return article_embeddings, article_vectors

--- a/src/poprox_recommender/embedders/user.py
+++ b/src/poprox_recommender/embedders/user.py
@@ -1,0 +1,47 @@
+import torch as th
+
+from poprox_concepts import ClickHistory, InterestProfile
+
+
+# Compute a vector for each user
+def build_user_embedding(click_history: ClickHistory, article_embeddings, model, device, max_clicks_per_user):
+    article_ids = list(dict.fromkeys(click_history.article_ids))[
+        -max_clicks_per_user:
+    ]  # deduplicate while maintaining order
+
+    padded_positions = max_clicks_per_user - len(article_ids)
+    assert padded_positions >= 0
+
+    article_ids = ["PADDED_NEWS"] * padded_positions + article_ids
+    default = article_embeddings["PADDED_NEWS"]
+    clicked_article_embeddings = [
+        article_embeddings.get(clicked_article, default).to(device) for clicked_article in article_ids
+    ]
+    clicked_news_vector = (
+        th.stack(
+            clicked_article_embeddings,
+            dim=0,
+        )
+        .unsqueeze(0)
+        .to(device)
+    )
+
+    return model.get_user_vector(clicked_news_vector)
+
+
+class UserEmbedder:
+    def __init__(self, model, device, max_clicks_per_user: int = 50):
+        self.model = model
+        self.device = device
+        self.max_clicks = max_clicks_per_user
+
+    def __call__(self, interest_profile: InterestProfile, clicked_article_embeddings: dict[str, th.Tensor]):
+        user_embedding = build_user_embedding(
+            interest_profile.click_history,
+            clicked_article_embeddings,
+            self.model,
+            self.device,
+            self.max_clicks,
+        )
+
+        return user_embedding

--- a/src/poprox_recommender/model/__init__.py
+++ b/src/poprox_recommender/model/__init__.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from safetensors.torch import load_file
+from transformers import AutoTokenizer
+
+from poprox_recommender.model.nrms import NRMS
+from poprox_recommender.paths import model_file_path
+
+
+@dataclass
+class ModelConfig:
+    num_epochs: float = 10
+
+    num_clicked_news_a_user: float = 50
+    word_freq_threshold: float = 1
+    dropout_probability: float = 0.2
+    word_embedding_dim: float = 300
+    category_embedding_dim: float = 100
+    query_vector_dim: float = 200
+    additive_attn_hidden_dim: float = 200
+    num_attention_heads: float = 16
+    hidden_size: int = 768
+
+    pretrained_model = "distilbert-base-uncased"
+
+
+def load_checkpoint(device_name=None):
+    checkpoint = None
+
+    if device_name is None:
+        # device_name = "cuda" if th.cuda.is_available() else "cpu"
+        device_name = "cpu"
+
+    load_path = model_file_path("model.safetensors")
+
+    checkpoint = load_file(load_path)
+    return checkpoint, device_name
+
+
+def load_model(checkpoint, device):
+    model = NRMS(ModelConfig()).to(device)
+    model.load_state_dict(checkpoint)
+    model.eval()
+
+    return model
+
+
+TOKENIZER = AutoTokenizer.from_pretrained("distilbert-base-uncased", cache_dir="/tmp/")
+CHECKPOINT, DEVICE = load_checkpoint()
+MODEL = load_model(CHECKPOINT, DEVICE)

--- a/src/poprox_recommender/scorers/__init__.py
+++ b/src/poprox_recommender/scorers/__init__.py
@@ -1,0 +1,3 @@
+from poprox_recommender.scorers.article import ArticleScorer
+
+__all__ = ["ArticleScorer"]

--- a/src/poprox_recommender/scorers/article.py
+++ b/src/poprox_recommender/scorers/article.py
@@ -1,0 +1,11 @@
+import numpy as np
+import torch as th
+
+
+class ArticleScorer:
+    def __init__(self, model):
+        self.model = model
+
+    def __call__(self, candidate_embeddings: th.Tensor, user_embedding: th.Tensor) -> np.ndarray:
+        pred = self.model.get_prediction(candidate_embeddings, user_embedding.squeeze())
+        return pred.cpu().detach().numpy()

--- a/src/poprox_recommender/topics.py
+++ b/src/poprox_recommender/topics.py
@@ -17,7 +17,7 @@ def find_topic(past_articles: list[Article], article_id: UUID):
     # each article might correspond to multiple topic
     for article in past_articles:
         if article.article_id == article_id:
-            return extract_general_topic(article)
+            return extract_general_topics(article)
 
 
 def normalized_topic_count(topic_counts: dict[str, int]):

--- a/src/poprox_recommender/topics.py
+++ b/src/poprox_recommender/topics.py
@@ -1,13 +1,43 @@
+from collections import defaultdict
+from uuid import UUID
+
 from torch.nn.functional import cosine_similarity
 from transformers import AutoModel, AutoTokenizer
 
-from poprox_concepts import Article
+from poprox_concepts import Article, ClickHistory
 from poprox_concepts.domain.topics import GENERAL_TOPICS
 
 
 def extract_general_topics(article: Article):
     article_topics = set([mention.entity.name for mention in article.mentions])
     return article_topics.intersection(GENERAL_TOPICS)
+
+
+def find_topic(past_articles: list[Article], article_id: UUID):
+    # each article might correspond to multiple topic
+    for article in past_articles:
+        if article.article_id == article_id:
+            return extract_general_topic(article)
+
+
+def normalized_topic_count(topic_counts: dict[str, int]):
+    total_count = sum(topic_counts.values())
+    normalized_counts = {key: value / total_count for key, value in topic_counts.items()}
+    return normalized_counts
+
+
+def user_topic_preference(past_articles: list[Article], click_history: ClickHistory) -> dict[str, int]:
+    """Topic preference only based on click history"""
+    clicked_articles = click_history.article_ids  # List[UUID]
+
+    topic_count_dict = defaultdict(int)
+
+    for article_id in clicked_articles:
+        clicked_topics = find_topic(past_articles, article_id)
+        for topic in clicked_topics:
+            topic_count_dict[topic] += 1
+
+    return topic_count_dict
 
 
 def classify_news_topic(model, tokenizer, general_topics, topic):


### PR DESCRIPTION
This doesn't take us all the way to a pipeline abstraction or even a standard component interface, but it helps clarify what the various components we already have in play do and how they fit together. There aren't any (intentional) changes to the functionality here; this just re-organizes the code to make it easier to think about.