### PR TITLE
Standardize component argument and return types

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -77,11 +77,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    botocore: '>=1.34.70,<1.34.132'
   url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
   hash:
     md5: 64ebb883a6c94f2a18aafedecc215351
@@ -93,11 +93,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    botocore: '>=1.34.70,<1.34.132'
   url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.1-pyhd8ed1ab_0.conda
   hash:
     md5: 64ebb883a6c94f2a18aafedecc215351
@@ -258,8 +258,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -271,8 +271,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -411,8 +411,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.6'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyconfig-0.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6db9c8d8592eeb6ee25a8a90f137fe25
@@ -424,8 +424,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.6'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyconfig-0.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6db9c8d8592eeb6ee25a8a90f137fe25
@@ -453,11 +453,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
     python: '>=3.8'
     sniffio: '>=1.1'
     typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
@@ -469,11 +469,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
     python: '>=3.8'
     sniffio: '>=1.1'
     typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
@@ -547,9 +547,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+    typing-extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -561,9 +561,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+    typing-extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -758,8 +758,8 @@ package:
   platform: osx-arm64
   dependencies:
     cryptography: ''
-    python: '>=3.4'
     pyopenssl: '>=17.0.0'
+    python: '>=3.4'
     python-gssapi: '>=1.2.0'
     typing_extensions: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
@@ -774,8 +774,8 @@ package:
   platform: win-64
   dependencies:
     cryptography: ''
-    python: '>=3.4'
     pyopenssl: '>=17.0.0'
+    python: '>=3.4'
     python-gssapi: '>=1.2.0'
     typing_extensions: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
@@ -1688,9 +1688,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    pytz: ''
     python: '>=3.7'
+    pytz: ''
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9669586875baeced8fc30c0826c3270e
@@ -1702,9 +1702,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
-    pytz: ''
     python: '>=3.7'
+    pytz: ''
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9669586875baeced8fc30c0826c3270e
@@ -1927,10 +1927,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    numcodecs: ''
-    python-blosc: ''
-    python: '>=3.8'
     msgpack-python: '>=1.0'
+    numcodecs: ''
+    python: '>=3.8'
+    python-blosc: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binpickle-0.3.4-pyhd8ed1ab_2.conda
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
@@ -1942,10 +1942,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    numcodecs: ''
-    python-blosc: ''
-    python: '>=3.8'
     msgpack-python: '>=1.0'
+    numcodecs: ''
+    python: '>=3.8'
+    python-blosc: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binpickle-0.3.4-pyhd8ed1ab_2.conda
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
@@ -2007,11 +2007,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     packaging: ''
-    webencodings: ''
     python: '>=3.6'
+    setuptools: ''
     six: '>=1.9.0'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -2023,11 +2023,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     packaging: ''
-    webencodings: ''
     python: '>=3.6'
+    setuptools: ''
     six: '>=1.9.0'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -2106,10 +2106,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
     botocore: '>=1.34.131,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
     md5: 16cbd51eb7f0fc40a88c636006437c85
@@ -2121,10 +2121,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
     botocore: '>=1.34.131,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
     md5: 16cbd51eb7f0fc40a88c636006437c85
@@ -2151,9 +2151,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
@@ -2166,9 +2166,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
@@ -2347,9 +2347,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-    msgpack-python: '>=0.5.2,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: a54e449940b3e4bb2129b8daae0c1f65
@@ -2361,9 +2361,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-    msgpack-python: '>=0.5.2,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: a54e449940b3e4bb2129b8daae0c1f65
@@ -2389,9 +2389,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
     cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: 42a12b0b21d64b36a9ab9a24a04eb910
@@ -2403,9 +2403,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
     cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: 42a12b0b21d64b36a9ab9a24a04eb910
@@ -2621,18 +2621,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
+    billiard: '>=4.2.0,<5.0'
     click: '>=8.1.2,<9.0'
     click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
+    click-plugins: '>=1.1.1'
+    click-repl: '>=0.2.0'
+    importlib-metadata: '>=3.6'
     kombu: '>=5.3.4,<6.0'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    python-tzdata: '>=2022.7'
+    vine: '>=5.1.0,<6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
@@ -2644,18 +2644,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
+    billiard: '>=4.2.0,<5.0'
     click: '>=8.1.2,<9.0'
     click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
+    click-plugins: '>=1.1.1'
+    click-repl: '>=0.2.0'
+    importlib-metadata: '>=3.6'
     kombu: '>=5.3.4,<6.0'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    python-tzdata: '>=2022.7'
+    vine: '>=5.1.0,<6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/celery-5.3.6-pyhd8ed1ab_0.conda
   hash:
     md5: f3949418e3578d5cbea5df5d32c5b6ff
@@ -2849,8 +2849,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    colorama: ''
     __win: ''
+    colorama: ''
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
   hash:
@@ -2954,8 +2954,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
     click: '>=3.0'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -2967,8 +2967,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: ''
     click: '>=3.0'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -2995,10 +2995,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     click: ''
     prompt_toolkit: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
@@ -3010,10 +3010,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     click: ''
     prompt_toolkit: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
@@ -3039,9 +3039,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    pylev: '>=1.3,<2.0'
     pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
@@ -3053,9 +3053,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    pylev: '>=1.3,<2.0'
     pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
@@ -3178,31 +3178,31 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    typing_extensions: ''
-    jinja2: ''
-    ruamel.yaml: ''
-    tomli: ''
-    click-default-group: ''
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    click: '>=8.0'
-    packaging: '>=20.4'
-    requests: '>=2.18'
-    pydantic: '>=1.10'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    keyring: '>=21.2.0'
-    html5lib: '>=1.0'
+    cachecontrol-with-filecache: '>=0.12.9'
     cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
     clikit: '>=0.6.2'
     crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
     pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
     tomlkit: '>=0.7.0'
-    virtualenv: '>=20.0.26'
     toolz: '>=0.12.0,<1.0.0'
-    cachecontrol-with-filecache: '>=0.12.9'
+    typing_extensions: ''
     urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
   url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
@@ -3214,31 +3214,31 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
-    typing_extensions: ''
-    jinja2: ''
-    ruamel.yaml: ''
-    tomli: ''
-    click-default-group: ''
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    click: '>=8.0'
-    packaging: '>=20.4'
-    requests: '>=2.18'
-    pydantic: '>=1.10'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    keyring: '>=21.2.0'
-    html5lib: '>=1.0'
+    cachecontrol-with-filecache: '>=0.12.9'
     cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
     clikit: '>=0.6.2'
     crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
     pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
     tomlkit: '>=0.7.0'
-    virtualenv: '>=20.0.26'
     toolz: '>=0.12.0,<1.0.0'
-    cachecontrol-with-filecache: '>=0.12.9'
+    typing_extensions: ''
     urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
   url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
@@ -3263,8 +3263,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
@@ -3276,8 +3276,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
@@ -3503,22 +3503,22 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: ''
-    packaging: ''
-    filelock: ''
-    python-xxhash: ''
-    multiprocess: ''
-    pyarrow-hotfix: ''
-    pyyaml: '>=5.1'
-    numpy: '>=1.17'
-    python: '>=3.8.0'
     aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
+    filelock: ''
+    fsspec: '>=2023.1.0,<=2024.5.0'
     huggingface_hub: '>=0.21.2'
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=15.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    pyarrow: '>=15.0.0'
-    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -3530,22 +3530,22 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pandas: ''
-    packaging: ''
-    filelock: ''
-    python-xxhash: ''
-    multiprocess: ''
-    pyarrow-hotfix: ''
-    pyyaml: '>=5.1'
-    numpy: '>=1.17'
-    python: '>=3.8.0'
     aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
