### PR TITLE
Simplify article embedding code

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -15,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    win-64: fba7e4600a1e315a247e3a2d7e381652256d3deba38ae7be417ec16753dce948
-    linux-64: 8e60b19f7a61d97a94368c2a3bb8d8f22597a9ec25928b41dc1f32b8f86714d6
-    osx-arm64: eb91ef97e74ca957b1f4b248cfb99129366ca80a6642c5f74e391252c82ce920
+    win-64: 4df3dd8275de98ed0941c995981b17cb95aed110814af476a08acf78853cb78f
+    linux-64: 719f8bd8f1e1b979f155b068c5359694f05e1ffdb40805306882bc908286f8f6
+    osx-arm64: 9a086780995a862a7893a3f09a8a23a25c31dca677ad03c883a61d64409d303c
   channels:
   - url: pytorch
     used_env_vars: []
@@ -57,51 +57,51 @@ package:
   category: main
   optional: false
 - name: aiobotocore
-  version: 2.13.0
+  version: 2.13.1
   manager: conda
   platform: linux-64
   dependencies:
     aiohttp: '>=3.9.2,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.107'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c1ba7be2b8a71c6a9de23402a5810ea2
-    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
+    md5: 64ebb883a6c94f2a18aafedecc215351
+    sha256: 8eacb10e5877fb743d75ae2c50eaaa89ece85479e557e693db8275bd96740ef3
   category: dev
   optional: true
 - name: aiobotocore
-  version: 2.13.0
+  version: 2.13.1
   manager: conda
   platform: osx-arm64
   dependencies:
     aiohttp: '>=3.9.2,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.107'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c1ba7be2b8a71c6a9de23402a5810ea2
-    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
+    md5: 64ebb883a6c94f2a18aafedecc215351
+    sha256: 8eacb10e5877fb743d75ae2c50eaaa89ece85479e557e693db8275bd96740ef3
   category: dev
   optional: true
 - name: aiobotocore
-  version: 2.13.0
+  version: 2.13.1
   manager: conda
   platform: win-64
   dependencies:
     aiohttp: '>=3.9.2,<4.0.0'
     aioitertools: '>=0.5.1,<1.0.0'
-    botocore: '>=1.34.70,<1.34.107'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c1ba7be2b8a71c6a9de23402a5810ea2
-    sha256: b3b6c22211f9d3a6d3bab852e38362f34aa28f2636992e530b49d3af4f57c6ee
+    md5: 64ebb883a6c94f2a18aafedecc215351
+    sha256: 8eacb10e5877fb743d75ae2c50eaaa89ece85479e557e693db8275bd96740ef3
   category: dev
   optional: true
 - name: aiohttp
@@ -1295,6 +1295,160 @@ package:
     sha256: b8aa3a1cce16c0cc11c4daaab8ee8c9e49f39380352f32d15bbc0253f99eba38
   category: main
   optional: false
+- name: azure-core-cpp
+  version: 1.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libcurl: '>=8.7.1,<9.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.3.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.12.0-h830ed8b_0.conda
+  hash:
+    md5: 320d066f9cad598854f4af32c7c82931
+    sha256: f76438c1f2a2c6142b344652c9fb93304cf1bb1534521f94c9c30fb9b238f0f5
+  category: main
+  optional: false
+- name: azure-core-cpp
+  version: 1.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcurl: '>=8.7.1,<9.0a0'
+    libcxx: '>=16'
+    openssl: '>=3.3.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.12.0-hd01fc5c_0.conda
+  hash:
+    md5: 2accb43f3af2ebf2dbd127978242c10a
+    sha256: 046435d3502da0f13c13ee6d92d57684624bf18aefc0d84b99d3ed39d034b078
+  category: main
+  optional: false
+- name: azure-identity-cpp
+  version: 1.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hdb0d106_1.conda
+  hash:
+    md5: a297ffb4b505f51d0f58352c5c13971b
+    sha256: 87420c137ae4d3e139cace9d9da8d63e6888d206f4eea0082975352d4ee65b14
+  category: main
+  optional: false
+- name: azure-identity-cpp
+  version: 1.8.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    libcxx: '>=16'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.8.0-h0a11218_1.conda
+  hash:
+    md5: ed8853eaa0ea62cee06025902a46ff17
+    sha256: 2e54b5d0bd189f43d93e5d3f93534d360c071a4fa4c9f1c9e17301cb29943d43
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.11.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.11.0-ha67cba7_1.conda
+  hash:
+    md5: f03bba57b85a5b3ac443a871787fc429
+    sha256: 1dc694bcecdead2dbd871bb3abe5470c4473a7e46cfa39885aec70c230d3c16e
+  category: main
+  optional: false
+- name: azure-storage-blobs-cpp
+  version: 12.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.11.0-h77cc766_1.conda
+  hash:
+    md5: 817fa040e0458866a658a471abc74c64
+    sha256: 390ada2bad5c76b33ef3d2e9e03ee54f7245060a34d6b199117e956301101449
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.6.0-he3f277c_1.conda
+  hash:
+    md5: 8a10bb068b138dd473300b5fe34a1865
+    sha256: 464c687ed110befb4099be88ea69d2d2fd039a428ab6d9575ac9bf88e932dd55
+  category: main
+  optional: false
+- name: azure-storage-common-cpp
+  version: 12.6.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    libcxx: '>=16'
+    libxml2: '>=2.12.7,<3.0a0'
+    openssl: '>=3.3.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.6.0-h7024f69_1.conda
+  hash:
+    md5: e796ec0c1c7486270353910f0683de86
+    sha256: fbf126aad4d98627a32334cdff8e8f0626120a641f424e08d741595d8b6dc8de
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
+  version: 12.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
+    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.10.0-h29b5301_1.conda
+  hash:
+    md5: bb35c23b178fc17b9e4458766f91da7f
+    sha256: ef222289612266a7e60a968b16921ecf22845e6a8354133f61b6e9c376659c19
+  category: main
+  optional: false
+- name: azure-storage-files-datalake-cpp
+  version: 12.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
+    azure-storage-common-cpp: '>=12.6.0,<12.6.1.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.10.0-h64d02d0_1.conda
+  hash:
+    md5: ddbd1d97fa5a420f5a68384be1079e42
+    sha256: 593d9d1343ff5ff012264002b9190bc0a7a2a51fb94f54e23b0c54f45153a59b
+  category: main
+  optional: false
 - name: backports
   version: '1.0'
   manager: conda
@@ -1532,167 +1686,104 @@ package:
   category: main
   optional: false
 - name: blosc
-  version: 1.21.5
+  version: 1.21.6
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.2.0,<1.3.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-hc2324a3_1.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
   hash:
-    md5: 11d76bee958b1989bd1ac6ee7372ea6d
-    sha256: fde5e8ad75d2a5f154e29da7763a5dd9ee5b5b5c3fc22a1f5170296c8f6f3f62
+    md5: 54fe76ab3d0189acaef95156874db7f9
+    sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
   category: main
   optional: false
 - name: blosc
-  version: 1.21.5
+  version: 1.21.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.2.0,<1.3.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.5-h9c252e8_1.conda
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h5499902_0.conda
   hash:
-    md5: e1be80625e4f6bdc2154ee099c641683
-    sha256: 3b38493b95cc3d9f6369bbcbab55a2cdbbe6bbe32c74b923f8d638e874033139
+    md5: e94ca7aec8544f700d45b24aff2dd4d7
+    sha256: 5a1e635a371449a750b776cab64ad83f5218b58b3f137ebd33ad3ec17f1ce92e
   category: main
   optional: false
 - name: blosc
-  version: 1.21.5
+  version: 1.21.6
   manager: conda
   platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.2.0,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
-    vc: '>=14.3,<15'
-    vc14_runtime: '>=14.38.33130'
-    zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hbd69f2e_1.conda
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
   hash:
-    md5: 06c7d9a1cdecef43921be8b577a61ee7
-    sha256: a74c8a91bee3947f9865abd057ce33a1ebb728f04041bfd47bc478fdc133ca22
+    md5: 2390269374fded230fcbca8332a4adc0
+    sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
   category: main
   optional: false
-- name: bokeh
-  version: 3.4.1
+- name: boto3
+  version: 1.34.131
   manager: conda
   platform: linux-64
   dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pandas: '>=1.2'
-    pillow: '>=7.1.0'
-    python: '>=3.9'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f8e0831bbf38d83973438ce9af9af9a
-    sha256: 0289e61d7a30a693cf79d36484abd13f72ad785bd23cadc227c29dca89d95046
-  category: main
-  optional: false
-- name: bokeh
-  version: 3.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pandas: '>=1.2'
-    pillow: '>=7.1.0'
-    python: '>=3.9'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f8e0831bbf38d83973438ce9af9af9a
-    sha256: 0289e61d7a30a693cf79d36484abd13f72ad785bd23cadc227c29dca89d95046
-  category: main
-  optional: false
-- name: bokeh
-  version: 3.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    contourpy: '>=1.2'
-    jinja2: '>=2.9'
-    numpy: '>=1.16'
-    packaging: '>=16.8'
-    pandas: '>=1.2'
-    pillow: '>=7.1.0'
-    python: '>=3.9'
-    pyyaml: '>=3.10'
-    tornado: '>=6.2'
-    xyzservices: '>=2021.09.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0f8e0831bbf38d83973438ce9af9af9a
-    sha256: 0289e61d7a30a693cf79d36484abd13f72ad785bd23cadc227c29dca89d95046
-  category: main
-  optional: false
-- name: boto3
-  version: 1.34.106
-  manager: conda
-  platform: linux-64
-  dependencies:
-    botocore: '>=1.34.106,<1.35.0'
+    botocore: '>=1.34.131,<1.35.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.8'
     s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
-    md5: 190a8f3c28a2c6047dcca712eca663b1
-    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
+    md5: 16cbd51eb7f0fc40a88c636006437c85
+    sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
   category: dev
   optional: true
 - name: boto3
-  version: 1.34.106
+  version: 1.34.131
   manager: conda
   platform: osx-arm64
   dependencies:
-    botocore: '>=1.34.106,<1.35.0'
+    botocore: '>=1.34.131,<1.35.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.8'
     s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
-    md5: 190a8f3c28a2c6047dcca712eca663b1
-    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
+    md5: 16cbd51eb7f0fc40a88c636006437c85
+    sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
   category: dev
   optional: true
 - name: boto3
-  version: 1.34.106
+  version: 1.34.131
   manager: conda
   platform: win-64
   dependencies:
-    botocore: '>=1.34.106,<1.35.0'
+    botocore: '>=1.34.131,<1.35.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.8'
     s3transfer: '>=0.10.0,<0.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.106-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
