### PR TITLE
Dynamically cache the recommender at runtime

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from poprox_concepts import Article, InterestProfile
 from poprox_recommender.diversifiers import MMRDiversifier, PFARDiversifier
 from poprox_recommender.embedders import ArticleEmbedder, UserEmbedder
-from poprox_recommender.model import get_recommender
+from poprox_recommender.model import get_model
 from poprox_recommender.scorers import ArticleScorer
 from poprox_recommender.topics import user_topic_preference
 
@@ -25,7 +25,7 @@ def select_articles(
     algo_params = algo_params or {}
     diversify = str(algo_params.get("diversity_algo", "pfar"))
 
-    rec = get_recommender()
+    rec = get_model()
     recommendations = {}
     if rec and click_history.article_ids:
         article_embedder = ArticleEmbedder(rec.model, rec.tokenizer, rec.device)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from poprox_concepts import Article, InterestProfile
 from poprox_recommender.diversifiers import MMRDiversifier, PFARDiversifier
 from poprox_recommender.embedders import ArticleEmbedder, UserEmbedder
-from poprox_recommender.model import DEVICE, MODEL, TOKENIZER
+from poprox_recommender.model import get_recommender
 from poprox_recommender.scorers import ArticleScorer
 from poprox_recommender.topics import user_topic_preference
 
@@ -25,11 +25,12 @@ def select_articles(
     algo_params = algo_params or {}
     diversify = str(algo_params.get("diversity_algo", "pfar"))
 
+    rec = get_recommender()
     recommendations = {}
-    if MODEL and TOKENIZER and click_history.article_ids:
-        article_embedder = ArticleEmbedder(MODEL, TOKENIZER, DEVICE)
-        user_embedder = UserEmbedder(MODEL, DEVICE)
-        article_scorer = ArticleScorer(MODEL)
+    if rec and click_history.article_ids:
+        article_embedder = ArticleEmbedder(rec.model, rec.tokenizer, rec.device)
+        user_embedder = UserEmbedder(rec.model, rec.device)
+        article_scorer = ArticleScorer(rec.model)
 
         candidate_article_embeddings = article_embedder(candidate_articles)
         clicked_article_embeddings = article_embedder(clicked_articles)

--- a/src/poprox_recommender/model/__init__.py
+++ b/src/poprox_recommender/model/__init__.py
@@ -9,7 +9,7 @@ from transformers import AutoTokenizer
 from poprox_recommender.model.nrms import NRMS
 from poprox_recommender.paths import model_file_path
 
-_cached_recommender: Optional[RecommenderComponents] = None
+_cached_model: Optional[RecommenderComponents] = None
 
 
 @dataclass
@@ -57,12 +57,12 @@ def load_model(checkpoint, device):
     return model
 
 
-def get_recommender(device=None) -> RecommenderComponents:
-    global _cached_recommender
-    if _cached_recommender is None:
+def get_model(device=None) -> RecommenderComponents:
+    global _cached_model
+    if _cached_model is None:
         tokenizer = AutoTokenizer.from_pretrained("distilbert-base-uncased", cache_dir="/tmp/")
         checkpoint, device = load_checkpoint(device)
         model = load_model(checkpoint, device)
-        _cached_recommender = RecommenderComponents(tokenizer, model, device)
+        _cached_model = RecommenderComponents(tokenizer, model, device)
 
-    return _cached_recommender
+    return _cached_model


### PR DESCRIPTION
This moves model loading into a `get_model` function to defer loading from import to runtime, caching in a global variable. This returns both the tokenizer and scoring model.