+    filelock: ''
+    fsspec: '>=2023.1.0,<=2024.5.0'
     huggingface_hub: '>=0.21.2'
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=15.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-    pyarrow: '>=15.0.0'
-    fsspec: '>=2023.1.0,<=2024.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7e2c046cd09a2498bac484413771a9df
@@ -4042,49 +4042,49 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    fsspec: ''
-    dvc-objects: ''
-    omegaconf: ''
-    celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    requests: '>=2.22'
-    configobj: '>=5.0.6'
-    colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
-    packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
-    pydot: '>=1.2.4'
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
     attrs: '>=22.2.0'
-    dvc-task: '>=0.3.0,<1'
-    flufl.lock: '>=5,<8'
-    gto: '>=1.6.0,<2'
+    celery: ''
+    colorama: '>=0.3.9'
+    configobj: '>=5.0.6'
+    distro: '>=1.3'
+    dpath: <3,>=2.1.0
+    dulwich: ''
+    dvc-data: '>=3.15,<3.16'
+    dvc-http: '>=2.29.0'
+    dvc-objects: ''
     dvc-render: '>=1.0.1,<2'
     dvc-studio-client: '>=0.20,<1'
-    dvc-data: '>=3.15,<3.16'
+    dvc-task: '>=0.3.0,<1'
+    flatten-dict: <1,>=0.4.1
+    flufl.lock: '>=5,<8'
+    fsspec: ''
+    funcy: '>=1.14'
+    grandalf: <1,>=0.7
+    gto: '>=1.6.0,<2'
+    hydra-core: '>=1.1'
+    iterative-telemetry: '>=0.0.7'
+    kombu: ''
+    networkx: '>=2.5'
+    omegaconf: ''
+    packaging: '>=19'
+    pathspec: '>=0.10.3'
+    platformdirs: <4,>=3.1.1
+    psutil: '>=5.8'
+    pydot: '>=1.2.4'
+    pygtrie: '>=2.3.2'
+    pyparsing: '>=2.4.7'
+    python: '>=3.9'
+    requests: '>=2.22'
+    rich: '>=12'
+    ruamel.yaml: '>=0.17.11'
     scmrepo: '>=3.3.4,<4'
+    shortuuid: '>=0.5'
+    shtab: <2,>=1.3.4
+    tabulate: '>=0.8.7'
+    tomlkit: '>=0.11.1'
+    tqdm: <5,>=4.63.1
+    voluptuous: '>=0.11.7'
+    zc.lockfile: '>=1.2.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
   hash:
     md5: b8d2488c8bbe93bcd4f6faa160656703
@@ -4096,49 +4096,49 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    fsspec: ''
-    dvc-objects: ''
-    omegaconf: ''
-    celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    requests: '>=2.22'
-    configobj: '>=5.0.6'
-    colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
-    packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
-    pydot: '>=1.2.4'
-    voluptuous: '>=0.11.7'
-    zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
     attrs: '>=22.2.0'
-    dvc-task: '>=0.3.0,<1'
-    flufl.lock: '>=5,<8'
-    gto: '>=1.6.0,<2'
+    celery: ''
+    colorama: '>=0.3.9'
+    configobj: '>=5.0.6'
+    distro: '>=1.3'
+    dpath: <3,>=2.1.0
+    dulwich: ''
+    dvc-data: '>=3.15,<3.16'
+    dvc-http: '>=2.29.0'
+    dvc-objects: ''
     dvc-render: '>=1.0.1,<2'
     dvc-studio-client: '>=0.20,<1'
-    dvc-data: '>=3.15,<3.16'
+    dvc-task: '>=0.3.0,<1'
+    flatten-dict: <1,>=0.4.1
+    flufl.lock: '>=5,<8'
+    fsspec: ''
+    funcy: '>=1.14'
+    grandalf: <1,>=0.7
+    gto: '>=1.6.0,<2'
+    hydra-core: '>=1.1'
+    iterative-telemetry: '>=0.0.7'
+    kombu: ''
+    networkx: '>=2.5'
+    omegaconf: ''
+    packaging: '>=19'
+    pathspec: '>=0.10.3'
+    platformdirs: <4,>=3.1.1
+    psutil: '>=5.8'
+    pydot: '>=1.2.4'
+    pygtrie: '>=2.3.2'
+    pyparsing: '>=2.4.7'
+    python: '>=3.9'
+    requests: '>=2.22'
+    rich: '>=12'
+    ruamel.yaml: '>=0.17.11'
     scmrepo: '>=3.3.4,<4'
+    shortuuid: '>=0.5'
+    shtab: <2,>=1.3.4
+    tabulate: '>=0.8.7'
+    tomlkit: '>=0.11.1'
+    tqdm: <5,>=4.63.1
+    voluptuous: '>=0.11.7'
+    zc.lockfile: '>=1.2.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.51.2-pyhd8ed1ab_0.conda
   hash:
     md5: b8d2488c8bbe93bcd4f6faa160656703
@@ -4171,16 +4171,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
+    attrs: '>=21.3.0'
+    dictdiffer: '>=0.8.1'
+    diskcache: '>=5.2.1'
+    dvc-objects: '>=4.0.1,<6'
+    fsspec: '>=2024.2.0'
     funcy: '>=1.14'
     pygtrie: '>=2.3.2'
-    attrs: '>=21.3.0'
-    diskcache: '>=5.2.1'
-    dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
+    python: '>=3.9'
     sqltrie: '>=0.11.0,<1'
-    dvc-objects: '>=4.0.1,<6'
+    tqdm: '>=4.63.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
@@ -4192,16 +4192,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
+    attrs: '>=21.3.0'
+    dictdiffer: '>=0.8.1'
+    diskcache: '>=5.2.1'
+    dvc-objects: '>=4.0.1,<6'
+    fsspec: '>=2024.2.0'
     funcy: '>=1.14'
     pygtrie: '>=2.3.2'
-    attrs: '>=21.3.0'
-    diskcache: '>=5.2.1'
-    dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
+    python: '>=3.9'
     sqltrie: '>=0.11.0,<1'
-    dvc-objects: '>=4.0.1,<6'
+    tqdm: '>=4.63.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.1-pyhd8ed1ab_1.conda
   hash:
     md5: e402fc3b728b926ce1ece0236a1f81bd
@@ -4227,9 +4227,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    aiohttp-retry: '>=2.5.0'
     fsspec: ''
     python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
@@ -4241,9 +4241,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    aiohttp-retry: '>=2.5.0'
     fsspec: ''
     python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
@@ -4269,9 +4269,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
     fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
@@ -4283,9 +4283,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
     fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
@@ -4312,10 +4312,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    flatten-dict: '>=0.4.1'
+    funcy: '>=1.17'
     python: '>=3.7'
     tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
@@ -4327,10 +4327,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    flatten-dict: '>=0.4.1'
+    funcy: '>=1.17'
     python: '>=3.7'
     tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
@@ -4357,9 +4357,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    boto3: '>=1.9.201'
     dvc: ''
     python: '>=3.8'
-    boto3: '>=1.9.201'
     s3fs: '>=2021.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -4372,9 +4372,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    boto3: '>=1.9.201'
     dvc: ''
     python: '>=3.8'
-    boto3: '>=1.9.201'
     s3fs: '>=2021.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -4402,10 +4402,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
-    voluptuous: ''
     dulwich: ''
     python: '>=3.8'
+    requests: ''
+    voluptuous: ''
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.21.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6d7a1b396bdbb394ed4da8b801615e4f
@@ -4417,10 +4417,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
-    voluptuous: ''
     dulwich: ''
     python: '>=3.8'