-    md5: 190a8f3c28a2c6047dcca712eca663b1
-    sha256: 166f852992379473a758f6b84efb2222d66132ddb79f8f25d35df4d6e2d67364
+    md5: 16cbd51eb7f0fc40a88c636006437c85
+    sha256: cf90e13146b5d143a749c68a0550b6ddd0e1e0d5f87976cf41b1708f88b84589
   category: dev
   optional: true
 - name: botocore
-  version: 1.34.106
+  version: 1.34.131
   manager: conda
   platform: linux-64
   dependencies:
@@ -1700,14 +1791,14 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
-    md5: ff7f42537b4f054b10b4d02732e10ab8
-    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
+    md5: 955a32ec433efee3e3ab19658ce1996d
+    sha256: 35e3141a25580397dc7977c88409b3d19871fb7e5be4951b7f9879abb307a04d
   category: dev
   optional: true
 - name: botocore
-  version: 1.34.106
+  version: 1.34.131
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1715,14 +1806,14 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
-    md5: ff7f42537b4f054b10b4d02732e10ab8
-    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
+    md5: 955a32ec433efee3e3ab19658ce1996d
+    sha256: 35e3141a25580397dc7977c88409b3d19871fb7e5be4951b7f9879abb307a04d
   category: dev
   optional: true
 - name: botocore
-  version: 1.34.106
+  version: 1.34.131
   manager: conda
   platform: win-64
   dependencies:
@@ -1730,10 +1821,10 @@ package:
     python: '>=3.10'
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.106-pyge310_1234567_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
-    md5: ff7f42537b4f054b10b4d02732e10ab8
-    sha256: 91a9502baa830fa2feeaef0ff58086dc996e083fbd83935ed848295c6319c735
+    md5: 955a32ec433efee3e3ab19658ce1996d
+    sha256: 35e3141a25580397dc7977c88409b3d19871fb7e5be4951b7f9879abb307a04d
   category: dev
   optional: true
 - name: brotli-python
@@ -2018,22 +2109,22 @@ package:
     freetype: '>=2.12.1,<3.0a0'
     icu: '>=73.2,<74.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pixman: '>=0.42.2,<1.0a0'
+    libxcb: '>=1.16,<1.17.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pixman: '>=0.43.2,<1.0a0'
     xorg-libice: '>=1.1.1,<2.0a0'
     xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-libx11: '>=1.8.9,<2.0a0'
     xorg-libxext: '>=1.3.4,<2.0a0'
     xorg-libxrender: '>=0.9.11,<0.10.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hbb29018_2.conda
   hash:
-    md5: f907bb958910dc404647326ca80c263e
-    sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
+    md5: b6d90276c5aee9b4407dd94eb0cd40a8
+    sha256: 51cfaf4669ad83499b3da215b915c503d36faf6edf6db4681a70b5710842a86c
   category: dev
   optional: true
 - name: cairo
@@ -2041,21 +2132,21 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
+    __osx: '>=11.0'
     fontconfig: '>=2.14.2,<3.0a0'
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     icu: '>=73.2,<74.0a0'
-    libcxx: '>=16.0.6'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pixman: '>=0.42.2,<1.0a0'
+    libcxx: '>=16'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pixman: '>=0.43.4,<1.0a0'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hc6c324b_2.conda
   hash:
-    md5: 3fa6eebabb77f65e82f86b72b95482db
-    sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
+    md5: 6efeefcad878c15377f49f64e2cbf232
+    sha256: 7cb330f41fd5abd3d2444a62c0439af8b11c96497aa2f87d76a5b580edf6d35c
   category: dev
   optional: true
 - name: cairo
@@ -2067,18 +2158,18 @@ package:
     fonts-conda-ecosystem: ''
     freetype: '>=2.12.1,<3.0a0'
     icu: '>=73.2,<74.0a0'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    pixman: '>=0.42.2,<1.0a0'
+    libglib: '>=2.80.2,<3.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    pixman: '>=0.43.4,<1.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zlib: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h91e5215_2.conda
   hash:
-    md5: b3fe2c6381ec74afe8128e16a11eee02
-    sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
+    md5: 7a0b2818b003bd79106c29f55126d2c3
+    sha256: 89568f4f6844c8c195457fbb2ce39acd9a727be4daadebc2464455db2fda143c
   category: dev
   optional: true
 - name: celery
@@ -2550,42 +2641,6 @@ package:
     sha256: 2d582bc15d9116ec5467b565fb87d9034c8b56f60943e8eb69407f55f1ab5a78
   category: dev
   optional: true
-- name: cloudpickle
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
-  category: main
-  optional: false
-- name: cloudpickle
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
-  category: main
-  optional: false
-- name: cloudpickle
-  version: 3.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 753d29fe41bb881e4b9c004f0abf973f
-    sha256: 0dfbc1ffa72e7a0882f486c9b1e4e9cccb68cf5c576fe53a89d076c9f1d43754
-  category: main
-  optional: false
 - name: colorama
   version: 0.4.6
   manager: conda
@@ -2769,56 +2824,8 @@ package:
     sha256: ee523a09a70c4ef71418b12ea3086169b69969dbfa382791dbde5e1a00e41728
   category: dev
   optional: true
-- name: contourpy
-  version: 1.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.20'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py311h9547e67_0.conda
-  hash:
-    md5: 74ad0ae64f1ef565e27eda87fa749e84
-    sha256: 82cec326aa81b9b6b40d9f4dab5045f0553092405efd0de9d2daf71179f20607
-  category: main
-  optional: false
-- name: contourpy
-  version: 1.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-    numpy: '>=1.20'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.1-py311hcc98501_0.conda
-  hash:
-    md5: 3f5b59b9e9b329527f1af3ee98b3d750
-    sha256: 9045fa8a05a102d4cd484fec327511386db759b4241bbacd2c5ac34a238f9379
-  category: main
-  optional: false
-- name: contourpy
-  version: 1.2.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    numpy: '>=1.20'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py311h005e61a_0.conda
-  hash:
-    md5: 050075a7a22e39222595b9191bc082e3
-    sha256: f9c392ae4c746ac32c55b20d8c487cbc06a91d5dd650261089d90fb55cfcb8c2
-  category: main
-  optional: false
 - name: coverage
-  version: 7.5.3
+  version: 7.5.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -2826,14 +2833,14 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.5.3-py311h331c9d8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.5.4-py311h331c9d8_0.conda
   hash:
-    md5: 543dd05fd661e4e9c9deb3b37093d6a2
-    sha256: 88e0063cf333147890aafacc2f87360867991241af827a111d97433b7055691e
+    md5: 5c93ea564766cd29c0864436ca9f247e
+    sha256: d2e668b5e42a4048b76f18b1626447b3ceee981e756a2207fabf3050957c7b14
   category: dev
   optional: true
 - name: coverage
-  version: 7.5.3
+  version: 7.5.4
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -2841,14 +2848,14 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.5.3-py311hd3f4193_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.5.4-py311hd3f4193_0.conda
   hash:
-    md5: 402a8b40b9c9423f40a32be066b467be
-    sha256: dcdfa3b24affe7399654f2e8429c15e05a54b8cce32583263a0731c37b62dcbc
+    md5: b4e8dc88dd72727496da5328f9a20895
+    sha256: 1cc9483be4418d49941a324cba8067fcc927623a999f16273e0130cd49547a02
   category: dev
   optional: true
 - name: coverage
-  version: 7.5.3
+  version: 7.5.4
   manager: conda
   platform: win-64
   dependencies:
@@ -2858,10 +2865,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.5.3-py311he736701_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.5.4-py311he736701_0.conda
   hash:
-    md5: eead686af955162027fb5825e83a3131
-    sha256: 16b1692a5ea5254842267e3f66489ecc009ff0d63c0d02148d756e32495c0947
+    md5: 0b62e854068114195984c9c690f0a973
+    sha256: a4d6f71133bea0e5b72eeec9c6c928c6c8b6f0abcd19654c454c76946378e03e
   category: dev
   optional: true
 - name: crashtest
@@ -3002,226 +3009,6 @@ package:
   hash:
     md5: b9f4cc3a87998e74e94c59d526424847
     sha256: cd00daadc59b29bc2b227fbe8b1e36f4eb361bd3e403ae517afbc9963bf14eca
