### PR TITLE
Use equal weights for unselected topics in PFAR

### DIFF
--- a/src/poprox_recommender/diversifiers/pfar.py
+++ b/src/poprox_recommender/diversifiers/pfar.py
@@ -2,7 +2,7 @@ import math
 
 import torch as th
 
-from poprox_recommender.topics import extract_general_topics, normalized_topic_count
+from poprox_recommender.topics import GENERAL_TOPICS, extract_general_topics, normalized_topic_count
 
 
 class PFARDiversifier:
@@ -68,7 +68,7 @@ def pfar_diversification(relevance_scores, articles, topic_preferences, lamb, ta
 
             for topic in candidate_topics:
                 if topic in topic_preferences:
-                    summation += topic_preferences[topic]
+                    summation += 1.0 / len(GENERAL_TOPICS)
 
             pfar_score_i = relevance_i + lamb * tau * summation * product
 


### PR DESCRIPTION
(Based on #45 and the updated state of `main`)

If I understand correctly, the original paper assumes that people prefer providers equally, which we know isn't true when the "providers" are topics. However, limiting the PFAR boost to topics people have actually clicked on (or selected during onboarding) reduces the impact of diversification to only one or two slots out of the ten in our newsletters.

I think the reason is that the set of selected topics grows very quickly since most articles have several high-level topics, so after the first few slots there simply aren't any more topics that haven't already been selected. That's even more true when using the intersection of people's topic preferences with the list of high-level topics (which will be a shorter list.)