### PR TITLE
Add best-effort type checking at pipeline construction and run time

### DIFF
--- a/src/poprox_recommender/components/samplers/uniform.py
+++ b/src/poprox_recommender/components/samplers/uniform.py
@@ -7,7 +7,7 @@ class UniformSampler:
     def __init__(self, num_slots):
         self.num_slots = num_slots
 
-    def __call__(self, candidate: ArticleSet, backup: ArticleSet | None = None):
+    def __call__(self, candidate: ArticleSet, backup: ArticleSet | None = None) -> ArticleSet:
         backup_articles = list(filter(lambda article: article not in candidate.articles, backup.articles))
 
         num_backups = (

--- a/src/poprox_recommender/pipeline.py
+++ b/src/poprox_recommender/pipeline.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from dataclasses import dataclass
+from inspect import _empty, signature
 from typing import Callable
 
 from poprox_concepts import Article, ArticleSet, InterestProfile
@@ -39,9 +40,13 @@ class RecommendationPipeline:
     def __init__(self, name):
         self.name = name
         self.components = []
+        self._state_types = {"candidate": ArticleSet, "clicked": ArticleSet, "profile": InterestProfile}
 
     def add(self, component: Callable, inputs: list[str], output: str):
-        self.components.append(ComponentSpec(component, inputs, output))
+        spec = ComponentSpec(component, inputs, output)
+        self._validate_input_types(spec, self._state_types)
+        self._state_types[output] = self._validate_output_type(spec)
+        self.components.append(spec)
 
     def __call__(self, inputs: PipelineState | StateDict) -> PipelineState:
         # Avoid modifying the inputs
@@ -82,3 +87,37 @@ class RecommendationPipeline:
         state[state._last] = output
 
         return state
+
+    def _validate_input_types(self, spec: ComponentSpec, state_types: dict[str, type]):
+        # Best effort type-checking to highlight when inputs are mismatched or out of order
+        sig = signature(spec.component.__call__)
+        sig_params = list(sig.parameters.values())
+
+        for input_name, sig_param in zip(spec.inputs, sig_params):
+            input_type = state_types[input_name]
+            sig_param_type = sig_param.annotation
+            if sig_param_type is not _empty and input_type != sig_param_type:
+                msg = (
+                    f"Component {spec.component} expected inputs with types {[p.annotation for p in sig_params]} "
+                    f"but received inputs with types {[state_types[i] for i in spec.inputs]}"
+                )
+
+                raise TypeError(msg)
+
+    def _validate_output_type(self, spec: ComponentSpec):
+        # Best effort type-checking to highlight when output is
+        # mismatched with existing state values types
+        sig = signature(spec.component.__call__)
+        output_name = spec.output
+
+        state_type = self._state_types.get(output_name, None)
+        output_type = sig.return_annotation
+        if state_type and output_type is not _empty and state_type != output_type:
+            msg = (
+                f"Component {spec.component} returns output with type {output_type} "
+                f"but would need to return {state_type} in order to overwrite {output_name}"
+            )
+
+            raise TypeError(msg)
+
+        return output_type

--- a/src/poprox_recommender/pipeline.py
+++ b/src/poprox_recommender/pipeline.py
@@ -108,7 +108,7 @@ class RecommendationPipeline:
         state_type = self._state_types.get(output_name, None)
         output_type = sig.return_annotation
 
-        if output_type is not _empty and output_type not in (ArticleSet, InterestProfile):
+        if output_type is not _empty and not issubclass(output_type, (ArticleSet, InterestProfile)):
             msg = (
                 f"Pipeline components must return ArticleSet or InterestProfile, "
                 f"but received {type(output_type)} from {type(spec.component)}"
@@ -127,8 +127,7 @@ class RecommendationPipeline:
 
     def _validate_return_type(self, component_spec, output):
         expected_type = self._state_types.get(component_spec.output, None)
-        output_type = type(output)
-        if not included_in(output_type, expected_type):
+        if not isinstance(output, expected_type):
             msg = (
                 f"{type(component_spec.component)} is expected to return {expected_type}, "
                 f"but received {type(output)}"
@@ -145,7 +144,7 @@ def included_in(object_type: type, t: Any):
     if t == _empty or t is None:
         return True
 
-    if object_type == t:
+    if issubclass(object_type, t):
         return True
 
     if not is_union(t):

--- a/src/poprox_recommender/pipeline.py
+++ b/src/poprox_recommender/pipeline.py
@@ -121,9 +121,6 @@ class RecommendationPipeline:
                 f"but would need to return {state_type} in order to overwrite {output_name}"
             )
 
-        state._last = component_spec.output
-        state[state._last] = output
-
             raise TypeError(msg)
 
         return output_type

--- a/src/poprox_recommender/pytorch/decorators.py
+++ b/src/poprox_recommender/pytorch/decorators.py
@@ -5,6 +5,7 @@ Decorators to help with Torch usage.
 # pyright: strict
 from __future__ import annotations
 
+from functools import wraps
 from typing import Callable, ParamSpec, TypeVar
 
 import torch
@@ -26,6 +27,7 @@ def torch_inference(func: Callable[P, R]) -> Callable[P, R]:
         func: the function to wrap.
     """
 
+    @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         with torch.inference_mode():
             return func(*args, **kwargs)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,73 @@
+import pytest
+
+from poprox_concepts.domain import ArticleSet, InterestProfile
+from poprox_recommender.pipeline import RecommendationPipeline
+
+
+class UnannotatedArticleComponent:
+    def __call__(self, articles, profile):
+        return articles
+
+
+class ArticleComponent:
+    def __call__(self, articles: ArticleSet, profile: InterestProfile) -> ArticleSet:
+        return articles
+
+
+# The inconsistent parameter naming between article and profile components
+# is intentional in order to test that our type checking doesn't require
+# consistent naming
+class UnannotatedProfileComponent:
+    def __call__(self, article_set, interest_profile):
+        return interest_profile
+
+
+class ProfileComponent:
+    def __call__(self, article_set: ArticleSet, interest_profile: InterestProfile) -> InterestProfile:
+        return interest_profile
+
+
+def test_construction_without_annotations():
+    pipeline = RecommendationPipeline(name="matching")
+    pipeline.add(UnannotatedProfileComponent(), output="profile", inputs=["candidate", "profile"])
+    pipeline.add(UnannotatedArticleComponent(), output="recs", inputs=["candidate", "profile"])
+
+    assert len(pipeline.components) == 2
+
+
+def test_construction_with_matching_inputs():
+    pipeline = RecommendationPipeline(name="matching")
+    pipeline.add(ProfileComponent(), output="profile", inputs=["candidate", "profile"])
+    pipeline.add(ArticleComponent(), output="recs", inputs=["candidate", "profile"])
+
+    assert len(pipeline.components) == 2
+
+
+def test_construction_with_mismatched_inputs():
+    pipeline = RecommendationPipeline(name="matching")
+
+    with pytest.raises(TypeError):
+        pipeline.add(ProfileComponent(), output="profile", inputs=["profile", "candidate"])
+
+
+def test_construction_with_new_state_values():
+    pipeline = RecommendationPipeline(name="new_state")
+    pipeline.add(ProfileComponent(), output="augmented_profile", inputs=["candidate", "profile"])
+    pipeline.add(ArticleComponent(), output="recs", inputs=["candidate", "augmented_profile"])
+
+    assert len(pipeline.components) == 2
+
+
+def test_construction_with_mismatched_new_state_values():
+    pipeline = RecommendationPipeline(name="mismatched_new_state")
+    pipeline.add(ProfileComponent(), output="augmented_profile", inputs=["candidate", "profile"])
+
+    with pytest.raises(TypeError):
+        pipeline.add(ArticleComponent(), output="recs", inputs=["augmented_profile", "candidate"])
+
+
+def test_construction_with_mismatched_state_overwrite():
+    pipeline = RecommendationPipeline(name="mismatched_output_type")
+
+    with pytest.raises(TypeError):
+        pipeline.add(ProfileComponent(), output="candidate", inputs=["candidate", "profile"])


### PR DESCRIPTION
When components are added to the pipeline, this keeps track of the types of their inputs and outputs in order to validate that components are wired together in a way that provides the right types to the right inputs (so that e.g. flipping the order of component arguments will result in an error.) It also checks at pipeline execution time that the types being returned by components actually match their type annotations.