### PR TITLE
Move article embedding lookup table construction to `UserEmbedder`

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -31,15 +31,15 @@ def select_articles(
         user_embedder = UserEmbedder(MODEL, DEVICE)
         article_scorer = ArticleScorer(MODEL)
 
-        candidate_article_lookup, candidate_article_tensor = article_embedder(candidate_articles)
-        clicked_article_lookup, clicked_article_tensor = article_embedder(clicked_articles)
+        candidate_article_embeddings = article_embedder(candidate_articles)
+        clicked_article_embeddings = article_embedder(clicked_articles)
 
-        user_embedding = user_embedder(interest_profile, clicked_article_lookup)
-        article_scores = article_scorer(candidate_article_tensor, user_embedding)
+        user_embedding = user_embedder(interest_profile, clicked_articles, clicked_article_embeddings)
+        article_scores = article_scorer(candidate_article_embeddings, user_embedding)
 
         if diversify == "mmr":
             diversifier = MMRDiversifier(algo_params)
-            recs = diversifier(article_scores, candidate_article_tensor, num_slots)
+            recs = diversifier(article_scores, candidate_article_embeddings, num_slots)
 
         elif diversify == "pfar":
             diversifier = PFARDiversifier(algo_params)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -18,7 +18,7 @@ def select_articles(
     algo_params: dict[str, Any] | None = None,
 ) -> dict[UUID, list[Article]]:
     click_history = interest_profile.click_history
-    clicked_articles = filter(lambda a: a.article_id in set(click_history.article_ids), past_articles)
+    clicked_articles = list(filter(lambda a: a.article_id in set(click_history.article_ids), past_articles))
     interest_profile.click_topic_counts = user_topic_preference(past_articles, interest_profile.click_history)
     account_id = click_history.account_id
 

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -16,9 +16,8 @@ class ArticleEmbedder:
                 article.title, padding="max_length", max_length=30, truncation=True
             )
 
-        articles = {
-            "id": list(tokenized_titles.keys()),
-            "title": th.tensor(list(tokenized_titles.values())),
-        }
+        title_tensor = th.tensor(list(tokenized_titles.values())).to(self.device)
+        if len(title_tensor.shape) == 1:
+            title_tensor = title_tensor.unsqueeze(dim=0)
 
-        return self.model.get_news_vector(articles["title"].to(self.device))
+        return self.model.get_news_vector(title_tensor)

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -9,34 +9,16 @@ class ArticleEmbedder:
         self.tokenizer = tokenizer
         self.device = device
 
-    def __call__(self, articles: list[Article]):
-        article_features = transform_article_features(articles, self.tokenizer)
-        article_lookup, article_tensor = build_article_embeddings(article_features, self.model, self.device)
+    def __call__(self, articles: list[Article]) -> th.Tensor:
+        tokenized_titles = {}
+        for article in articles:
+            tokenized_titles[article.article_id] = self.tokenizer.encode(
+                article.title, padding="max_length", max_length=30, truncation=True
+            )
 
-        return article_lookup, article_tensor
+        articles = {
+            "id": list(tokenized_titles.keys()),
+            "title": th.tensor(list(tokenized_titles.values())),
+        }
 
-
-def transform_article_features(articles: list[Article], tokenizer) -> dict[str, list]:
-    tokenized_titles = {}
-    for article in articles:
-        tokenized_titles[article.article_id] = tokenizer.encode(
-            article.title, padding="max_length", max_length=30, truncation=True
-        )
-
-    return tokenized_titles
-
-
-# Compute a vector for each news story
-def build_article_embeddings(article_features, model, device) -> tuple[dict[str, th.Tensor], th.Tensor]:
-    articles = {
-        "id": list(article_features.keys()),
-        "title": th.tensor(list(article_features.values())),
-    }
-    article_embeddings = {}
-    article_vectors = model.get_news_vector(articles["title"].to(device))
-    for article_id, article_vector in zip(articles["id"], article_vectors, strict=False):
-        if article_id not in article_embeddings:
-            article_embeddings[article_id] = article_vector
-
-    article_embeddings["PADDED_NEWS"] = th.zeros(list(article_embeddings.values())[0].size(), device=device)
-    return article_embeddings, article_vectors
+        return self.model.get_news_vector(articles["title"].to(self.device))

--- a/src/poprox_recommender/embedders/user.py
+++ b/src/poprox_recommender/embedders/user.py
@@ -12,18 +12,16 @@ class UserEmbedder:
     def __call__(
         self, interest_profile: InterestProfile, clicked_articles: list[Article], clicked_article_embeddings: th.Tensor
     ):
-        clicked_article_embeddings = {}
+        embedding_lookup = {}
         for article, article_vector in zip(clicked_articles, clicked_article_embeddings, strict=True):
-            if article.article_id not in clicked_article_embeddings:
-                clicked_article_embeddings[article.article_id] = article_vector
+            if article.article_id not in embedding_lookup:
+                embedding_lookup[article.article_id] = article_vector
 
-        clicked_article_embeddings["PADDED_NEWS"] = th.zeros(
-            list(clicked_article_embeddings.values())[0].size(), device=self.device
-        )
+        embedding_lookup["PADDED_NEWS"] = th.zeros(list(embedding_lookup.values())[0].size(), device=self.device)
 
         user_embedding = build_user_embedding(
             interest_profile.click_history,
-            clicked_article_embeddings,
+            embedding_lookup,
             self.model,
             self.device,
             self.max_clicks,


### PR DESCRIPTION
The lookup table is only used in the creation of user embeddings, so we can defer constructing it until we actually need it. That avoids the need to return two different types that contain the same information in different formats from the `ArticleEmbedder`, which cleans up the calling code a bit.