+    requests: ''
+    voluptuous: ''
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.21.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6d7a1b396bdbb394ed4da8b801615e4f
@@ -4449,12 +4449,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pywin32-on-windows: ''
+    celery: '>=5.3.0,<6'
+    funcy: '>=1.17'
     kombu: ''
     python: '>=3.7'
-    funcy: '>=1.17'
+    pywin32-on-windows: ''
     shortuuid: '>=1.0.8'
-    celery: '>=5.3.0,<6'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
@@ -4466,12 +4466,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pywin32-on-windows: ''
+    celery: '>=5.3.0,<6'
+    funcy: '>=1.17'
     kombu: ''
     python: '>=3.7'
-    funcy: '>=1.17'
+    pywin32-on-windows: ''
     shortuuid: '>=1.0.8'
-    celery: '>=5.3.0,<6'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
@@ -4536,12 +4536,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     appdirs: ''
+    click: '>=5.1'
     filelock: ''
+    packaging: ''
     python: '>=3.7'
     requests: '>=2'
-    click: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
@@ -4553,12 +4553,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     appdirs: ''
+    click: '>=5.1'
     filelock: ''
+    packaging: ''
     python: '>=3.7'
     requests: '>=2'
-    click: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
@@ -4766,9 +4766,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    python: '>=3.6'
     pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
     six: '>=1.12,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
   hash:
@@ -4781,9 +4781,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
-    python: '>=3.6'
     pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
     six: '>=1.12,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
   hash:
@@ -4810,8 +4810,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    psutil: ''
     atpublic: ''
+    psutil: ''
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
   hash:
@@ -4824,8 +4824,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    psutil: ''
     atpublic: ''
+    psutil: ''
     python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-7.1-pyhd8ed1ab_0.tar.bz2
   hash:
@@ -5069,10 +5069,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
     font-ttf-ubuntu: ''
-    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -5084,10 +5084,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
     font-ttf-ubuntu: ''
-    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -5549,9 +5549,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-    gitdb: '>=4.0.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
@@ -5563,9 +5563,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-    gitdb: '>=4.0.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
@@ -5881,16 +5881,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    rich: ''
-    ruamel.yaml: ''
     entrypoints: ''
     funcy: ''
-    python: '>=3.9'
-    typer: '>=0.4.1'
-    tabulate: '>=0.8.10'
-    scmrepo: '>=3,<4'
     pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
     semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
@@ -5902,16 +5902,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    rich: ''
-    ruamel.yaml: ''
     entrypoints: ''
     funcy: ''
-    python: '>=3.9'
-    typer: '>=0.4.1'
-    tabulate: '>=0.8.10'
-    scmrepo: '>=3,<4'
     pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
     semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
@@ -5978,8 +5978,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
     python: '>=3'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -5991,8 +5991,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ''
     python: '>=3'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -6018,9 +6018,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -6032,9 +6032,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -6129,23 +6129,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    tomlkit: '>=0.11.1'
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
     httpx: '>=0.22.0'
     hyperlink: '>=21.0.0'
-    platformdirs: '>=2.5.0'
     keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
     shellingham: '>=1.4.0'
     tomli-w: '>=1.0'
-    packaging: '>=23.2'
-    click: '>=8.0.6'
-    zstandard: <1.0
-    hatchling: '>=1.24.2'
-    pexpect: '>=4.8,<5'
+    tomlkit: '>=0.11.1'
     userpath: '>=1.7,<2'
     uv: '>=0.1.35'
     virtualenv: '>=20.26.1'
+    zstandard: <1.0
   url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
   hash:
     md5: 75ef4cd9ebf1c870d9389d2af8c67a42
@@ -6157,23 +6157,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    tomlkit: '>=0.11.1'
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
     httpx: '>=0.22.0'
     hyperlink: '>=21.0.0'
-    platformdirs: '>=2.5.0'
     keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
     shellingham: '>=1.4.0'
     tomli-w: '>=1.0'
-    packaging: '>=23.2'
-    click: '>=8.0.6'
-    zstandard: <1.0
-    hatchling: '>=1.24.2'
-    pexpect: '>=4.8,<5'
+    tomlkit: '>=0.11.1'
     userpath: '>=1.7,<2'
     uv: '>=0.1.35'
     virtualenv: '>=20.26.1'
+    zstandard: <1.0
   url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
   hash:
     md5: 75ef4cd9ebf1c870d9389d2af8c67a42
@@ -6204,14 +6204,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: ''
-    trove-classifiers: ''
-    python: '>=3.7'
-    packaging: '>=21.3'
-    pluggy: '>=1.0.0'
-    pathspec: '>=0.10.1'
-    tomli: '>=1.2.2'
     editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7571d6e5561b04aef679a11904dfcebf
@@ -6223,14 +6223,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    importlib-metadata: ''
-    trove-classifiers: ''
-    python: '>=3.7'
-    packaging: '>=21.3'
-    pluggy: '>=1.0.0'
-    pathspec: '>=0.10.1'
-    tomli: '>=1.2.2'
     editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7571d6e5561b04aef679a11904dfcebf
@@ -6293,8 +6293,8 @@ package:
   platform: osx-arm64
   dependencies:
     python: ''
-    webencodings: ''
     six: '>=1.9'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: b2355343d6315c892543200231d7154a
@@ -6307,8 +6307,8 @@ package:
   platform: win-64
   dependencies:
     python: ''
-    webencodings: ''
     six: '>=1.9'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: b2355343d6315c892543200231d7154a
@@ -6337,12 +6337,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
   hash:
     md5: a6b9a0158301e697e4d0a36a3d60e133
@@ -6354,12 +6354,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
   hash:
     md5: a6b9a0158301e697e4d0a36a3d60e133
@@ -6388,12 +6388,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    certifi: ''
-    idna: ''
     anyio: ''
-    sniffio: ''
-    python: '>=3.8'
+    certifi: ''
     httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9f359af5a886fd6ca6b2b6ea02e58332
@@ -6405,12 +6405,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    certifi: ''
-    idna: ''
     anyio: ''
-    sniffio: ''
-    python: '>=3.8'
+    certifi: ''
     httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9f359af5a886fd6ca6b2b6ea02e58332
@@ -6441,14 +6441,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
     filelock: ''
+    fsspec: '>=2023.5.0'
+    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.9'
-    typing-extensions: '>=3.7.4.3'
-    fsspec: '>=2023.5.0'
+    requests: ''
     tqdm: '>=4.42.1'
+    typing-extensions: '>=3.7.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
     md5: 759dfbd44e93d75a23b203fe50dade8d
@@ -6460,14 +6460,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
     filelock: ''
+    fsspec: '>=2023.5.0'
+    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.9'
-    typing-extensions: '>=3.7.4.3'
-    fsspec: '>=2023.5.0'
+    requests: ''
     tqdm: '>=4.42.1'
+    typing-extensions: '>=3.7.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.23.4-pyhd8ed1ab_0.conda
   hash:
     md5: 759dfbd44e93d75a23b203fe50dade8d
@@ -6495,11 +6495,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    importlib_resources: ''
-    python: '>=3.6'
     antlr-python-runtime: 4.9.*
+    importlib_resources: ''
     omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
@@ -6511,11 +6511,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    importlib_resources: ''
-    python: '>=3.6'
     antlr-python-runtime: 4.9.*
+    importlib_resources: ''
     omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
@@ -6576,8 +6576,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
     idna: '>=2.6'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
   hash:
     md5: 1303beb57b40f8f4ff6fb1bb23bf0553