-  category: main
-  optional: false
-- name: cytoolz
-  version: 0.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.3-py311h459d7ec_0.conda
-  hash:
-    md5: 13d385f635d7fbe9acc93600f67a6cb4
-    sha256: 1c05863330af1c1af9fcd721170fe50a42757b60e32f35933edd96e97bc188bd
-  category: main
-  optional: false
-- name: cytoolz
-  version: 0.12.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-0.12.3-py311h05b510d_0.conda
-  hash:
-    md5: d880c8585f9f1dc7057efd5bf7a212e2
-    sha256: 260980644b0ed686518437f9e86346b0798d7cab6a368a7ab61f085526ae5920
-  category: main
-  optional: false
-- name: cytoolz
-  version: 0.12.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    toolz: '>=0.10.0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.3-py311ha68e1ae_0.conda
-  hash:
-    md5: cac7a698148d6f4c5818ef6edc0a1e58
-    sha256: 41a67dd265e30f79fcbc5a9ecba50fc6dbe69fd66b7b12fe07ccb61ae75303ef
-  category: main
-  optional: false
-- name: dask
-  version: 2024.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bokeh: '>=2.4.2,!=3.0.*'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    dask-expr: '>=1.1,<1.2'
-    distributed: '>=2024.6.0,<2024.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.21'
-    pandas: '>=1.3'
-    pyarrow: '>=7.0'
-    pyarrow-hotfix: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 706801e668da4c74e7a06a911d5abdfd
-    sha256: 24b9c04fe195edb3cedeffa36f8f657a552cc1f1706374e57ed346a7916f8a39
-  category: main
-  optional: false
-- name: dask
-  version: 2024.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    bokeh: '>=2.4.2,!=3.0.*'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    dask-expr: '>=1.1,<1.2'
-    distributed: '>=2024.6.0,<2024.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.21'
-    pandas: '>=1.3'
-    pyarrow: '>=7.0'
-    pyarrow-hotfix: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 706801e668da4c74e7a06a911d5abdfd
-    sha256: 24b9c04fe195edb3cedeffa36f8f657a552cc1f1706374e57ed346a7916f8a39
-  category: main
-  optional: false
-- name: dask
-  version: 2024.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    bokeh: '>=2.4.2,!=3.0.*'
-    cytoolz: '>=0.11.0'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    dask-expr: '>=1.1,<1.2'
-    distributed: '>=2024.6.0,<2024.6.1.0a0'
-    jinja2: '>=2.10.3'
-    lz4: '>=4.3.2'
-    numpy: '>=1.21'
-    pandas: '>=1.3'
-    pyarrow: '>=7.0'
-    pyarrow-hotfix: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 706801e668da4c74e7a06a911d5abdfd
-    sha256: 24b9c04fe195edb3cedeffa36f8f657a552cc1f1706374e57ed346a7916f8a39
-  category: main
-  optional: false
-- name: dask-core
-  version: 2024.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=1.5.0'
-    fsspec: '>=2021.09.0'
-    importlib_metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.2.0'
-    python: '>=3.9'
-    pyyaml: '>=5.3.1'
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: edf709967712b2953ab4189256266adc
-    sha256: c27668dc802b67588d32da4d2f19833ad815bd39457f375f228f2bfae08bc13d
-  category: main
-  optional: false
-- name: dask-core
-  version: 2024.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=1.5.0'
-    fsspec: '>=2021.09.0'
-    importlib_metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.2.0'
-    python: '>=3.9'
-    pyyaml: '>=5.3.1'
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: edf709967712b2953ab4189256266adc
-    sha256: c27668dc802b67588d32da4d2f19833ad815bd39457f375f228f2bfae08bc13d
-  category: main
-  optional: false
-- name: dask-core
-  version: 2024.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    click: '>=8.1'
-    cloudpickle: '>=1.5.0'
-    fsspec: '>=2021.09.0'
-    importlib_metadata: '>=4.13.0'
-    packaging: '>=20.0'
-    partd: '>=1.2.0'
-    python: '>=3.9'
-    pyyaml: '>=5.3.1'
-    toolz: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: edf709967712b2953ab4189256266adc
-    sha256: c27668dc802b67588d32da4d2f19833ad815bd39457f375f228f2bfae08bc13d
-  category: main
-  optional: false
-- name: dask-expr
-  version: 1.1.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dask-core: 2024.6.0
-    pandas: '>=2'
-    pyarrow: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2b2b28ff641f91527fac96dfb0a8ea9a
-    sha256: 9c40027b6ca711c7b310e609f1cac503e8034cc7ce0ae502c9238b95a9e2ae8b
-  category: main
-  optional: false
-- name: dask-expr
-  version: 1.1.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    dask-core: 2024.6.0
-    pandas: '>=2'
-    pyarrow: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2b2b28ff641f91527fac96dfb0a8ea9a
-    sha256: 9c40027b6ca711c7b310e609f1cac503e8034cc7ce0ae502c9238b95a9e2ae8b
-  category: main
-  optional: false
-- name: dask-expr
-  version: 1.1.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    dask-core: 2024.6.0
-    pandas: '>=2'
-    pyarrow: ''
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2b2b28ff641f91527fac96dfb0a8ea9a
-    sha256: 9c40027b6ca711c7b310e609f1cac503e8034cc7ce0ae502c9238b95a9e2ae8b
   category: main
   optional: false
 - name: datasets
@@ -3499,90 +3286,6 @@ package:
     sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
   category: dev
   optional: true
-- name: distributed
-  version: 2024.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=1.5.0'
-    cytoolz: '>=0.10.1'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.0'
-    packaging: '>=20.0'
-    psutil: '>=5.7.2'
-    python: '>=3.9'
-    pyyaml: '>=5.3.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.10.0'
-    tornado: '>=6.0.4'
-    urllib3: '>=1.24.3'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc8c9391ef25c481d768967db027dfc0
-    sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
-  category: main
-  optional: false
-- name: distributed
-  version: 2024.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=1.5.0'
-    cytoolz: '>=0.10.1'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.0'
-    packaging: '>=20.0'
-    psutil: '>=5.7.2'
-    python: '>=3.9'
-    pyyaml: '>=5.3.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.10.0'
-    tornado: '>=6.0.4'
-    urllib3: '>=1.24.3'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc8c9391ef25c481d768967db027dfc0
-    sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
-  category: main
-  optional: false
-- name: distributed
-  version: 2024.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    click: '>=8.0'
-    cloudpickle: '>=1.5.0'
-    cytoolz: '>=0.10.1'
-    dask-core: '>=2024.6.0,<2024.6.1.0a0'
-    jinja2: '>=2.10.3'
-    locket: '>=1.0.0'
-    msgpack-python: '>=1.0.0'
-    packaging: '>=20.0'
-    psutil: '>=5.7.2'
-    python: '>=3.9'
-    pyyaml: '>=5.3.1'
-    sortedcontainers: '>=2.0.5'
-    tblib: '>=1.6.0'
-    toolz: '>=0.10.0'
-    tornado: '>=6.0.4'
-    urllib3: '>=1.24.3'
-    zict: '>=3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc8c9391ef25c481d768967db027dfc0
-    sha256: ff82170e2b6ce9aed68b8e8e7c4dc6cde3d7eb94dfb4b024212231bcb11de635
-  category: main
-  optional: false
 - name: distro
   version: 1.9.0
   manager: conda
@@ -4430,39 +4133,39 @@ package:
   category: dev
   optional: true
 - name: filelock
-  version: 3.15.1
+  version: 3.15.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
   hash:
-    md5: ca4149866d80007713ff47906bba8cb3
-    sha256: 4b32cbd6082db21d463250cbfaaaaf37bfaa84950deeb1298753cae8d45771e7
+    md5: 0e7e4388e9d5283e22b35a9443bdbcc9
+    sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
   category: main
   optional: false
 - name: filelock
-  version: 3.15.1
+  version: 3.15.4
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
   hash:
-    md5: ca4149866d80007713ff47906bba8cb3
-    sha256: 4b32cbd6082db21d463250cbfaaaaf37bfaa84950deeb1298753cae8d45771e7
+    md5: 0e7e4388e9d5283e22b35a9443bdbcc9
+    sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
   category: main
   optional: false
 - name: filelock
-  version: 3.15.1
+  version: 3.15.4
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
   hash:
-    md5: ca4149866d80007713ff47906bba8cb3
-    sha256: 4b32cbd6082db21d463250cbfaaaaf37bfaa84950deeb1298753cae8d45771e7
+    md5: 0e7e4388e9d5283e22b35a9443bdbcc9
+    sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
   category: main
   optional: false
 - name: flatten-dict
@@ -4825,8 +4528,8 @@ package:
   hash:
     md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
     sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: freetype
   version: 2.12.1
   manager: conda
@@ -4838,8 +4541,8 @@ package:
   hash:
     md5: e6085e516a3e304ce41a8ee08b9b89ad
     sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: freetype
   version: 2.12.1
   manager: conda
@@ -4854,8 +4557,8 @@ package:
   hash:
     md5: 3761b23693f768dc75a8fd0a73ca053f
     sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: fribidi
   version: 1.0.10
   manager: conda
@@ -5287,10 +4990,10 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
   hash:
-    md5: e358c7c5f6824c272b5034b3816438a7
-    sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
+    md5: c94a5994ef49749880a8139cf9afcbe1
+    sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
   category: main
   optional: false
 - name: gmp
@@ -5298,11 +5001,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
   hash:
-    md5: 64f45819921ba710398706e1a6404eb5
-    sha256: 0ed5aff70675dc0ed5c2f39bb02b908b864e8eee4ceb56e1c798ba8d7509551f
+    md5: eed7278dfbab727b56f2c0b64330814b
+    sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
   category: main
   optional: false
 - name: gmpy2
@@ -5860,7 +5564,7 @@ package:
   category: dev
   optional: true
 - name: hatchling
-  version: 1.24.2
+  version: 1.25.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5872,14 +5576,14 @@ package:
     python: '>=3.7'
     tomli: '>=1.2.2'
     trove-classifiers: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 28cef29029f6da70e7a987a76a3599a4
-    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+    md5: 7571d6e5561b04aef679a11904dfcebf
+    sha256: fb8a16a913f909d8f7d2ae95c18a1aeb7be3eebfb1b7a4246500c06d54498f89
   category: dev
   optional: true
 - name: hatchling
-  version: 1.24.2
+  version: 1.25.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -5891,14 +5595,14 @@ package:
     python: '>=3.7'
     tomli: '>=1.2.2'
     trove-classifiers: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 28cef29029f6da70e7a987a76a3599a4
-    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+    md5: 7571d6e5561b04aef679a11904dfcebf
+    sha256: fb8a16a913f909d8f7d2ae95c18a1aeb7be3eebfb1b7a4246500c06d54498f89
   category: dev
   optional: true
 - name: hatchling
-  version: 1.24.2
+  version: 1.25.0
   manager: conda
   platform: win-64
   dependencies:
@@ -5910,10 +5614,10 @@ package:
     python: '>=3.7'
     tomli: '>=1.2.2'
     trove-classifiers: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.24.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 28cef29029f6da70e7a987a76a3599a4
-    sha256: 1161601871d8aa6c5ff7719a277462cdf0160351a88f2a84a22d6ead3b90150f
+    md5: 7571d6e5561b04aef679a11904dfcebf
+    sha256: fb8a16a913f909d8f7d2ae95c18a1aeb7be3eebfb1b7a4246500c06d54498f89
   category: dev
   optional: true
 - name: hpack
@@ -6287,8 +5991,8 @@ package:
   hash:
     md5: cc47e1facc155f91abd89b11e48e72ff
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: icu
   version: '73.2'
   manager: conda
@@ -6298,8 +6002,8 @@ package:
   hash:
     md5: 8521bd47c0e11c5902535bb1a17c565f
     sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: icu
   version: '73.2'
   manager: conda
@@ -6390,80 +6094,80 @@ package:
   category: main
   optional: false
 - name: importlib-metadata
-  version: 7.1.0
+  version: 7.2.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.2.1-pyha770c72_0.conda
   hash:
-    md5: 0896606848b2dc5cebdf111b6543aa04
-    sha256: cc2e7d1f7f01cede30feafc1118b7aefa244d0a12224513734e24165ae12ba49
-  category: main
-  optional: false
+    md5: b9f5330c0853ccabc39a9878c6f1a2ab
+    sha256: 21c0aed99d05658760c87dcb3fce6e1175966d1bc51b7c31981e779e90574d27
+  category: dev
+  optional: true
 - name: importlib-metadata
-  version: 7.1.0
+  version: 7.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.2.1-pyha770c72_0.conda
   hash:
-    md5: 0896606848b2dc5cebdf111b6543aa04
-    sha256: cc2e7d1f7f01cede30feafc1118b7aefa244d0a12224513734e24165ae12ba49
-  category: main
-  optional: false
+    md5: b9f5330c0853ccabc39a9878c6f1a2ab
+    sha256: 21c0aed99d05658760c87dcb3fce6e1175966d1bc51b7c31981e779e90574d27
+  category: dev
+  optional: true
 - name: importlib-metadata
-  version: 7.1.0
+  version: 7.2.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.2.1-pyha770c72_0.conda
   hash:
-    md5: 0896606848b2dc5cebdf111b6543aa04
-    sha256: cc2e7d1f7f01cede30feafc1118b7aefa244d0a12224513734e24165ae12ba49
-  category: main
-  optional: false
+    md5: b9f5330c0853ccabc39a9878c6f1a2ab
+    sha256: 21c0aed99d05658760c87dcb3fce6e1175966d1bc51b7c31981e779e90574d27
+  category: dev
+  optional: true
 - name: importlib_metadata
-  version: 7.1.0
+  version: 7.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=7.1.0,<7.1.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=7.2.1,<7.2.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.2.1-hd8ed1ab_0.conda
   hash:
-    md5: 6ef2b72d291b39e479d7694efa2b2b98
-    sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
-  category: main
-  optional: false
+    md5: d6c936d009aa63e5f82d216c95cdcaee
+    sha256: 24520c5f12ce9b78beb97b4f815ca7b763518cc84136e12f6db10aa23f55d0f8
+  category: dev
+  optional: true
 - name: importlib_metadata
-  version: 7.1.0
+  version: 7.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: '>=7.1.0,<7.1.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=7.2.1,<7.2.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.2.1-hd8ed1ab_0.conda
   hash:
-    md5: 6ef2b72d291b39e479d7694efa2b2b98
-    sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
-  category: main
-  optional: false
+    md5: d6c936d009aa63e5f82d216c95cdcaee
+    sha256: 24520c5f12ce9b78beb97b4f815ca7b763518cc84136e12f6db10aa23f55d0f8
+  category: dev
+  optional: true
 - name: importlib_metadata
-  version: 7.1.0
+  version: 7.2.1
   manager: conda
   platform: win-64
   dependencies:
-    importlib-metadata: '>=7.1.0,<7.1.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=7.2.1,<7.2.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.2.1-hd8ed1ab_0.conda
   hash:
-    md5: 6ef2b72d291b39e479d7694efa2b2b98
-    sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
-  category: main
-  optional: false
+    md5: d6c936d009aa63e5f82d216c95cdcaee
+    sha256: 24520c5f12ce9b78beb97b4f815ca7b763518cc84136e12f6db10aa23f55d0f8
+  category: dev
+  optional: true
 - name: importlib_resources
   version: 6.4.0
   manager: conda
@@ -7003,49 +6707,6 @@ package:
     sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
   category: main
   optional: false
-- name: lcms2
-  version: '2.16'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
-  hash:
-    md5: 51bb7010fc86f70eee639b4bb7a894f5
-    sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
-  category: main
-  optional: false
-- name: lcms2
-  version: '2.16'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
-  hash:
-    md5: 66f6c134e76fe13cce8a9ea5814b5dd5
-    sha256: 151e0c84feb7e0747fabcc85006b8973b22f5abbc3af76a9add0b0ef0320ebe4
-  category: main
-  optional: false
-- name: lcms2
-  version: '2.16'
-  manager: conda
-  platform: win-64
-  dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
-  hash:
-    md5: d3592435917b62a8becff3a60db674f6
-    sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
-  category: main
-  optional: false
 - name: ld_impl_linux-64
   version: '2.40'
   manager: conda
@@ -7131,8 +6792,8 @@ package:
   hash:
     md5: 76bbff344f0134279f225174e9064c8f
     sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: lerc
   version: 4.0.0
   manager: conda
@@ -7143,8 +6804,8 @@ package:
   hash:
     md5: de462d5aacda3b30721b512c5da4e742
     sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: lerc
   version: 4.0.0
   manager: conda
@@ -7156,8 +6817,8 @@ package:
   hash:
     md5: 1900cb3cab5055833cfddb0ba233b074
     sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libabseil
   version: '20240116.2'
   manager: conda
@@ -7204,6 +6865,10 @@ package:
   dependencies:
     aws-crt-cpp: '>=0.26.12,<0.26.13.0a0'
     aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
+    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.10.0,<12.10.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     gflags: '>=2.2.2,<2.3.0a0'
     glog: '>=0.7.1,<0.8.0a0'
@@ -7222,10 +6887,10 @@ package:
     re2: ''
     snappy: '>=1.2.0,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-16.1.0-h9102155_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-16.1.0-h4a673ee_10_cpu.conda
   hash:
-    md5: b0b7ce228075d1411a2ccb7e21f1b122
-    sha256: 149e20cc07b2380808a0028fae3ed7d4a88af2f9b4b7a769b31a675b62ec1dea
+    md5: c737ba625b762cc4cbe7c68d27e8d2e1
+    sha256: a36f9db24f9ab132564cf2bc2db5c1229ea1b27ad2f9fd3b3beea03bd1bc234d
   category: main
   optional: false
 - name: libarrow
@@ -7236,6 +6901,10 @@ package:
     __osx: '>=11.0'
     aws-crt-cpp: '>=0.26.12,<0.26.13.0a0'
     aws-sdk-cpp: '>=1.11.329,<1.11.330.0a0'
+    azure-core-cpp: '>=1.12.0,<1.12.1.0a0'
+    azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
+    azure-storage-blobs-cpp: '>=12.11.0,<12.11.1.0a0'
+    azure-storage-files-datalake-cpp: '>=12.10.0,<12.10.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     glog: '>=0.7.1,<0.8.0a0'
     libabseil: '>=20240116.2,<20240117.0a0'
@@ -7252,10 +6921,10 @@ package:
     re2: ''
     snappy: '>=1.2.0,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-16.1.0-h431211a_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-16.1.0-hcc492dc_10_cpu.conda
   hash:
-    md5: ad48aafb919b6a21e19266f7e14d276e
-    sha256: 4f95a408928ed018b9da4d9a89cf173365658c67e8b50a7db9e9abf1217275ea
+    md5: aa64beeecba56f20687830640d36037e
+    sha256: b92087c714a568044a3a6bca2282432633ecbc39c0875b1e102d74941b947809
   category: main
   optional: false
 - name: libarrow
@@ -7284,10 +6953,10 @@ package:
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-16.1.0-h08bbd85_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-16.1.0-h08bbd85_10_cpu.conda
   hash:
-    md5: 4f5f6c067bf877fcf4e8e8509a11b750
-    sha256: 1a39ccb832a1dab85b61cf29e4a8d69a18d40014aa80bbcbbabc50c611bf9b39
+    md5: 9c93dddf780facd96a8e127a7cb78973
+    sha256: b347c3e819f36e3978df2427d5a32ddd07f418a659f69a06348425d3f1bb8ada
   category: main
   optional: false
 - name: libarrow-acero
@@ -7298,10 +6967,10 @@ package:
     libarrow: 16.1.0
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-16.1.0-hac33072_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-16.1.0-hac33072_10_cpu.conda
   hash:
-    md5: e5c246be982ab7cc133b93870b264a25
-    sha256: 7331c72e6162c10f843105c0f5fe71813470286768cb1b5da9f3a79d6e56ad0c
+    md5: 1283e2eecd89d1e06c33d004451a4a9e
+    sha256: bb3bc9960e1f1f39ad054cfb816835bbd713a44e64c569280f3e188715252dc1
   category: main
   optional: false
 - name: libarrow-acero
@@ -7312,10 +6981,10 @@ package:
     __osx: '>=11.0'
     libarrow: 16.1.0
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-16.1.0-h00cdb27_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-16.1.0-h00cdb27_10_cpu.conda
   hash:
-    md5: 176c3595ef50c480e0aec823a0ccf6d4
-    sha256: f79746bfad436da1a07b45c8cc7f654661c4fd1b8662db171b76bbd16362a511
+    md5: d362624d2b3e08797e41d82299514b61
+    sha256: aa2f0b3aadd48574a2a01bf916908948c854e9bf9723ee26aab3ef4b465d5420
   category: main
   optional: false
 - name: libarrow-acero
@@ -7327,10 +6996,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-16.1.0-he0c23c2_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-16.1.0-he0c23c2_10_cpu.conda
   hash:
-    md5: f6154c5f1735cf49ed9705df84c2f827
-    sha256: e68887b28aa39aab01fd1039cfb6e71ccdc55a331133d0f906df720a4ec68af2
+    md5: f1fbbb04f78a21f704ddf0e66560604e
+    sha256: f938692d7421b4bccb1c84d6b80a77762c93885eb6f086c4f72ef5f2270a751f
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7343,10 +7012,10 @@ package:
     libgcc-ng: '>=12'
     libparquet: 16.1.0
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-16.1.0-hac33072_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-16.1.0-hac33072_10_cpu.conda
   hash:
-    md5: 45960fd843ea7b95d907e8aa1f49337d
-    sha256: f45ae06fca781a27cadd10f7949971bf39423ed1b03a8b2eaeefd0cddf02a5c6
+    md5: 49d2f8911e30844309aaf1fe221f0d66
+    sha256: 9eff44174aa6773c97d94b6882708f77394fa5fc59862885ad280b7aad087e10
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7359,10 +7028,10 @@ package:
     libarrow-acero: 16.1.0
     libcxx: '>=16'
     libparquet: 16.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-16.1.0-h00cdb27_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-16.1.0-h00cdb27_10_cpu.conda
   hash:
-    md5: 30ecd0317353e9de4d546860fa14d702
-    sha256: adc7741aca9203b4de4b5d03e8f84072ca5a86af527754116ca4e526b82986ec
+    md5: b72c5c171000c5460a26c2f0f06c7e09
+    sha256: 6d7760be9132e94fa8d03ed2c9c0de9d7beebef7169ffb23a8785989e669a51b
   category: main
   optional: false
 - name: libarrow-dataset
@@ -7376,10 +7045,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-16.1.0-he0c23c2_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-16.1.0-he0c23c2_10_cpu.conda
   hash:
-    md5: 29413668011de1e3b3be6b38a6892e71
-    sha256: cc4b4cc7ec5cccfc0c52d3c73e706d8617b8aeef0142f105eef1a771b213a67b
+    md5: 3274f44ee5025327d4c8cd7fe9423052
+    sha256: a2c4c0db80546c780b3ad4350616b4a794731a9582a8b4e03b657e1eb35f68ea
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7394,10 +7063,10 @@ package:
     libgcc-ng: '>=12'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-16.1.0-h7e0c224_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-16.1.0-h7e0c224_10_cpu.conda
   hash:
-    md5: b1cebbb3160bbafc6cbf7eb79354f32a
-    sha256: 3da1c83dd172b413886885417ef4a013e6f3e67ecc082057297a18b157f6eb70
+    md5: d3aa33ea25ffdc1147134b202c84158d
+    sha256: 67654938b3ac8f4e965c4f790e8168f9dbff25df146bf3dfbbf68509ce7e48c1
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7412,10 +7081,10 @@ package:
     libarrow-dataset: 16.1.0
     libcxx: '>=16'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-16.1.0-hc68f6b8_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-16.1.0-hc68f6b8_10_cpu.conda
   hash:
-    md5: 51a3f33608fa5185ef0034aebc0aa77e
-    sha256: a5802c6ac946cda338498d9020b93cb4d157c40f3ec6579d579584a55f05e02a
+    md5: e9103f667995a4c408d05297e319a6ba
+    sha256: bb64daac9c0cfad6f05733285f958743ae354aff9d6885306171ac0e754cf125
   category: main
   optional: false
 - name: libarrow-substrait
@@ -7431,10 +7100,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-16.1.0-h1f0e801_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-16.1.0-h1f0e801_10_cpu.conda
   hash:
-    md5: 46cc6c8a7478a82ab9a0b252a0c97bfe
-    sha256: b8ff3db6459d10320708981c54241cf7ede3cd10e022f3b5c94f754fd5e0c95f
+    md5: 7bc69a1e8be1b4799fd4f71d97eafc80
+    sha256: da7268cdbf4fdb3f40bc6419c563608ec128ef8c3caaca220b09dab5f19ec0e5
   category: main
   optional: false
 - name: libasprintf
@@ -7761,8 +7430,8 @@ package:
   hash:
     md5: 8e88f9389f1165d7c0936fe40d9a9a79
     sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libdeflate
   version: '1.20'
   manager: conda
@@ -7772,8 +7441,8 @@ package:
   hash:
     md5: 97efeaeba2a9a82bdf46fc6d025e3a57
     sha256: 6d16cccb141b6bb05c38107b335089046664ea1d6611601d3f6e7e4227a99925
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libdeflate
   version: '1.20'
   manager: conda
@@ -7786,8 +7455,8 @@ package:
   hash:
     md5: b12b5bde5eb201a1df75e49320cc938a
     sha256: 6628a5b76ad70c1a0909563c637ddc446ee824739ba7c348d4da2f0aa6ac9527
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libedit
   version: 3.1.20191231
   manager: conda
@@ -7953,10 +7622,10 @@ package:
   dependencies:
     _libgcc_mutex: '0.1'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h77fa898_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h77fa898_13.conda
   hash:
-    md5: bbb96c5e7a11ef8ca2b666fe9fe3d199
-    sha256: 78931358d83ff585d0cd448632366a5cbe6bcf41a66c07e8178200008127c2b5
+    md5: 9358cdd61ef0d600d2a0dde2d53b006c
+    sha256: ffa0f472c8b37f864de855af2d3c057f1813162319f10ebd97332d73fc27ba60
   category: main
   optional: false
 - name: libgd
@@ -8082,10 +7751,10 @@ package:
   platform: linux-64
   dependencies:
     libgfortran5: 13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_13.conda
   hash:
-    md5: a78f7b3d951665c4c57578a8d3787993
-    sha256: de97f291cda4be906c9021c93a9d5d40eb65ab7bd5cba38dfa11f12597d7ef6a
+    md5: 516e66b26eea14e7e322fe99e88e0f02
+    sha256: 3ef5d92510e9cdd70ec2a9f1f83b8c1d327ff0f9bfc17831a8f8f06f10c2085c
   category: main
   optional: false
 - name: libgfortran5
@@ -8094,10 +7763,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=13.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-h3d2ce59_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-h3d2ce59_13.conda
   hash:
-    md5: e3896e5c2dd1cbabaf4abb3254df47b0
-    sha256: be5f5873c392bc4c25bee25cef2d30a9dab69c0d82ff1ddf687f9ece6d36f56c
+    md5: 1e380198685bc1e993bbbc4b579f5916
+    sha256: 19cffb68b19ff5f426d1cb3db670dccb73c09f54b8d3f8e304665e2cee68f14f
   category: main
   optional: false
 - name: libgfortran5
@@ -8222,10 +7891,10 @@ package:
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h77fa898_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h77fa898_13.conda
   hash:
-    md5: 9404d1686e63142d41acc72ef876a588
-    sha256: bcea6ddfea86f0e6a1a831d1d2c3f36f7613b5e447229e19f978ded0d184cf5a
+    md5: d370d1855cca14dff6a819c90c77497c
+    sha256: c5949bec7eee93cdd5c367e6e5c5e92ee1c5139a827567af23853dd52721d8ed
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -8425,8 +8094,8 @@ package:
   hash:
     md5: d66573916ffcf376178462f1b61c941e
     sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -8436,8 +8105,8 @@ package:
   hash:
     md5: 69bda57310071cf6d2b86caf11573d2d
     sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -8499,8 +8168,8 @@ package:
   hash:
     md5: ea25936bb4080d843790b586850f82b8
     sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libjpeg-turbo
   version: 3.0.0
   manager: conda
@@ -8510,8 +8179,8 @@ package:
   hash:
     md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
     sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libjpeg-turbo
   version: 3.0.0
   manager: conda
@@ -8524,8 +8193,8 @@ package:
   hash:
     md5: 3f1b948619c45b1ca714d60c7389092c
     sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: liblapack
   version: 3.9.0
   manager: conda
@@ -8687,10 +8356,10 @@ package:
     libstdcxx-ng: '>=12'
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-16.1.0-h6a7eafb_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-16.1.0-h6a7eafb_10_cpu.conda
   hash:
-    md5: 4b42538e4ec9092564866d22d1120bf4
-    sha256: f6e1fff909c9f50b03cb480db3eb08e89511aa9a7b54c9bdfc3fc95f32d45625
+    md5: a65776bbdae47c8b725f77dbed54c5d2
+    sha256: 5ee24400a6be13b0b1469097379c3a4719caeffb43c1f9f4425bfdaf762f2ed9
   category: main
   optional: false
 - name: libparquet
@@ -8703,10 +8372,10 @@ package:
     libcxx: '>=16'
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-16.1.0-hcf52c46_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-16.1.0-hcf52c46_10_cpu.conda
   hash:
-    md5: dd2cd31c1a52c1c083fda9303e0238ff
-    sha256: a7b6d8ccd4c82bc7e9b298780c513aee8eb4ed249e5abaf21fb52de602cf1f5c
+    md5: 4ebfc2c6a8edb48003a4a205c151f15d
+    sha256: b160cd408351bebea686fd43cc4637a46a646b9bbc20963733287b972599df52
   category: main
   optional: false
 - name: libparquet
@@ -8720,10 +8389,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-16.1.0-h178134c_9_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-16.1.0-h178134c_10_cpu.conda
   hash:
-    md5: 70176efe48b255bc49a520b78d57af02
-    sha256: 41a09821a5b202d8df946a5012ec88f32b967f3de4d057a83aa95b3037f5cb79
+    md5: 9da99c7d1b336426fbf9d8cda8479530
+    sha256: 24994b4938b3b3b5622c82b5d4520323c8cd5c35195df82a039777470210ba86
   category: main
   optional: false
 - name: libpng
@@ -8737,8 +8406,8 @@ package:
   hash:
     md5: 009981dd9cfcaa4dbfa25ffaed86bcae
     sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libpng
   version: 1.6.43
   manager: conda
@@ -8749,8 +8418,8 @@ package:
   hash:
     md5: 77e684ca58d82cae9deebafb95b1a2b8
     sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libpng
   version: 1.6.43
   manager: conda
@@ -8764,8 +8433,8 @@ package:
   hash:
     md5: 77e398acc32617a0384553aea29e866b
     sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libprotobuf
   version: 4.25.3
   manager: conda
@@ -8979,10 +8648,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: 13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-hc0a3c3a_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-hc0a3c3a_13.conda
   hash:
-    md5: ea50441ab527f23ffa108ade07e2fde0
-    sha256: 9a5d43eed33fe8b2fd6adf71ef8f0253fd515e1440c9b7b7782db608e3085bea
+    md5: 1053882642ed5bbc799e1e866ff86826
+    sha256: 143171c6084e526122cc2976fbbfadf7b9f50e5d13036adf20feb7ed9d036dd2
   category: main
   optional: false
 - name: libthrift
@@ -9051,8 +8720,8 @@ package:
   hash:
     md5: 66f03896ffbe1a110ffda05c7a856504
     sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libtiff
   version: 4.6.0
   manager: conda
@@ -9070,8 +8739,8 @@ package:
   hash:
     md5: 28c9f8c6dd75666dfb296aea06c49cb8
     sha256: 6df3e129682f6dc43826e5028e1807624b2a7634c4becbb50e56be9f77167f25
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libtiff
   version: 4.6.0
   manager: conda
@@ -9090,8 +8759,8 @@ package:
   hash:
     md5: 6d1828c9039929e2f185c5fa9d133018
     sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libtorch
   version: 2.1.2
   manager: conda
@@ -9280,8 +8949,8 @@ package:
   hash:
     md5: b26e8aa824079e1be0294e7152ca4559
     sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libwebp-base
   version: 1.4.0
   manager: conda
@@ -9291,8 +8960,8 @@ package:
   hash:
     md5: c0af0edfebe780b19940e94871f1a765
     sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libwebp-base
   version: 1.4.0
   manager: conda
@@ -9305,53 +8974,39 @@ package:
   hash:
     md5: abd61d0ab127ec5cd68f62c2969e6f34
     sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: libxcb
-  version: '1.15'
+  version: '1.16'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     pthread-stubs: ''
-    xorg-libxau: ''
+    xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
   hash:
-    md5: 33277193f5b92bad9fdd230eb700929c
-    sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
-  category: main
-  optional: false
+    md5: 151cba22b85a989c2d6ef9633ffee1e4
+    sha256: 7180375f37fd264bb50672a63da94536d4abd81ccec059e932728ae056324b3a
+  category: dev
+  optional: true
 - name: libxcb
-  version: '1.15'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pthread-stubs: ''
-    xorg-libxau: ''
-    xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
-  hash:
-    md5: 988d5f86ab60fa6de91b3ee3a88a3af9
-    sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
-  category: main
-  optional: false
-- name: libxcb
-  version: '1.15'
+  version: '1.16'
   manager: conda
   platform: win-64
   dependencies:
     m2w64-gcc-libs: ''
     m2w64-gcc-libs-core: ''
     pthread-stubs: ''
-    xorg-libxau: ''
+    xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
   hash:
-    md5: 090d91b69396f14afef450c285f9758c
-    sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
-  category: main
-  optional: false
+    md5: 7c1217d3b075f195ab17370f2d550f5d
+    sha256: 3b1f3b04baa370cfb1c350cfa829e6236519df5f03e3f57ea2cb2eb044eb8616
+  category: dev
+  optional: true
 - name: libxcrypt
   version: 4.4.36
   manager: conda
