### PR TITLE
Add shell formatting to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,14 @@ repos:
       # Run the linter.
       - id: ruff
         args: [--fix]
+        name: auto-fix Python lint errors
       # Run the formatter.
       - id: ruff-format
+        name: format Python source
   - repo: local
     hooks:
       - id: format-toml-files
-        name: toml-format
+        name: format toml files
         entry: taplo
         args: ["format"]
         files: \.toml$
@@ -37,7 +39,7 @@ repos:
         additional_dependencies:
           - "@taplo/cli"
       # shfmt support, adapted from https://github.com/mvdan/sh/issues/818
-      - id: format-shell-files
+      - id: format-shell-scripts
         name: format shell scripts
         language: golang
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,12 @@ repos:
         language: node
         additional_dependencies:
           - "@taplo/cli"
+      # shfmt support, adapted from https://github.com/mvdan/sh/issues/818
+      - id: format-shell-files
+        name: format shell scripts
+        language: golang
+        require_serial: true
+        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.8.0]
+        entry: shfmt
+        args: ["-l", "-w", "-i", "4"]
+        types: [shell]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 
-while getopts ":e:r:" flag
-do
+while getopts ":e:r:" flag; do
     case "${flag}" in
-        e) env=${OPTARG};;
-        r) region=${OPTARG};;
-        *) echo "Invalid option. Only -e and -r are allowed" >&2
-            exit 1 ;;
+    e) env=${OPTARG} ;;
+    r) region=${OPTARG} ;;
+    *)
+        echo "Invalid option. Only -e and -r are allowed" >&2
+        exit 1
+        ;;
     esac
 done
 env=${env:-prod}
 region=${region:-us-east-1}
 
-echo "ENV: $env";
-echo "Region: $region";
+echo "ENV: $env"
+echo "Region: $region"
 
 # Download model artifacts
 dvc pull


### PR DESCRIPTION
Add shfmt to pre-commit to format our shell scripts, and run it on the existing scripts.

This is an additional Go-based dependency.