@@ -6589,8 +6589,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: ''
     idna: '>=2.6'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
   hash:
     md5: 1303beb57b40f8f4ff6fb1bb23bf0553
@@ -6653,8 +6653,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    ukkonen: ''
     python: '>=3.6'
+    ukkonen: ''
   url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
   hash:
     md5: ba68cb5105760379432cebc82b45af40
@@ -6666,8 +6666,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ukkonen: ''
     python: '>=3.6'
+    ukkonen: ''
   url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.36-pyhd8ed1ab_0.conda
   hash:
     md5: ba68cb5105760379432cebc82b45af40
@@ -6901,21 +6901,21 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    psutil: ''
-    nest-asyncio: ''
     __osx: ''
     appnope: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
     matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
-    comm: '>=0.1.1'
-    traitlets: '>=5.4.0'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
     pyzmq: '>=24'
+    tornado: '>=6.1'
+    traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
   hash:
     md5: 9eb15d654daa0ef5a98802f586bb4ffc
@@ -6927,20 +6927,20 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    psutil: ''
     __win: ''
-    nest-asyncio: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
     matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
-    comm: '>=0.1.1'
-    traitlets: '>=5.4.0'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
     pyzmq: '>=24'
+    tornado: '>=6.1'
+    traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
   hash:
     md5: 18df5fc4944a679e085e0e8f31775fc8
@@ -6979,14 +6979,14 @@ package:
     __unix: ''
     decorator: ''
     exceptiongroup: ''
-    matplotlib-inline: ''
-    stack_data: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
     jedi: '>=0.16'
+    matplotlib-inline: ''
     pexpect: '>4.3'
+    pickleshare: ''
     prompt-toolkit: '>=3.0.41,<3.1.0'
+    pygments: '>=2.4.0'
+    python: '>=3.10'
+    stack_data: ''
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
@@ -7000,17 +7000,17 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    colorama: ''
     __win: ''
+    colorama: ''
     decorator: ''
     exceptiongroup: ''
-    matplotlib-inline: ''
-    stack_data: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
     jedi: '>=0.16'
+    matplotlib-inline: ''
+    pickleshare: ''
     prompt-toolkit: '>=3.0.41,<3.1.0'
+    pygments: '>=2.4.0'
+    python: '>=3.10'
+    stack_data: ''
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
@@ -7037,8 +7037,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     arrow: '>=0.15.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -7050,8 +7050,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     arrow: '>=0.15.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -7079,11 +7079,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
     appdirs: ''
-    filelock: ''
     distro: ''
+    filelock: ''
     python: '>=3.7'
+    requests: ''
   url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
@@ -7095,11 +7095,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
     appdirs: ''
-    filelock: ''
     distro: ''
+    filelock: ''
     python: '>=3.7'
+    requests: ''
   url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
@@ -7241,8 +7241,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -7254,8 +7254,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
     parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -7292,8 +7292,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -7305,8 +7305,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -7367,8 +7367,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -7380,8 +7380,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -7486,11 +7486,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
     jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.22.0-pyhd8ed1ab_0.conda
@@ -7504,11 +7504,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
     jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.22.0-pyhd8ed1ab_0.conda
@@ -7536,8 +7536,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     importlib_resources: '>=1.4.0'
+    python: '>=3.8'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
   hash:
@@ -7550,8 +7550,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     importlib_resources: '>=1.4.0'
+    python: '>=3.8'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
   hash:
@@ -7585,16 +7585,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
     fqdn: ''
+    idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    webcolors: '>=1.11'
-    rfc3986-validator: '>0.1.0'
     jsonschema: '>=4.22.0,<4.22.1.0a0'
+    python: ''
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
+    webcolors: '>=1.11'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.22.0-pyhd8ed1ab_0.conda
   hash:
     md5: 32ab666927ee17b9468c2c72bbd7ba1b
@@ -7606,16 +7606,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: ''
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
     fqdn: ''
+    idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    webcolors: '>=1.11'
-    rfc3986-validator: '>0.1.0'
     jsonschema: '>=4.22.0,<4.22.1.0a0'
+    python: ''
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
+    webcolors: '>=1.11'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.22.0-pyhd8ed1ab_0.conda
   hash:
     md5: 32ab666927ee17b9468c2c72bbd7ba1b
@@ -7641,9 +7641,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 885867f6adab3d7ecdf8ab6ca0785f51
@@ -7655,9 +7655,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 885867f6adab3d7ecdf8ab6ca0785f51
@@ -7687,13 +7687,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
     pyzmq: '>=23.0'
     tornado: '>=6.2'
+    traitlets: '>=5.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: 3cdbb2fa84490e5fd44c9f9806c0d292
@@ -7705,13 +7705,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
     pyzmq: '>=23.0'
     tornado: '>=6.2'
+    traitlets: '>=5.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: 3cdbb2fa84490e5fd44c9f9806c0d292
@@ -7788,14 +7788,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
     md5: ed45423c41b3da15ea1df39b1f80c2ca
@@ -7807,14 +7807,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
     md5: ed45423c41b3da15ea1df39b1f80c2ca
@@ -7856,25 +7856,25 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    jinja2: ''
-    prometheus_client: ''
-    websocket-client: ''
-    argon2-cffi: ''
-    overrides: ''
-    jupyter_server_terminals: ''
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    pyzmq: '>=24'
-    nbconvert-core: '>=6.4.4'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
     anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
+    argon2-cffi: ''
+    jinja2: ''
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
     jupyter_events: '>=0.9.0'
+    jupyter_server_terminals: ''
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: ''
+    packaging: ''
+    prometheus_client: ''
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.1-pyhd8ed1ab_0.conda
   hash:
     md5: 174af03c6e6038edd32021a48aa003c4
@@ -7886,25 +7886,25 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    jinja2: ''
-    prometheus_client: ''
-    websocket-client: ''
-    argon2-cffi: ''
-    overrides: ''
-    jupyter_server_terminals: ''
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    pyzmq: '>=24'
-    nbconvert-core: '>=6.4.4'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
     anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
+    argon2-cffi: ''
+    jinja2: ''
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
     jupyter_events: '>=0.9.0'
+    jupyter_server_terminals: ''
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: ''
+    packaging: ''
+    prometheus_client: ''
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.1-pyhd8ed1ab_0.conda
   hash:
     md5: 174af03c6e6038edd32021a48aa003c4
@@ -7983,23 +7983,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    tomli: '>=1.2.2'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
     async-lru: '>=1.0.0'
-    notebook-shim: '>=0.2'
-    setuptools: '>=40.1.0'
     httpx: '>=0.25.0'
-    jupyterlab_server: '>=2.27.1,<3'
+    importlib_metadata: '>=4.8.3'
+    importlib_resources: '>=1.4'
     ipykernel: '>=6.5.0'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    setuptools: '>=40.1.0'
+    tomli: '>=1.2.2'
+    tornado: '>=6.2.0'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.3-pyhd8ed1ab_0.conda
   hash:
     md5: fc3e207aa4596a682acc725da4b845ad
@@ -8011,23 +8011,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    tomli: '>=1.2.2'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
     async-lru: '>=1.0.0'
-    notebook-shim: '>=0.2'
-    setuptools: '>=40.1.0'
     httpx: '>=0.25.0'
-    jupyterlab_server: '>=2.27.1,<3'
+    importlib_metadata: '>=4.8.3'
+    importlib_resources: '>=1.4'
     ipykernel: '>=6.5.0'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    setuptools: '>=40.1.0'
