### PR TITLE
Improve ease of running tests from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To set up the environment with Conda:
 conda install -n base -c conda-forge conda-lock
 conda lock install -n poprox-recsys --dev
 conda activate poprox-recsys
+python -m pip install --no-deps -e .
 ```
 
 If you use `micromamba` instead of a full Conda installation, it can directly use the lockfile:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ If you use `micromamba` instead of a full Conda installation, it can directly us
 
 ```console
 micromamba create -n poprox-recs -f conda-lock.yml --category main --category dev
+python -m pip install --no-deps -e .
 ```
+
+> [!NOTE]
+> You need to re-run the `pip install` every time you re-create your Conda environment.
 
 Set up `pre-commit` to make sure that code formatting rules are applied as you make changes:
 

--- a/serverless/offline.functions.yaml
+++ b/serverless/offline.functions.yaml
@@ -1,6 +1,6 @@
 functions:
   generateRecommendations:
-    handler: src.poprox_recommender.handler.generate_recs
+    handler: poprox_recommender.handler.generate_recs
     memorySize: 4096
     events:
       - httpApi:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# PyTest runs this file before even attempting to import any of the test cases,
+# so in addition to dynamic PyTest configuration, we can also put code to set
+# up import paths and things like that here.
 import os
 import sys
 from pathlib import Path
@@ -11,4 +14,5 @@ try:
 except ImportError:
     # tweak up paths so pytest can work without installing the recommender
     sys.path.insert(0, os.fspath(src_dir))
+    # put in `PYTHONPATH` too so that serverless can find our python code
     os.environ["PYTHONPATH"] = os.fspath(src_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from pathlib import Path
+
+test_dir = Path(__file__).parent
+root_dir = test_dir.parent.resolve()
+src_dir = root_dir / "src"
+
+try:
+    import poprox_recommender  # noqa: F401
+except ImportError:
+    # tweak up paths so pytest can work without installing the recommender
+    sys.path.insert(0, os.fspath(src_dir))
+    os.environ["PYTHONPATH"] = os.fspath(src_dir)

--- a/tests/test_serverless_offline.py
+++ b/tests/test_serverless_offline.py
@@ -3,6 +3,7 @@ Test the POPROX endpoint running under Serverless Offline.
 """
 
 import logging
+import os
 import sys
 from pathlib import Path
 from threading import Condition, Lock, Thread
@@ -19,6 +20,11 @@ def sl_listener():
     """
     Fixture that starts and stops serverless offline to test endpoint responses.
     """
+
+    local = os.environ.get("POPROX_LOCAL_LAMBDA", None)
+    if local:
+        yield
+        return
 
     thread = ServerlessBackground()
     thread.start()


### PR DESCRIPTION
This makes 4 improvements to our documentation and test setup to reduce risk of error in local test runs:

1. Add the editable install instructions to README as a part of dev setup
2. Add logic to `conftest.py` (which PyTest runs before importing tests) to auto-detect whether the recommender package is installed in editable mode, and add the `src` directory to the Python search path if it is not.
3. Add logic to the serverless tests to skip running serverless if an environment variable is set, to make it easier to debug the tests themselves by having them ping a manually-started serverless process.
4. Set up Serverless to import from `poprox_recommender`, not `src.poprox_recommender`, so import errors due to incorrect installs happen when Serverless tries to import the handler instead of when the handler tries to import its sub-components.