@@ -9378,8 +9033,8 @@ package:
   hash:
     md5: 340278ded8b0dc3a73f3660bbb0adbc6
     sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: libxml2
   version: 2.12.7
   manager: conda
@@ -9394,8 +9049,8 @@ package:
   hash:
     md5: 8ea71a74847498c793b0a8e9054a177a
     sha256: 0ea12032b53d3767564a058ccd5208c0a1724ed2f8074dd22257ff3859ea6a4e
-  category: dev
-  optional: true
+  category: main
+  optional: false
 - name: libxml2
   version: 2.12.7
   manager: conda
@@ -9451,15 +9106,15 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 18.1.7
+  version: 18.1.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.7-hde57baf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_0.conda
   hash:
-    md5: 2f651f8977594cc74852fa280785187a
-    sha256: 30121bc3ebf134d69bcb24ab1270bfa2beeb0ae59579b8acb67a38e3531c05d1
+    md5: 82393fdbe38448d878a8848b6fcbcefb
+    sha256: 42bc913b3c91934a1ce7ff635e87ee48e2e252632f0cbf607c5a3e4409d9f9dd
   category: main
   optional: false
 - name: llvmlite
@@ -9510,88 +9165,6 @@ package:
   hash:
     md5: 13f71d9ece680a74d1b6a4117ef46bc6
     sha256: 0ebc278a5737c0893e139b3ef70330caceab09ddf39329b9e2c594883d990538
-  category: main
-  optional: false
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: main
-  optional: false
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: main
-  optional: false
-- name: locket
-  version: 1.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
-  url: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 91e27ef3d05cc772ce627e51cff111c4
-    sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
-  category: main
-  optional: false
-- name: lz4
-  version: 4.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py311h38e4bf4_0.conda
-  hash:
-    md5: 3910c815fc788621f88b2bdc0fa9f0a6
-    sha256: 61d20694cf17fd621fc07859ccdd810be9de702fd0fa5c8f60f0ef4602b8bcde
-  category: main
-  optional: false
-- name: lz4
-  version: 4.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.3.3-py311hd44b8e9_0.conda
-  hash:
-    md5: 55e5496cc171c496f2f1930de465b863
-    sha256: 94e21299626e9910d9a42de2d28e8ffc018af2dc0ecd247905d06b2a418f313a
-  category: main
-  optional: false
-- name: lz4
-  version: 4.3.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/lz4-4.3.3-py311haddf500_0.conda
-  hash:
-    md5: 5e0fceb00bc784481e1ac2aa44b1e844
-    sha256: 1f826e3a559eed39113d4d3b8131b937abf9d3139e63786ff0c8c295f0a5a652
   category: main
   optional: false
 - name: lz4-c
@@ -10544,54 +10117,6 @@ package:
     sha256: df806841be847e5287b22b6ae7f380874f81ea51f1b51ae14a570f3385c7b133
   category: dev
   optional: true
-- name: openjpeg
-  version: 2.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-  hash:
-    md5: 7f2e286780f072ed750df46dc2631138
-    sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
-  category: main
-  optional: false
-- name: openjpeg
-  version: 2.5.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
-  hash:
-    md5: 5029846003f0bc14414b9128a1f7c84b
-    sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
-  category: main
-  optional: false
-- name: openjpeg
-  version: 2.5.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
-  hash:
-    md5: 7e7099ad94ac3b599808950cec30ad4e
-    sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
-  category: main
-  optional: false
 - name: openssl
   version: 3.3.1
   manager: conda
@@ -10785,8 +10310,8 @@ package:
   hash:
     md5: 84e2dd379d4edec4dd6382861486104d
     sha256: d600c0cc42fca1ad36d969758b2495062ad83124ecfcf5673c98b11093af7055
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pandas
   version: 2.2.2
   manager: conda
@@ -10804,8 +10329,8 @@ package:
   hash:
     md5: b1790dadc62d0af23378d5a79b263893
     sha256: b08f214593af94dd9bb50d7bf432d1defde66312bd1a2476f27a5fdd9f45ef66
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pandas
   version: 2.2.2
   manager: conda
@@ -10824,8 +10349,8 @@ package:
   hash:
     md5: ec3ed8d602148625469dc13c481f23b5
     sha256: 351b4f7211fc755ea1af8b218d2515418df3af08170197011934faf06bb5d98e
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pango
   version: 1.54.0
   manager: conda
@@ -10888,48 +10413,6 @@ package:
     sha256: f7910cc0ea1cff76adb2bcec81627e10d6b13f1956a47a69422b71cdc554bfe6
   category: dev
   optional: true
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: main
-  optional: false
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: main
-  optional: false
-- name: partd
-  version: 1.4.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    locket: ''
-    python: '>=3.9'
-    toolz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0badf9c54e24cecfb0ad2f99d680c163
-    sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
-  category: main
-  optional: false
 - name: pastel
   version: 0.2.1
   manager: conda
@@ -11127,76 +10610,6 @@ package:
     sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
   category: dev
   optional: true
-- name: pillow
-  version: 10.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py311h18e6fac_0.conda
-  hash:
-    md5: 6c520a9d36c9d7270988c7a6c360d6d4
-    sha256: 6e54cc2acead8884e81e3e1b4f299b18d5daa0e3d11f4db5686db9e2ada2a353
-  category: main
-  optional: false
-- name: pillow
-  version: 10.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.3.0-py311h0b5d0a1_0.conda
-  hash:
-    md5: 15ea30bca869d60e6de571232638a701
-    sha256: 756788e2fa2088131da13cfaf923e33b8e5411fa07cac01eba7dfc95ef769920
-  category: main
-  optional: false
-- name: pillow
-  version: 10.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    tk: '>=8.6.13,<8.7.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py311h6819b35_0.conda
-  hash:
-    md5: 86b3e331bf65cca7b8b5aacf9fefa1be
-    sha256: aaf367926867e0cfe727b4f64b95d78b9db9166e634cd26ec6f847cdcb0e5adb
-  category: main
-  optional: false
 - name: pip
   version: '24.0'
   manager: conda
@@ -11516,34 +10929,35 @@ package:
   category: dev
   optional: true
 - name: psutil
-  version: 5.9.8
+  version: 6.0.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py311h331c9d8_0.conda
   hash:
-    md5: 9bc62d25dcf64eec484974a3123c9d57
-    sha256: 467788418a2c71fb3df9ac0a6282ae693d1070a6cb47cb59bdb529b53acaee1c
+    md5: f1cbef9236edde98a811ba5a98975f2e
+    sha256: 33fea160c284e588f4ff534567e84c8d3679556787708b9bab89a99e5008ac76
   category: main
   optional: false
 - name: psutil
-  version: 5.9.8
+  version: 6.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.8-py311h05b510d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py311hd3f4193_0.conda
   hash:
-    md5: 970ef0edddc6c2cfeb16b7225a28a1f4
-    sha256: 2b6e485c761fa3e7271c44a070c0d08e79a6758ac4d7a660eaff0ed0a60c6f2b
+    md5: 3cfef0112ab97269edb8fd98afc78288
+    sha256: 984318469265162206090199a756db2f327dada39b050c9878534663b3eb6268
   category: main
   optional: false
 - name: psutil
-  version: 5.9.8
+  version: 6.0.0
   manager: conda
   platform: win-64
   dependencies:
@@ -11552,10 +10966,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.8-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py311he736701_0.conda
   hash:
-    md5: 17e48538806e7c682d2ffcbd5c9f9aa0
-    sha256: 77760f2ce0d2be9339d94d0fb5b3d102659355563f5b6471a1231525e63ff581
+    md5: 325e47d267a6db408c1d61bde22c2d9c
+    sha256: 9a9900e87f48a04ea597a987105dd978f4d62312f334f2a0f58f3a749b42e226
   category: main
   optional: false
 - name: pthread-stubs
@@ -11568,19 +10982,8 @@ package:
   hash:
     md5: 22dad4df6e8630e8dff2428f6f6a7036
     sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
-  category: main
-  optional: false
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
-  hash:
-    md5: d3f26c6494d4105d4ecb85203d687102
-    sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pthread-stubs
   version: '0.4'
   manager: conda
@@ -11591,8 +10994,8 @@ package:
   hash:
     md5: a1f820480193ea83582b13249a7e7bd9
     sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: pthreads-win32
   version: 2.9.1
   manager: conda
@@ -12420,51 +11823,52 @@ package:
   category: main
   optional: false
 - name: python-blosc
-  version: 1.11.1
+  version: 1.11.2
   manager: conda
   platform: linux-64
   dependencies:
-    blosc: '>=1.21.5,<2.0a0'
+    blosc: '>=1.21.6,<2.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-blosc-1.11.1-py311h320fe9a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-blosc-1.11.2-py311hd037940_0.conda
   hash:
-    md5: a8d7790622393e0eb7301b79938dab02
-    sha256: 2160423a35a643e89aa262d383aa332eb4e0ae12030a916e26e3f5881092d1a5
+    md5: 2442b6b424ab92cdd6c41f543f59d645
+    sha256: b4f800176ed25f52a5d62465e4a391907e544696602500c0824f59c3e57fbed3
   category: main
   optional: false
 - name: python-blosc
-  version: 1.11.1
+  version: 1.11.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    blosc: '>=1.21.5,<2.0a0'
+    __osx: '>=11.0'
+    blosc: '>=1.21.6,<2.0a0'
     libcxx: '>=16'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-blosc-1.11.1-py311hfbe21a1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-blosc-1.11.2-py311h0111b8e_0.conda
   hash:
-    md5: bdc8dcef30561017a484166d73d1d820
-    sha256: b224e5c69ca88580fee53fc2a2cf006b94c6accaa327e664d9250c7ca7ec2966
+    md5: 029e8bf4c78e235b52c6a14b625fe012
+    sha256: 51b17825daa25486846743859b86d4ce534809272527330833eee3d1189fac1f
   category: main
   optional: false
 - name: python-blosc
-  version: 1.11.1
+  version: 1.11.2
   manager: conda
   platform: win-64
   dependencies:
-    blosc: '>=1.21.5,<2.0a0'
+    blosc: '>=1.21.6,<2.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-blosc-1.11.1-py311hf63dbb6_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python-blosc-1.11.2-py311hbc92ba2_0.conda
   hash:
-    md5: 7528e83b8377ff383afcf3450ff5c5bf
-    sha256: 431731f98fa7bfdabeece290bfef116dfc5f87481495bd7b8963bdb506df1f73
+    md5: bcc9ab797d1f74a8af72632c6eb68af4
+    sha256: f6af71107da68b27ea96340f5873954dc47919f1196620f5edd21015842a6a71
   category: main
   optional: false
 - name: python-dateutil