+    tomli: '>=1.2.2'
+    tornado: '>=6.2.0'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.3-pyhd8ed1ab_0.conda
   hash:
     md5: fc3e207aa4596a682acc725da4b845ad
@@ -8052,8 +8052,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     pygments: '>=2.4.1,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -8065,8 +8065,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     pygments: '>=2.4.1,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -8098,15 +8098,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    requests: '>=2.31'
-    jupyter_server: '>=1.21,<3'
     babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
     json5: '>=0.9.0'
     jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.2-pyhd8ed1ab_0.conda
   hash:
     md5: d1cb7b113daaadd89e5aa6a32b28bf0d
@@ -8118,15 +8118,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    requests: '>=2.31'
-    jupyter_server: '>=1.21,<3'
     babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
     json5: '>=0.9.0'
     jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.2-pyhd8ed1ab_0.conda
   hash:
     md5: d1cb7b113daaadd89e5aa6a32b28bf0d
@@ -8156,13 +8156,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pyyaml: ''
-    packaging: ''
-    nbformat: ''
-    tomli: ''
-    mdit-py-plugins: ''
-    python: '>=3.8'
     markdown-it-py: '>=1.0'
+    mdit-py-plugins: ''
+    nbformat: ''
+    packaging: ''
+    python: '>=3.8'
+    pyyaml: ''
+    tomli: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.2-pyhd8ed1ab_1.conda
   hash:
     md5: 86aa2d7c9be0af3fcd0b98e89e060446
@@ -8174,13 +8174,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pyyaml: ''
-    packaging: ''
-    nbformat: ''
-    tomli: ''
-    mdit-py-plugins: ''
-    python: '>=3.8'
     markdown-it-py: '>=1.0'
+    mdit-py-plugins: ''
+    nbformat: ''
+    packaging: ''
+    python: '>=3.8'
+    pyyaml: ''
+    tomli: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.2-pyhd8ed1ab_1.conda
   hash:
     md5: 86aa2d7c9be0af3fcd0b98e89e060446
@@ -8212,13 +8212,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: ''
     __osx: ''
-    jaraco.classes: ''
-    jaraco.functools: ''
-    jaraco.context: ''
-    python: '>=3.8'
     importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh534df25_0.conda
   hash:
     md5: 8c071c544a2fc27cbc75dfa0d7362f0c
@@ -8230,13 +8230,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    importlib_resources: ''
     __win: ''
-    jaraco.classes: ''
-    jaraco.functools: ''
-    jaraco.context: ''
-    python: '>=3.8'
     importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.8'
     pywin32-ctypes: '>=0.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.2.1-pyh7428d3b_0.conda
   hash:
@@ -8387,16 +8387,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: '>=1.0'
-    numpy: '>=1.19'
-    python: '>=3.7.0'
-    scipy: '>=1.2'
-    psutil: '>=5'
     binpickle: '>=0.3.2'
     cffi: '>=1.12.2'
     csr: '>=0.3.1'
-    seedbank: '>=0.1.0'
     numba: '>=0.51,<0.59'
+    numpy: '>=1.19'
+    pandas: '>=1.0'
+    psutil: '>=5'
+    python: '>=3.7.0'
+    scipy: '>=1.2'
+    seedbank: '>=0.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/lenskit-0.14.4-pyhd8ed1ab_0.conda
   hash:
     md5: d3f95eaf0ca981e4831d603f3eb87e2f
@@ -8408,16 +8408,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pandas: '>=1.0'
-    numpy: '>=1.19'
-    python: '>=3.7.0'
-    scipy: '>=1.2'
-    psutil: '>=5'
     binpickle: '>=0.3.2'
     cffi: '>=1.12.2'
     csr: '>=0.3.1'
-    seedbank: '>=0.1.0'
     numba: '>=0.51,<0.59'
+    numpy: '>=1.19'
+    pandas: '>=1.0'
+    psutil: '>=5'
+    python: '>=3.7.0'
+    scipy: '>=1.2'
+    seedbank: '>=0.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/lenskit-0.14.4-pyhd8ed1ab_0.conda
   hash:
     md5: d3f95eaf0ca981e4831d603f3eb87e2f
@@ -10970,8 +10970,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     mdurl: '>=0.1,<1'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
@@ -10983,8 +10983,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     mdurl: '>=0.1,<1'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
@@ -11052,8 +11052,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    traitlets: ''
     python: '>=3.6'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
     md5: 779345c95648be40d22aaa89de7d4254
@@ -11065,8 +11065,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    traitlets: ''
     python: '>=3.6'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
     md5: 779345c95648be40d22aaa89de7d4254
@@ -11091,8 +11091,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     markdown-it-py: '>=1.0.0,<4.0.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: eb90dd178bcdd0260dfaa6e1cbccf042
@@ -11104,8 +11104,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     markdown-it-py: '>=1.0.0,<4.0.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: eb90dd178bcdd0260dfaa6e1cbccf042
@@ -11512,10 +11512,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
+    python: '>=3.8'
     traitlets: '>=5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
   hash:
@@ -11528,10 +11528,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
+    python: '>=3.8'
     traitlets: '>=5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
   hash:
@@ -11572,23 +11572,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     beautifulsoup4: ''
-    defusedxml: ''
     bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
+    defusedxml: ''
     entrypoints: '>=0.2.2'
-    markupsafe: '>=2.0'
+    jinja2: '>=3.0'
     jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
+    jupyterlab_pygments: ''
+    markupsafe: '>=2.0'
     mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
   hash:
     md5: e2d2abb421c13456a9a9f80272fdf543
@@ -11600,23 +11600,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     beautifulsoup4: ''
-    defusedxml: ''
     bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
+    defusedxml: ''
     entrypoints: '>=0.2.2'
-    markupsafe: '>=2.0'
+    jinja2: '>=3.0'
     jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
+    jupyterlab_pygments: ''
+    markupsafe: '>=2.0'
     mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
   hash:
     md5: e2d2abb421c13456a9a9f80272fdf543
@@ -11644,11 +11644,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '>=4.12,!=5.0.*'
-    traitlets: '>=5.1'
     jsonschema: '>=2.6'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
     python-fastjsonschema: '>=2.15'
+    traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
     md5: 0b57b5368ab7fc7cdc9e3511fa867214
@@ -11660,11 +11660,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '>=4.12,!=5.0.*'
-    traitlets: '>=5.1'
     jsonschema: '>=2.6'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
     python-fastjsonschema: '>=2.15'
+    traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
     md5: 0b57b5368ab7fc7cdc9e3511fa867214
@@ -11787,11 +11787,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    tqdm: ''
     click: ''
     joblib: ''
     python: '>=3.7'
     regex: '>=2021.8.3'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
   hash:
     md5: 518c769ca4273480a99be6e559a26192
@@ -11803,11 +11803,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    tqdm: ''
     click: ''
     joblib: ''
     python: '>=3.7'
     regex: '>=2021.8.3'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
   hash:
     md5: 518c769ca4273480a99be6e559a26192
@@ -11832,8 +11832,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: 2.7|>=3.7
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
@@ -11845,8 +11845,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: 2.7|>=3.7
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
@@ -11944,12 +11944,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab: '>=4.2.0,<4.3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2,<0.3'
     python: '>=3.8'
     tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab_server: '>=2.27.1,<3'
-    jupyterlab: '>=4.2.0,<4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: 08fa71a038c2cac2e636a5a456df15d5
@@ -11961,12 +11961,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab: '>=4.2.0,<4.3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2,<0.3'
     python: '>=3.8'
     tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab_server: '>=2.27.1,<3'
