### PR TITLE
Refactor default pipeline and selection into pipeline constructor functions

### DIFF
--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -45,12 +45,13 @@ def personalized_pipeline(num_slots: int, algo_params: dict[str, Any] | None = N
         num_slots: The number of items to recommend.
         algo_params: Additional parameters to the reocmmender algorithm.
     """
-
     model = get_model()
     if model is None:
         return None
 
-    diversify = str(algo_params.get("diversity_algo", "pfar")) if algo_params else "pfar"
+    if not algo_params:
+        algo_params = {}
+    diversify = str(algo_params.get("diversity_algo", "pfar"))
 
     article_embedder = ArticleEmbedder(model.model, model.tokenizer, model.device)
     user_embedder = UserEmbedder(model.model, model.device)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -1,3 +1,4 @@
+# pyright: basic
 from typing import Any
 
 from poprox_concepts import ArticleSet, InterestProfile
@@ -84,3 +85,4 @@ def fallback_pipeline(num_slots: int) -> RecommendationPipeline:
     pipeline = RecommendationPipeline(name="random_topical")
     pipeline.add(topic_filter, inputs=["candidate", "profile"], output="topical")
     pipeline.add(sampler, inputs=["topical", "candidate"], output="recs")
+    return pipeline


### PR DESCRIPTION
This refactors the `select_articles` logic to create pipelines into separate functions to create personalized and fallback pipelines, and then directly uses the personalized pipeline in `test_offline` instead of calling `select_articles`.

This is Step 1 of my effort to speed up evaluation by caching article embeddings.