@@ -13228,7 +12632,7 @@ package:
   category: dev
   optional: true
 - name: ruff
-  version: 0.4.9
+  version: 0.4.10
   manager: conda
   platform: linux-64
   dependencies:
@@ -13236,14 +12640,14 @@ package:
     libstdcxx-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.4.9-py311hae69bc3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.4.10-py311hae69bc3_0.conda
   hash:
-    md5: 97b1901b332439b6a3ba8c1ebee8e0ee
-    sha256: 45765e0262e9b9435b653467e7efc50831753e530db808468a95cfb5d211cd38
+    md5: 0d1582d2fdbd445be8033b1ad3652af9
+    sha256: d9ff64d594b90605aacd466b42e4581960c46d0828035acb07aa2cae748945e2
   category: dev
   optional: true
 - name: ruff
-  version: 0.4.9
+  version: 0.4.10
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13251,14 +12655,14 @@ package:
     libcxx: '>=16'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.4.9-py311hd374d79_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.4.10-py311hd374d79_0.conda
   hash:
-    md5: 48cc00763083875f15a2cf4005ceefeb
-    sha256: edb688fcf874fda757e7034a55b21a7195a7b70fcddbbfb2acaeb3d0ca6446e4
+    md5: 5444e967aa38032f3f15b426099b2fe3
+    sha256: 69a33bf6a8418d7c679d00d7161c855a2045d5f903e6e85fb2308bb42321897d
   category: dev
   optional: true
 - name: ruff
-  version: 0.4.9
+  version: 0.4.10
   manager: conda
   platform: win-64
   dependencies:
@@ -13267,10 +12671,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.4.9-py311ha637bb9_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.4.10-py311ha637bb9_0.conda
   hash:
-    md5: 4b660bf499ffff4ddf379b5c4fc443e7
-    sha256: 3b3cbe3f005f86a8e400c3ac1822a3bb82eaf3a61899015d2da40b47d8334cd0
+    md5: 99c7927e9cec3b672c848abde78ac19f
+    sha256: d74514cc8e506ff29b7a88efea502e730b9e80b9ce88deaaebc29b3a63b965fe
   category: dev
   optional: true
 - name: s2n
@@ -13332,42 +12736,42 @@ package:
   category: dev
   optional: true
 - name: s3transfer
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: linux-64
   dependencies:
     botocore: '>=1.33.2,<2.0a.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+    md5: 80f00f9033aee2358171207746e09ea0
+    sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
   category: dev
   optional: true
 - name: s3transfer
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: osx-arm64
   dependencies:
     botocore: '>=1.33.2,<2.0a.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+    md5: 80f00f9033aee2358171207746e09ea0
+    sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
   category: dev
   optional: true
 - name: s3transfer
-  version: 0.10.1
+  version: 0.10.2
   manager: conda
   platform: win-64
   dependencies:
     botocore: '>=1.33.2,<2.0a.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
-    md5: a41cafc1fb653ce0e48b9310226e90fd
-    sha256: 1802059a0df82b191ecd4afab9c93599033b88370fac2b4d0e9687a831e92ab4
+    md5: 80f00f9033aee2358171207746e09ea0
+    sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
   category: dev
   optional: true
 - name: safetensors
@@ -13414,7 +12818,7 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.13.1
+  version: 1.14.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -13428,14 +12832,14 @@ package:
     numpy: '>=1.19,<3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.1-py311h517d4fd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py311h517d4fd_0.conda
   hash:
-    md5: 764b0e055f59dbd7d114d32b8c6e55e6
-    sha256: f2312e5565f39308639f982729c151c2c75d5eaf86ac2863e19765f9797f7f3b
+    md5: 92bf19ecf13e70907ae8c301de32ed10
+    sha256: 196efa22d669d5c39a294eab73915534893364f44d87fbf230527041f20a2c95
   category: main
   optional: false
 - name: scipy
-  version: 1.13.1
+  version: 1.14.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -13449,14 +12853,14 @@ package:
     numpy: '>=1.19,<3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.13.1-py311hceeca8c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.0-py311hceeca8c_0.conda
   hash:
-    md5: af2deddee1cc1f11a8a5799a64ecfe3a
-    sha256: 5fd68198ac99720a1cfc3d5e4f534909917ab02b5feb8bc6a70553f54ae65fb7
+    md5: b931df1a1fea50fcca51e03c744fda31
+    sha256: 72d639dbcf6160f3634ce3d0b9ca3ba109ea8b73dc2d6f2298e4befcfa5f8778
   category: main
   optional: false
 - name: scipy
-  version: 1.13.1
+  version: 1.14.0
   manager: conda
   platform: win-64
   dependencies:
@@ -13469,10 +12873,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.1-py311hd4686c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py311hd4686c6_0.conda
   hash:
-    md5: 980070a1c48686998f8256d0c4d76cf2
-    sha256: d692402c159ab3c23a722d3d168b013f21193ab01ce1a913582e6db7fe2f0ecf
+    md5: f710d249ab10c0cc4b47806ceec603e0
+    sha256: e2f4fa2c265ebf25b6eee47d6543ce2b47fa6462e15d58f905f3202308ac3cda
   category: main
   optional: false
 - name: scmrepo
@@ -13636,39 +13040,39 @@ package:
   category: dev
   optional: true
 - name: setuptools
-  version: 70.0.0
+  version: 70.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c8ddb4f34a208df4dd42509a0f6a1c89
-    sha256: daa4638d288cfdf3b0ecea395d8efa25cafc4ebf4026464a36c797c84541d2be
+    md5: 258e66f95f814d51ada2a1fe9274039b
+    sha256: a43d33436f4ac57ebd6ee15f700b33b26a2d37b7e43981b1fa036908579dafd6
   category: main
   optional: false
 - name: setuptools
-  version: 70.0.0
+  version: 70.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c8ddb4f34a208df4dd42509a0f6a1c89
-    sha256: daa4638d288cfdf3b0ecea395d8efa25cafc4ebf4026464a36c797c84541d2be
+    md5: 258e66f95f814d51ada2a1fe9274039b
+    sha256: a43d33436f4ac57ebd6ee15f700b33b26a2d37b7e43981b1fa036908579dafd6
   category: main
   optional: false
 - name: setuptools
-  version: 70.0.0
+  version: 70.1.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: c8ddb4f34a208df4dd42509a0f6a1c89
-    sha256: daa4638d288cfdf3b0ecea395d8efa25cafc4ebf4026464a36c797c84541d2be
+    md5: 258e66f95f814d51ada2a1fe9274039b
+    sha256: a43d33436f4ac57ebd6ee15f700b33b26a2d37b7e43981b1fa036908579dafd6
   category: main
   optional: false
 - name: shellingham
@@ -14026,42 +13430,6 @@ package:
     sha256: bc12100b2d8836b93c55068b463190505b8064d0fc7d025e89f20ebf22fe6c2b
   category: dev
   optional: true
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6d6552722448103793743dabfbda532d
-    sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-  category: main
-  optional: false
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6d6552722448103793743dabfbda532d
-    sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-  category: main
-  optional: false
-- name: sortedcontainers
-  version: 2.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6d6552722448103793743dabfbda532d
-    sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-  category: main
-  optional: false
 - name: sqltrie
   version: 0.11.0
   manager: conda
@@ -14107,54 +13475,6 @@ package:
     sha256: d8cf09e2d5d1b3a1afc0585d7d4c7f110c2c35d9cc97f178869a2732c16d930a
   category: dev
   optional: true
-- name: swifter
-  version: 1.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dask: '>=2.10.0'
-    pandas: '>=1.0.0'
-    psutil: '>=5.6.6'
-    python: '>=3.6'
-    tqdm: '>=4.33.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/swifter-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f0baedb54d258c14f2627921d8fd5d9
-    sha256: ed328c7c2129161dcd3b318865dfdb25b68799203f69541d96e1aba496af41f1
-  category: main
-  optional: false
-- name: swifter
-  version: 1.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    dask: '>=2.10.0'
-    pandas: '>=1.0.0'
-    psutil: '>=5.6.6'
-    python: '>=3.6'
-    tqdm: '>=4.33.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/swifter-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f0baedb54d258c14f2627921d8fd5d9
-    sha256: ed328c7c2129161dcd3b318865dfdb25b68799203f69541d96e1aba496af41f1
-  category: main
-  optional: false
-- name: swifter
-  version: 1.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    dask: '>=2.10.0'
-    pandas: '>=1.0.0'
-    psutil: '>=5.6.6'
-    python: '>=3.6'
-    tqdm: '>=4.33.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/swifter-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f0baedb54d258c14f2627921d8fd5d9
-    sha256: ed328c7c2129161dcd3b318865dfdb25b68799203f69541d96e1aba496af41f1
-  category: main
-  optional: false
 - name: sympy
   version: 1.12.1
   manager: conda
@@ -14247,42 +13567,6 @@ package:
   hash:
     md5: e98333643abc739ebea1bac97a479828
     sha256: 87461c83a4f0d4f119af7368f20c47bbe0c27d963a7c22a3d08c71075077f855
-  category: main
-  optional: false
-- name: tblib
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 04eedddeb68ad39871c8127dd1c21f4f
-    sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
-  category: main
-  optional: false
-- name: tblib
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 04eedddeb68ad39871c8127dd1c21f4f
-    sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
-  category: main
-  optional: false
-- name: tblib
-  version: 3.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tblib-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 04eedddeb68ad39871c8127dd1c21f4f
-    sha256: 2e2c255b6f24a6d75b9938cb184520e27db697db2c24f04e18342443ae847c0a
   category: main
   optional: false
 - name: tk
@@ -14491,8 +13775,8 @@ package:
   hash:
     md5: 2fcb582444635e2c402e8569bb94e039
     sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: toolz
   version: 0.12.1
   manager: conda
@@ -14503,8 +13787,8 @@ package:
   hash:
     md5: 2fcb582444635e2c402e8569bb94e039
     sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: toolz
   version: 0.12.1
   manager: conda
@@ -14515,52 +13799,8 @@ package:
   hash:
     md5: 2fcb582444635e2c402e8569bb94e039
     sha256: 22b0a9790317526e08609d5dfdd828210ae89e6d444a9e954855fc29012e90c6
-  category: main
-  optional: false
-- name: tornado
-  version: 6.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h331c9d8_0.conda
-  hash:
-    md5: e29e451c96bf8e81a5760b7565c6ed2c
-    sha256: 753f5496ba6a69fc52bd58e55296d789b964d1ba1539420bfc10bcd0e1d016fb
-  category: main
-  optional: false
-- name: tornado
-  version: 6.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311hd3f4193_0.conda
-  hash:
-    md5: 180f7d621916cb04e655d4eda068f4bc
-    sha256: 4924c617390d88a6f85879b2892a42b3feeea4d1e5fb2f23b2175eeb2b41c7f2
-  category: main
-  optional: false
-- name: tornado
-  version: 6.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_0.conda
-  hash:
-    md5: d6b9b155b10baf4ee79602a0e6b8265f
-    sha256: 6efb2b0eaf5063c76288d1bf1a55488e9035d86bd63380de5ed4990499ca6859
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: tqdm
   version: 4.66.4
   manager: conda