-    jupyterlab: '>=4.2.0,<4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: 08fa71a038c2cac2e636a5a456df15d5
@@ -11991,8 +11991,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -12004,8 +12004,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -12191,10 +12191,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
+    antlr-python-runtime: 4.9.*
     python: '>=3.7'
     pyyaml: '>=5.1.0'
-    antlr-python-runtime: 4.9.*
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
@@ -12206,10 +12206,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ''
+    antlr-python-runtime: 4.9.*
     python: '>=3.7'
     pyyaml: '>=5.1.0'
-    antlr-python-runtime: 4.9.*
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
@@ -12374,8 +12374,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_utils: ''
     python: '>=3.6'
+    typing_utils: ''
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -12387,8 +12387,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_utils: ''
     python: '>=3.6'
+    typing_utils: ''
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -12799,8 +12799,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     ptyprocess: '>=0.5'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 629f3203c99b32e0988910c93e77f3b6
@@ -12812,8 +12812,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     ptyprocess: '>=0.5'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 629f3203c99b32e0988910c93e77f3b6
@@ -12875,9 +12875,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.7'
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
   hash:
     md5: f586ac1e56c8638b64f9c8122a7b8a67
@@ -12889,9 +12889,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    python: '>=3.7'
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
   hash:
     md5: f586ac1e56c8638b64f9c8122a7b8a67
@@ -13106,11 +13106,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    pyyaml: '>=5.1'
+    cfgv: '>=2.0.0'
     identify: '>=1.0.0'
     nodeenv: '>=0.11.1'
-    cfgv: '>=2.0.0'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
   hash:
@@ -13123,11 +13123,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    pyyaml: '>=5.1'
+    cfgv: '>=2.0.0'
     identify: '>=1.0.0'
     nodeenv: '>=0.11.1'
-    cfgv: '>=2.0.0'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
   hash:
@@ -13189,8 +13189,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    wcwidth: ''
     python: '>=3.7'
+    wcwidth: ''
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
   hash:
     md5: 1247c861065d227781231950e14fe817
@@ -13202,8 +13202,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    wcwidth: ''
     python: '>=3.7'
+    wcwidth: ''
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
   hash:
     md5: 1247c861065d227781231950e14fe817
@@ -13528,8 +13528,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
     pyarrow: '>=0.14'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -13541,8 +13541,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.5'
     pyarrow: '>=0.14'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -13605,10 +13605,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
     annotated-types: '>=0.4.0'
     pydantic-core: 2.18.4
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
   hash:
     md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
@@ -13620,10 +13620,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
     annotated-types: '>=0.4.0'
     pydantic-core: 2.18.4
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
   hash:
     md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
@@ -13930,8 +13930,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     cryptography: '>=41.0.5,<43'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
@@ -13943,8 +13943,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     cryptography: '>=41.0.5,<43'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: b50aec2c744a5c493c09cce9e2e7533e
@@ -14070,8 +14070,8 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    win_inet_pton: ''
     python: '>=3.8'
+    win_inet_pton: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
   hash:
     md5: 56cd9fe388baac0e90c7149cfac95b60
@@ -14101,13 +14101,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     colorama: ''
-    iniconfig: ''
-    python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1'
+    iniconfig: ''
+    packaging: ''
     pluggy: <2.0,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: 0f3f49c22c7ef3a1195fa61dad3c43be
@@ -14119,13 +14119,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     colorama: ''
-    iniconfig: ''
-    python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1'
+    iniconfig: ''
+    packaging: ''
     pluggy: <2.0,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: 0f3f49c22c7ef3a1195fa61dad3c43be
@@ -14646,6 +14646,7 @@ package:
   url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
   hash:
     md5: 49565ed726991fd28d08a39885caa88d
+    sha256: d48c964188ca49660d750cffd73698d217cf94e694cd51987f9f186425435e76
   category: main
   optional: false
 - name: pytz
@@ -14744,8 +14745,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pywin32: ''
     python: '>=2.7'
+    pywin32: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh07e9846_2.tar.bz2
   hash:
     md5: 91733394059b880d9cc0d010c20abda0
@@ -14947,8 +14948,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
+    python: '>=3.8'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
@@ -14961,8 +14962,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
+    python: '>=3.8'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
@@ -15035,10 +15036,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
@@ -15051,10 +15052,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
@@ -15080,8 +15081,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     python: '>=3.5'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -15093,8 +15094,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     python: '>=3.5'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -15157,10 +15158,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -15172,10 +15173,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -15394,10 +15395,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: ''
-    python: '>=3.8'
     aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
     fsspec: 2024.5.0
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
     md5: 69f9f792aa777125aa284263067d1e97
@@ -15409,10 +15410,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aiohttp: ''
-    python: '>=3.8'
     aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
     fsspec: 2024.5.0
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
     md5: 69f9f792aa777125aa284263067d1e97
@@ -15437,8 +15438,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
     md5: 80f00f9033aee2358171207746e09ea0
@@ -15450,8 +15451,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
     md5: 80f00f9033aee2358171207746e09ea0
@@ -15590,17 +15591,17 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    tqdm: ''
-    python: '>=3.8'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    pathspec: '>=0.9.0'
-    gitpython: '>3'
-    fsspec: '>=2024.2.0'
     aiohttp-retry: '>=2.5.0'
     asyncssh: '>=2.13.1,<3'
-    pygit2: '>=1.14.0'
     dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
   hash:
     md5: 633f93803051c8eae944808e40c17976
@@ -15612,17 +15613,17 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    tqdm: ''
-    python: '>=3.8'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    pathspec: '>=0.9.0'
-    gitpython: '>3'
-    fsspec: '>=2024.2.0'
     aiohttp-retry: '>=2.5.0'
     asyncssh: '>=2.13.1,<3'
-    pygit2: '>=1.14.0'
     dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.5-pyhd8ed1ab_0.conda
   hash:
     md5: 633f93803051c8eae944808e40c17976
@@ -15664,9 +15665,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-    numpy: '>=1.17'
     anyconfig: '>=0.12'
+    numpy: '>=1.17'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/seedbank-0.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 4e16b309563adbb713646c3b948a1151
@@ -15678,9 +15679,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-    numpy: '>=1.17'
     anyconfig: '>=0.12'
+    numpy: '>=1.17'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/seedbank-0.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 4e16b309563adbb713646c3b948a1151
@@ -15756,8 +15757,8 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    pywin32: ''
     python: '>=3.7'
+    pywin32: ''
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
   hash:
     md5: 5a86a21050ca3831ec7f77fb302f1132
@@ -16023,8 +16024,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    wrapt: ''
     python: '>=3.6'
+    wrapt: ''
   url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
   hash:
     md5: 2804ae86934b30c2afbd713d1448afe5
@@ -16036,8 +16037,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    wrapt: ''
     python: '>=3.6'
+    wrapt: ''
   url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
   hash:
     md5: 2804ae86934b30c2afbd713d1448afe5
@@ -16302,9 +16303,9 @@ package:
   platform: osx-arm64
   dependencies:
     __unix: ''
-    python: '*'
-    mpmath: '>=0.19'
     gmpy2: '>=2.0.8'
+    mpmath: '>=0.19'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pypyh2585a3b_103.conda
   hash:
     md5: 4af9db19148140eb2ff3b2a93697063b
@@ -16316,8 +16317,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     mpmath: '>=0.19'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12.1-pyh04b8f61_3.conda
   hash:
     md5: 2a2ecb906ec4efabca7e40bd36b627c8
@@ -16412,8 +16413,8 @@ package:
   dependencies:
     __win: ''
     python: '>=3.8'
-    tornado: '>=6.1.0'
     pywinpty: '>=1.1.0'
