### PR TITLE
Incrementally process MIND data instead of pre-loading all of it

### DIFF
--- a/src/poprox_recommender/test_offline.py
+++ b/src/poprox_recommender/test_offline.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from itertools import islice
 
 from lenskit.metrics import topn
 from tqdm import tqdm
@@ -70,7 +69,7 @@ if __name__ == "__main__":
     mrr = []
 
     logger.info("measuring recommendations")
-    for request in tqdm(islice(mind_data.iter_users(), 10), total=10, desc="recommend"):  # one by one
+    for request in tqdm(mind_data.iter_users(), total=mind_data.n_users, desc="recommend"):  # one by one
         logger.debug("recommending for user %s", request.interest_profile.profile_id)
         try:
             recommendations = select_articles(


### PR DESCRIPTION
This follows up on #62 to make the offline tests process the MIND test data incrementally instead of pre-instantiating all full recommendation requests in memory.

Right now, the evaluation is unusably slow, likely due to the lack of caching of article text embeddings. The old code had a 10-article limit that resulted in unhelpful evaluations but did let the code finish.

> [!IMPORTANT]
> This also brings a correctness fix to the metrics, as the previous reciprocal rank was always 1, because it looked for *any* logged record instead of only relevant ones.