@@ -15174,7 +14414,7 @@ package:
   category: dev
   optional: true
 - name: virtualenv
-  version: 20.26.2
+  version: 20.26.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -15182,14 +14422,14 @@ package:
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 7d36e7a485ea2f5829408813bdbbfb38
-    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
+    md5: 284008712816c64c85bf2b7fa9f3b264
+    sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
   category: dev
   optional: true
 - name: virtualenv
-  version: 20.26.2
+  version: 20.26.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -15197,14 +14437,14 @@ package:
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 7d36e7a485ea2f5829408813bdbbfb38
-    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
+    md5: 284008712816c64c85bf2b7fa9f3b264
+    sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
   category: dev
   optional: true
 - name: virtualenv
-  version: 20.26.2
+  version: 20.26.3
   manager: conda
   platform: win-64
   dependencies:
@@ -15212,46 +14452,46 @@ package:
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 7d36e7a485ea2f5829408813bdbbfb38
-    sha256: 1eefd180723fb2fd295352323b53777eeae5765b24d62ae75fc9f1e71b455f11
+    md5: 284008712816c64c85bf2b7fa9f3b264
+    sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
   category: dev
   optional: true
 - name: voluptuous
-  version: 0.14.2
+  version: 0.15.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d61310a459c334702a00a2b7f4fc534c
-    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
+    md5: d1c131b6f09b6f4630efdbcf18ebf445
+    sha256: 55acf47fa211d038c4b98db0ad16acbb1d05c7a77013470df3594c9992fc64a6
   category: dev
   optional: true
 - name: voluptuous
-  version: 0.14.2
+  version: 0.15.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d61310a459c334702a00a2b7f4fc534c
-    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
+    md5: d1c131b6f09b6f4630efdbcf18ebf445
+    sha256: 55acf47fa211d038c4b98db0ad16acbb1d05c7a77013470df3594c9992fc64a6
   category: dev
   optional: true
 - name: voluptuous
-  version: 0.14.2
+  version: 0.15.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d61310a459c334702a00a2b7f4fc534c
-    sha256: ff338b235fcbd764e97aec5bed53ea95eaf42f6edb4b34c697da2fce0e46b1cf
+    md5: d1c131b6f09b6f4630efdbcf18ebf445
+    sha256: 55acf47fa211d038c4b98db0ad16acbb1d05c7a77013470df3594c9992fc64a6
   category: dev
   optional: true
 - name: vs2015_runtime
@@ -15514,14 +14754,14 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
+    libxcb: '>=1.16,<1.17.0a0'
     xorg-kbproto: ''
     xorg-xextproto: '>=7.3.0,<8.0a0'
     xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-hb711507_1.conda
   hash:
-    md5: 077b6e8ad6a3ddb741fce2496dd01bec
-    sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
+    md5: 4a6d410296d7e39f00bacdee7df046e9
+    sha256: 66eabe62b66c1597c4a755dcd3f4ce2c78adaf7b32e25dfee45504d67d7735c1
   category: dev
   optional: true
 - name: xorg-libx11
@@ -15529,16 +14769,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
+    libxcb: '>=1.16,<1.17.0a0'
     m2w64-gcc-libs: ''
     m2w64-gcc-libs-core: ''
     xorg-kbproto: ''
     xorg-xextproto: '>=7.3.0,<8.0a0'
     xorg-xproto: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.9-hefa74cf_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libx11-1.8.9-h0076a8d_1.conda
   hash:
-    md5: 3672e991346895f332af1ebc60b8bca9
-    sha256: 15217b9180ff7d6840762363647fabcb79636517454d2c05dd69cb3fc38a1001
+    md5: 0296a4de2235cad9ad3112134f8e4519
+    sha256: c378304044321e74c6acd483674f404864a229ab2a8841bf9515bc1a30783e99
   category: dev
   optional: true
 - name: xorg-libxau
@@ -15551,19 +14791,8 @@ package:
   hash:
     md5: 2c80dc38fface310c9bd81b17037fee5
     sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
-  category: main
-  optional: false
-- name: xorg-libxau
-  version: 1.0.11
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
-  hash:
-    md5: ca73dc4f01ea91e44e3ed76602c5ea61
-    sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxau
   version: 1.0.11
   manager: conda
@@ -15575,8 +14804,8 @@ package:
   hash:
     md5: c46ba8712093cb0114404ae8a7582e1a
     sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxdmcp
   version: 1.1.3
   manager: conda
@@ -15587,19 +14816,8 @@ package:
   hash:
     md5: be93aabceefa2fac576e971aef407908
     sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
-  category: main
-  optional: false
-- name: xorg-libxdmcp
-  version: 1.1.3
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
-  hash:
-    md5: 6738b13f7fadc18725965abdd4129c36
-    sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxdmcp
   version: 1.1.3
   manager: conda
@@ -15610,8 +14828,8 @@ package:
   hash:
     md5: 46878ebb6b9cbd8afcf8088d7ef00ece
     sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: xorg-libxext
   version: 1.3.4
   manager: conda
@@ -15787,42 +15005,6 @@ package:
     sha256: 885f25c30141182f1841891dea54aea172da13911ba1625a6945e3553cae5aaf
   category: main
   optional: false
-- name: xyzservices
-  version: 2024.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de631703d59e40af41c56c4b4e2928ab
-    sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
-  category: main
-  optional: false
-- name: xyzservices
-  version: 2024.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de631703d59e40af41c56c4b4e2928ab
-    sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
-  category: main
-  optional: false
-- name: xyzservices
-  version: 2024.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de631703d59e40af41c56c4b4e2928ab
-    sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
-  category: main
-  optional: false
 - name: xz
   version: 5.2.6
   manager: conda
@@ -15983,42 +15165,6 @@ package:
     sha256: 0f6bedc9bd46f31ca888fd63149b3bc19e9616c8d808a72e8648dd6658e87500
   category: dev
   optional: true
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf30c2c15b82aacb07f9c09e28ff2275
-    sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
-  category: main
-  optional: false
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf30c2c15b82aacb07f9c09e28ff2275
-    sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
-  category: main
-  optional: false
-- name: zict
-  version: 3.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf30c2c15b82aacb07f9c09e28ff2275
-    sha256: 3d65c081514569ab3642ba7e6c2a6b4615778b596db6b1c82ee30a2d912539e5
-  category: main
-  optional: false
 - name: zipp
   version: 3.19.2
   manager: conda
@@ -16029,8 +15175,8 @@ package:
   hash:
     md5: 49808e59df5535116f6878b2a820d6f4
     sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zipp
   version: 3.19.2
   manager: conda
@@ -16041,8 +15187,8 @@ package:
   hash:
     md5: 49808e59df5535116f6878b2a820d6f4
     sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zipp
   version: 3.19.2
   manager: conda
@@ -16053,8 +15199,8 @@ package:
   hash:
     md5: 49808e59df5535116f6878b2a820d6f4
     sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
-  category: main
-  optional: false
+  category: dev
+  optional: true
 - name: zlib
   version: 1.3.1
   manager: conda
@@ -16097,49 +15243,53 @@ package:
   category: dev
   optional: true
 - name: zstandard
-  version: 0.19.0
+  version: 0.22.0
   manager: conda
   platform: linux-64
   dependencies:
-    cffi: '>=1.8'
+    cffi: '>=1.11'
     libgcc-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py311hd4cff14_0.tar.bz2
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.22.0-py311hb6f056b_1.conda
   hash:
-    md5: 056b3271f46abaa4673c8c6783283a07
-    sha256: 8aac43cc4fbdcc420fe8a22c764b67f6ac9168b103bfd10d79a82b748304ddf6
+    md5: 72e84ef20a510ab5fca1f3d80a16e9e2
+    sha256: 9980740f9b5f9028288c71b750d6a6691d0676ae50db97866d9ee34ab51e8b16
   category: dev
   optional: true
 - name: zstandard
-  version: 0.19.0
+  version: 0.22.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    cffi: '>=1.8'
+    __osx: '>=11.0'
+    cffi: '>=1.11'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.19.0-py311he2be06e_0.tar.bz2
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.22.0-py311h4a6b76e_1.conda
   hash:
-    md5: ece21cb47a93c985aa4b44219c4c8c8b
-    sha256: 43eaee70cd406468d96d1643b75d16e0da3955a9c1d37056767134b91b61d515
+    md5: 34b2bd2270fd11f9926e0498c0c87a05
+    sha256: b7b86382936a604d58af2706933c743c124bd9078054e13e6b76d57807596613
   category: dev
   optional: true
 - name: zstandard
-  version: 0.19.0
+  version: 0.22.0
   manager: conda
   platform: win-64
   dependencies:
-    cffi: '>=1.8'
+    cffi: '>=1.11'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.19.0-py311ha68e1ae_0.tar.bz2
+    vc14_runtime: '>=14.29.30139'
+    zstd: '>=1.5.6,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.22.0-py311h53056dc_1.conda
   hash:
-    md5: 94114ffe0cad9e1e704e2c0015c8aa87
-    sha256: c687a7d884e98c69f4f1fee8cb9949157bba7c76a54176edeb3262c156e08e71
+    md5: f9b1a5dbb2fb0f25c0ab72249f123273
+    sha256: 5926beed451fbd6bb426179b2e45ca0305392241dd8808c1664a2bbe4191a4fa
   category: dev
   optional: true
 - name: zstd

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - pytest >=7
   - coverage >=6.5
   - pexpect~=4.9
+  - pandas==2.*
   # tooling for code validation
   - pre-commit >=3.7,<4
   - ruff >=0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ dependencies = [
   "lenskit==0.14.*",
   "nltk>=3.8,<4",
   "numpy>=1.26,<2",
-  "pandas==2.*",
-  "swifter>=1.4,<2",
   "torch==2.*",
   "smart_open==7.*",
   "safetensors>=0.4,<1",
@@ -44,6 +42,7 @@ python = "3.11"
 dependencies = [
   "dvc[s3] ~=3.51",
   "docopt~=0.6",
+  "pandas==2.*",
   "requests~=2.13",
   "coverage[toml]>=6.5",
   "pytest>=8",


### PR DESCRIPTION
This removes `pandas` and `swifter` as (non-dev) dependencies, and may also fix a bug in the existing embedding code (judging by the recommendations produced.)