+    tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
   hash:
     md5: 4abd500577430a942a995fd0d09b76a2
@@ -16838,18 +16839,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
+    datasets: '!=2.5.0'
     filelock: ''
+    huggingface_hub: '>=0.23.0,<1.0'
+    numpy: '>=1.17,<2.0'
+    packaging: '>=20.0'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.0'
     regex: '!=2019.12.17'
-    tqdm: '>=4.27'
-    datasets: '!=2.5.0'
+    requests: ''
     safetensors: '>=0.4.1'
-    numpy: '>=1.17,<2.0'
     tokenizers: '>=0.19,<0.20'
-    huggingface_hub: '>=0.23.0,<1.0'
+    tqdm: '>=4.27'
   url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.42.3-pyhd8ed1ab_0.conda
   hash:
     md5: 733b39fa21567cfccac7fafaaae5e937
@@ -16861,18 +16862,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
+    datasets: '!=2.5.0'
     filelock: ''
+    huggingface_hub: '>=0.23.0,<1.0'
+    numpy: '>=1.17,<2.0'
+    packaging: '>=20.0'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.0'
     regex: '!=2019.12.17'
-    tqdm: '>=4.27'
-    datasets: '!=2.5.0'
+    requests: ''
     safetensors: '>=0.4.1'
-    numpy: '>=1.17,<2.0'
     tokenizers: '>=0.19,<0.20'
-    huggingface_hub: '>=0.23.0,<1.0'
+    tqdm: '>=4.27'
   url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.42.3-pyhd8ed1ab_0.conda
   hash:
     md5: 733b39fa21567cfccac7fafaaae5e937
@@ -16880,39 +16881,39 @@ package:
   category: main
   optional: false
 - name: trove-classifiers
-  version: 2024.5.22
+  version: 2024.7.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a887538e7f6697ed52a487dbaa0ebff5
-    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+    md5: 52882ea6e62b6ea10b63d2df83526448
+    sha256: 9c7d12753856c269e1c6fc21683609497bf52de409af00250b1e401775fb9ad9
   category: dev
   optional: true
 - name: trove-classifiers
-  version: 2024.5.22
+  version: 2024.7.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a887538e7f6697ed52a487dbaa0ebff5
-    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+    md5: 52882ea6e62b6ea10b63d2df83526448
+    sha256: 9c7d12753856c269e1c6fc21683609497bf52de409af00250b1e401775fb9ad9
   category: dev
   optional: true
 - name: trove-classifiers
-  version: 2024.5.22
+  version: 2024.7.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.5.22-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a887538e7f6697ed52a487dbaa0ebff5
-    sha256: f1bf2f01ab4cf799bc3c561eb9247709f7f63f8fc151a99ffd247bda50a5ee28
+    md5: 52882ea6e62b6ea10b63d2df83526448
+    sha256: 9c7d12753856c269e1c6fc21683609497bf52de409af00250b1e401775fb9ad9
   category: dev
   optional: true
 - name: typer
@@ -16973,8 +16974,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     click: '>=8.0.0'
+    python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
   hash:
@@ -16987,8 +16988,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     click: '>=8.0.0'
+    python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
   hash:
@@ -17329,9 +17330,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -17343,9 +17344,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -17511,10 +17512,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     distlib: <1,>=0.3.7
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
     md5: 284008712816c64c85bf2b7fa9f3b264
@@ -17526,10 +17527,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     distlib: <1,>=0.3.7
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
     md5: 284008712816c64c85bf2b7fa9f3b264
