### PR TITLE
Use equal weights for unselected topics in PFAR

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -17,7 +17,7 @@ from safetensors.torch import load_file
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
-from poprox_concepts import Article, ClickHistory, InterestProfile
+from poprox_concepts import GENERAL_TOPICS, Article, ClickHistory, InterestProfile
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
 from poprox_recommender.topics import extract_general_topics
@@ -207,9 +207,7 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
                     product = 0
                     break
 
-            for topic in candidate_topics:
-                if topic in topic_preferences:
-                    summation += topic_preferences[topic]
+                summation += 1.0 / len(GENERAL_TOPICS)
 
             pfar_score_i = relevance_i + lamb * tau * summation * product
 

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -17,7 +17,8 @@ from safetensors.torch import load_file
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
-from poprox_concepts import GENERAL_TOPICS, Article, ClickHistory, InterestProfile
+from poprox_concepts import Article, ClickHistory, InterestProfile
+from poprox_concepts.domain.topics import GENERAL_TOPICS
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
 from poprox_recommender.topics import extract_general_topics


### PR DESCRIPTION
If I understand correctly, the original paper assumes that people prefer providers equally, which we know isn't true when the "providers" are topics. However, limiting the PFAR boost to topics people have actually clicked on (or selected during onboarding) reduces the impact of diversification to only one or two slots out of the ten in our newsletters.

I think the reason is that the set of selected topics grows very quickly since most articles have several high-level topics, so after the first few slots there simply aren't any more topics that haven't already been selected. That's even more true when using the intersection of people's topic preferences with the list of high-level topics (which will be a shorter list.)