@@ -18305,8 +18306,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=2'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
@@ -18318,8 +18319,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=2'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
@@ -18547,13 +18548,13 @@ package:
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@cf9ebb74c9b296afde9c3599dc2ed284c8742533
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   hash:
-    sha256: cf9ebb74c9b296afde9c3599dc2ed284c8742533
+    sha256: c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@cf9ebb74c9b296afde9c3599dc2ed284c8742533
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -18561,13 +18562,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@cf9ebb74c9b296afde9c3599dc2ed284c8742533
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   hash:
-    sha256: cf9ebb74c9b296afde9c3599dc2ed284c8742533
+    sha256: c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@cf9ebb74c9b296afde9c3599dc2ed284c8742533
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -18575,11 +18576,11 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@cf9ebb74c9b296afde9c3599dc2ed284c8742533
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   hash:
-    sha256: cf9ebb74c9b296afde9c3599dc2ed284c8742533
+    sha256: c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@cf9ebb74c9b296afde9c3599dc2ed284c8742533
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@c0067a99e1b9521054ffb4ea9bddc3ebbaae1bd4
   optional: false

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -38,15 +38,15 @@ def select_articles(
         user_embedder = UserEmbedder(MODEL, DEVICE)
         article_scorer = ArticleScorer(MODEL)
 
-        candidate_article_embeddings = article_embedder(candidate_articles.articles)
-        clicked_article_embeddings = article_embedder(clicked_articles.articles)
+        candidate_articles = article_embedder(candidate_articles)
+        clicked_articles = article_embedder(clicked_articles)
 
-        user_embedding = user_embedder(interest_profile, clicked_articles.articles, clicked_article_embeddings)
-        article_scores = article_scorer(candidate_article_embeddings, user_embedding)
+        user_embedding = user_embedder(interest_profile, clicked_articles.articles, clicked_articles.embeddings)
+        article_scores = article_scorer(candidate_articles.embeddings, user_embedding)
 
         if diversify == "mmr":
             diversifier = MMRDiversifier(algo_params)
-            recs = diversifier(article_scores, candidate_article_embeddings, num_slots)
+            recs = diversifier(article_scores, candidate_articles.embeddings, num_slots)
 
         elif diversify == "pfar":
             diversifier = PFARDiversifier(algo_params)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -42,15 +42,15 @@ def select_articles(
         clicked_articles = article_embedder(clicked_articles)
 
         interest_profile = user_embedder(interest_profile, clicked_articles)
-        article_scores = article_scorer(candidate_articles.embeddings, interest_profile.embedding)
+        candidate_articles = article_scorer(candidate_articles, interest_profile)
 
         if diversify == "mmr":
             diversifier = MMRDiversifier(algo_params)
-            recs = diversifier(article_scores, candidate_articles.embeddings, num_slots)
+            recs = diversifier(candidate_articles.scores, candidate_articles.embeddings, num_slots)
 
         elif diversify == "pfar":
             diversifier = PFARDiversifier(algo_params)
-            recs = diversifier(article_scores, interest_profile, candidate_articles.articles, num_slots)
+            recs = diversifier(candidate_articles.scores, interest_profile, candidate_articles.articles, num_slots)
 
         recommendations[account_id] = [candidate_articles.articles[int(rec)] for rec in recs]
     else:

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -41,8 +41,8 @@ def select_articles(
         candidate_articles = article_embedder(candidate_articles)
         clicked_articles = article_embedder(clicked_articles)
 
-        user_embedding = user_embedder(interest_profile, clicked_articles.articles, clicked_articles.embeddings)
-        article_scores = article_scorer(candidate_articles.embeddings, user_embedding)
+        interest_profile = user_embedder(interest_profile, clicked_articles)
+        article_scores = article_scorer(candidate_articles.embeddings, interest_profile.embedding)
 
         if diversify == "mmr":
             diversifier = MMRDiversifier(algo_params)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -49,10 +49,10 @@ def select_articles(
             recs = diversifier(candidate_articles)
 
         elif diversify == "pfar":
-            diversifier = PFARDiversifier(algo_params)
-            recs = diversifier(candidate_articles.scores, interest_profile, candidate_articles.articles, num_slots)
+            diversifier = PFARDiversifier(algo_params, num_slots)
+            recs = diversifier(candidate_articles, interest_profile)
 
-        recommendations[account_id] = [candidate_articles.articles[int(rec)] for rec in recs]
+        recommendations[account_id] = recs.articles
     else:
         recommendations[account_id] = select_by_topic(
             candidate_articles.articles,

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -45,8 +45,8 @@ def select_articles(
         candidate_articles = article_scorer(candidate_articles, interest_profile)
 
         if diversify == "mmr":
-            diversifier = MMRDiversifier(algo_params)
-            recs = diversifier(candidate_articles.scores, candidate_articles.embeddings, num_slots)
+            diversifier = MMRDiversifier(algo_params, num_slots)
+            recs = diversifier(candidate_articles)
 
         elif diversify == "pfar":
             diversifier = PFARDiversifier(algo_params)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -41,7 +41,7 @@ def select_articles(
         candidate_articles = article_embedder(candidate_articles)
         clicked_articles = article_embedder(clicked_articles)
 
-        interest_profile = user_embedder(interest_profile, clicked_articles)
+        interest_profile = user_embedder(clicked_articles, interest_profile)
         candidate_articles = article_scorer(candidate_articles, interest_profile)
 
         if diversify == "mmr":

--- a/src/poprox_recommender/diversifiers/mmr.py
+++ b/src/poprox_recommender/diversifiers/mmr.py
@@ -3,15 +3,22 @@ from typing import Any
 import numpy as np
 from tqdm import tqdm
 
+from poprox_concepts import ArticleSet
+
 
 class MMRDiversifier:
-    def __init__(self, algo_params: dict[str, Any]):
+    def __init__(self, algo_params: dict[str, Any], num_slots=10):
         self.theta = float(algo_params.get("theta", 0.8))
+        self.num_slots = num_slots
 
-    def __call__(self, article_scores, candidate_article_tensor, topk):
-        similarity_matrix = compute_similarity_matrix(candidate_article_tensor)
+    def __call__(self, candidate_articles: ArticleSet) -> ArticleSet:
+        similarity_matrix = compute_similarity_matrix(candidate_articles.embeddings)
 
-        return mmr_diversification(article_scores, similarity_matrix, theta=self.theta, topk=topk)
+        article_indices = mmr_diversification(
+            candidate_articles.scores, similarity_matrix, theta=self.theta, topk=self.num_slots
+        )
+
+        return ArticleSet(articles=[candidate_articles.articles[int(idx)] for idx in article_indices])
 
 
 def compute_similarity_matrix(todays_article_vectors):

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -1,6 +1,6 @@
 import torch as th
 
-from poprox_concepts import Article
+from poprox_concepts import ArticleSet
 
 
 class ArticleEmbedder:
@@ -9,9 +9,9 @@ class ArticleEmbedder:
         self.tokenizer = tokenizer
         self.device = device
 
-    def __call__(self, articles: list[Article]) -> th.Tensor:
+    def __call__(self, article_set: ArticleSet) -> ArticleSet:
         tokenized_titles = {}
-        for article in articles:
+        for article in article_set.articles:
             tokenized_titles[article.article_id] = self.tokenizer.encode(
                 article.title, padding="max_length", max_length=30, truncation=True
             )
@@ -20,4 +20,6 @@ class ArticleEmbedder:
         if len(title_tensor.shape) == 1:
             title_tensor = title_tensor.unsqueeze(dim=0)
 
-        return self.model.get_news_vector(title_tensor)
+        article_embeddings = self.model.get_news_vector(title_tensor)
+
+        return article_set.model_copy(update={"embeddings": article_embeddings})

--- a/src/poprox_recommender/embedders/user.py
+++ b/src/poprox_recommender/embedders/user.py
@@ -9,7 +9,7 @@ class UserEmbedder:
         self.device = device
         self.max_clicks = max_clicks_per_user
 
-    def __call__(self, interest_profile: InterestProfile, clicked_articles: ArticleSet) -> InterestProfile:
+    def __call__(self, clicked_articles: ArticleSet, interest_profile: InterestProfile) -> InterestProfile:
         embedding_lookup = {}
         for article, article_vector in zip(clicked_articles.articles, clicked_articles.embeddings, strict=True):
             if article.article_id not in embedding_lookup:

--- a/src/poprox_recommender/embedders/user.py
+++ b/src/poprox_recommender/embedders/user.py
@@ -1,6 +1,6 @@
 import torch as th
 
-from poprox_concepts import Article, ClickHistory, InterestProfile
+from poprox_concepts import ArticleSet, ClickHistory, InterestProfile
 
 
 class UserEmbedder:
@@ -9,11 +9,9 @@ class UserEmbedder:
         self.device = device
         self.max_clicks = max_clicks_per_user
 
-    def __call__(
-        self, interest_profile: InterestProfile, clicked_articles: list[Article], clicked_article_embeddings: th.Tensor
-    ):
+    def __call__(self, interest_profile: InterestProfile, clicked_articles: ArticleSet) -> InterestProfile:
         embedding_lookup = {}
-        for article, article_vector in zip(clicked_articles, clicked_article_embeddings, strict=True):
+        for article, article_vector in zip(clicked_articles.articles, clicked_articles.embeddings, strict=True):
             if article.article_id not in embedding_lookup:
                 embedding_lookup[article.article_id] = article_vector
 
@@ -27,7 +25,7 @@ class UserEmbedder:
             self.max_clicks,
         )
 
-        return user_embedding
+        return interest_profile.model_copy(update={"embedding": user_embedding})
 
 
 # Compute a vector for each user

--- a/src/poprox_recommender/scorers/article.py
+++ b/src/poprox_recommender/scorers/article.py
@@ -1,11 +1,13 @@
-import numpy as np
-import torch as th
+from poprox_concepts import ArticleSet, InterestProfile
 
 
 class ArticleScorer:
     def __init__(self, model):
         self.model = model
 
-    def __call__(self, candidate_embeddings: th.Tensor, user_embedding: th.Tensor) -> np.ndarray:
+    def __call__(self, candidate_articles: ArticleSet, interest_profile: InterestProfile) -> ArticleSet:
+        candidate_embeddings = candidate_articles.embeddings
+        user_embedding = interest_profile.embedding
+
         pred = self.model.get_prediction(candidate_embeddings, user_embedding.squeeze())
-        return pred.cpu().detach().numpy()
+        return candidate_articles.model_copy(update={"scores": pred.cpu().detach().numpy()})


### PR DESCRIPTION
This builds on the previous refactoring and CCRI-POPROX/poprox-concepts#9 to standardize the component API a bit. After this refactor, every component takes an `ArticleSet` (an extendable wrapper around a list of articles) as the first argument and some take an `InterestProfile` (an extendable wrapper around click histories etc) as the second argument. Additionally, all components return one of these two types.

The mechanism by which components extend either `ArticleSet` or `InterestProfile` with new information that isn't part of their default definitions is Pydantic's ability to accept and set additional attributes beyond those in the class definition, which components can use to create new attributes like `embeddings`, `scores`, etc. I'd like to find a way to make these more visible, both to readers of the code and to the code itself so that we can validate that a sequence of components produces everything later components require before they try to access it. For now though, I'm leaving it very implicit in the interest of keeping the scope of this change manageable.

This doesn't take us all the way to a pipeline, but it comes pretty close—the next step along the path is likely to execute a list of components in sequence while forming the inputs for the next component from a combination of the previous component's inputs and output. Once we make it that far, then we can start to think about more complex configurations like branching component graphs etc.