### PR TITLE
Cache article embeddings

### DIFF
--- a/src/poprox_recommender/datachecks.py
+++ b/src/poprox_recommender/datachecks.py
@@ -1,0 +1,33 @@
+"""
+Data-checking routines.
+"""
+
+import torch as th
+
+
+def assert_tensor_size(tensor: th.Tensor, *size: int, label: str | None = None, prefix: bool = True):
+    """
+    Check that a tensor is of the expected size, and fail with an assertion error
+    if it is the incorrect size.
+
+    Args:
+        tensor: The tensor to check.
+        *size: The expected size of the tensor.
+        label: A label for the tensor.
+        prefix:
+            If ``True`` and the tensor has more dimensions than the expected size, only match the common prefix of
+            dimensions.
+    """
+    actual = tensor.shape
+    expected = th.Size(size)
+    if prefix and len(actual) > len(expected):
+        actual = actual[: len(expected)]
+    if actual != expected:
+        msg = f"unexpected tensor size {_size_string(actual)} (expected {_size_string(expected)})"
+        if label:
+            msg = f"{label}: {msg}"
+        raise AssertionError(msg)
+
+
+def _size_string(size: th.Size) -> str:
+    return " ⨉ ".join(str(d) for d in size)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -45,12 +45,13 @@ def personalized_pipeline(num_slots: int, algo_params: dict[str, Any] | None = N
         num_slots: The number of items to recommend.
         algo_params: Additional parameters to the reocmmender algorithm.
     """
-
     model = get_model()
     if model is None:
         return None
 
-    diversify = str(algo_params.get("diversity_algo", "pfar")) if algo_params else "pfar"
+    if not algo_params:
+        algo_params = {}
+    diversify = str(algo_params.get("diversity_algo", "pfar"))
 
     article_embedder = ArticleEmbedder(model.model, model.tokenizer, model.device)
     user_embedder = UserEmbedder(model.model, model.device)

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -1,3 +1,4 @@
+# pyright: basic
 from typing import Any
 
 from poprox_concepts import ArticleSet, InterestProfile
@@ -84,3 +85,4 @@ def fallback_pipeline(num_slots: int) -> RecommendationPipeline:
     pipeline = RecommendationPipeline(name="random_topical")
     pipeline.add(topic_filter, inputs=["candidate", "profile"], output="topical")
     pipeline.add(sampler, inputs=["topical", "candidate"], output="recs")
+    return pipeline

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -1,4 +1,5 @@
 # pyright: basic
+import logging
 from typing import Protocol
 from uuid import UUID
 
@@ -8,6 +9,7 @@ from transformers import PreTrainedTokenizer
 from poprox_concepts import ArticleSet
 from poprox_recommender.datachecks import assert_tensor_size
 
+logger = logging.getLogger(__name__)
 TITLE_LENGTH_LIMIT = 30
 
 
@@ -41,6 +43,7 @@ class ArticleEmbedder:
         uncached = [article for article in article_set.articles if cached[article.article_id] is None]
 
         if uncached:
+            logger.debug("need to embed %d of %d articles", len(uncached), len(cached))
             # Step 3: tokenize the uncached articles
             uc_title_tokens = th.stack(
                 [

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -6,6 +6,7 @@ import torch as th
 from transformers import PreTrainedTokenizer
 
 from poprox_concepts import ArticleSet
+from poprox_recommender.datachecks import assert_tensor_size
 
 TITLE_LENGTH_LIMIT = 30
 
@@ -52,7 +53,7 @@ class ArticleEmbedder:
                     for article in uncached
                 ]
             )
-            assert uc_title_tokens == (len(uncached), TITLE_LENGTH_LIMIT)
+            assert_tensor_size(uc_title_tokens, len(uncached), TITLE_LENGTH_LIMIT)
 
             # Step 4: embed the uncached articles
             uc_embeddings = self.model.get_news_vector(uc_title_tokens)

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -1,5 +1,6 @@
 # pyright: basic
 from typing import Protocol
+from uuid import UUID
 
 import torch as th
 from transformers import PreTrainedTokenizer
@@ -21,26 +22,56 @@ class ArticleEmbedder:
     model: ArticleEmbeddingModel
     tokenizer: PreTrainedTokenizer
     device: str | None
+    embedding_cache: dict[UUID, th.Tensor]
 
     def __init__(self, model: ArticleEmbeddingModel, tokenizer: PreTrainedTokenizer, device: str | None):
         self.model = model
         self.tokenizer = tokenizer
         self.device = device
+        self.embedding_cache = {}
 
     def __call__(self, article_set: ArticleSet) -> ArticleSet:
-        tokenized_titles = [
-            th.tensor(
-                self.tokenizer.encode(
-                    article.title, padding="max_length", max_length=TITLE_LENGTH_LIMIT, truncation=True
-                ),
-                dtype=th.int32,
+        # Step 1: get the cached articles wherever possible.
+        # Since Python dictionaries preserve order, this keeps the order aligned with the
+        # input article set.
+        cached = {article.article_id: self.embedding_cache.get(article.article_id) for article in article_set.articles}
+
+        # Step 2: find the uncached articles.
+        uncached = [article for article in article_set.articles if cached[article.article_id] is None]
+
+        if uncached:
+            # Step 3: tokenize the uncached articles
+            uc_title_tokens = th.stack(
+                [
+                    th.tensor(
+                        self.tokenizer.encode(
+                            article.title, padding="max_length", max_length=TITLE_LENGTH_LIMIT, truncation=True
+                        ),
+                        dtype=th.int32,
+                    )
+                    for article in uncached
+                ]
             )
-            for article in article_set.articles
-        ]
+            assert uc_title_tokens == (len(uncached), TITLE_LENGTH_LIMIT)
 
-        title_tensor = th.stack(tokenized_titles).to(self.device)
-        assert title_tensor.shape == (len(article_set.articles), TITLE_LENGTH_LIMIT)
+            # Step 4: embed the uncached articles
+            uc_embeddings = self.model.get_news_vector(uc_title_tokens)
+            assert uc_embeddings.shape[0] == len(uncached)
 
-        article_set.embeddings = self.model.get_news_vector(title_tensor)  # type: ignore
+            # Step 5: store embeddings to cache & result
+            for i, uca in enumerate(uncached):
+                # copy the tensor so it isn't attached to excess memory
+                a_emb = uc_embeddings[i, :].clone()
+                cached[uca.article_id] = a_emb
+                self.embedding_cache[uca.article_id] = a_emb
+
+        # Step 6: stack the embeddings into a single tensor
+        embed_single_tensors = list(cached.values())
+        assert not any(e is None for e in embed_single_tensors)
+        embed_tensor = th.stack(embed_single_tensors)  # type: ignore
+        assert embed_tensor.shape[0] == len(article_set.articles)
+
+        # Step 7: put the embedding tensor on the output
+        article_set.embeddings = embed_tensor  # type: ignore
 
         return article_set

--- a/src/poprox_recommender/embedders/article.py
+++ b/src/poprox_recommender/embedders/article.py
@@ -1,10 +1,26 @@
+# pyright: basic
+from typing import Protocol
+
 import torch as th
+from transformers import PreTrainedTokenizer
 
 from poprox_concepts import ArticleSet
 
 
+class ArticleEmbeddingModel(Protocol):
+    """
+    Interface exposed by article embedding models.
+    """
+
+    def get_news_vector(self, news: th.Tensor) -> th.Tensor: ...
+
+
 class ArticleEmbedder:
-    def __init__(self, model, tokenizer, device):
+    model: ArticleEmbeddingModel
+    tokenizer: PreTrainedTokenizer
+    device: str | None
+
+    def __init__(self, model: ArticleEmbeddingModel, tokenizer: PreTrainedTokenizer, device: str | None):
         self.model = model
         self.tokenizer = tokenizer
         self.device = device
@@ -20,6 +36,6 @@ class ArticleEmbedder:
         if len(title_tensor.shape) == 1:
             title_tensor = title_tensor.unsqueeze(dim=0)
 
-        article_set.embeddings = self.model.get_news_vector(title_tensor)
+        article_set.embeddings = self.model.get_news_vector(title_tensor)  # type: ignore
 
         return article_set

--- a/src/poprox_recommender/model/nrms/__init__.py
+++ b/src/poprox_recommender/model/nrms/__init__.py
@@ -42,13 +42,10 @@ class NRMS(torch.nn.Module):
 
         return click_probability
 
-    def get_news_vector(self, news):
+    def get_news_vector(self, news: torch.Tensor) -> torch.Tensor:
         """
         Args:
-            news:
-                {
-                    "title": batch_size * num_words_title
-                },
+            news: The encoded news content (currently just titles).
         Returns:
             (shape) batch_size, word_embedding_dim
         """

--- a/src/poprox_recommender/model/nrms/news_encoder.py
+++ b/src/poprox_recommender/model/nrms/news_encoder.py
@@ -28,7 +28,7 @@ class NewsEncoder(torch.nn.Module):
 
         self.additive_attention = NewsAdditiveAttention(plm_hidden_size, self.config.additive_attn_hidden_dim)
 
-    def forward(self, news_input):
+    def forward(self, news_input: torch.Tensor) -> torch.Tensor:
         # batch_size, num_words_title, word_embedding_dim
 
         V = self.plm(news_input).last_hidden_state

--- a/tests/test_datachecks.py
+++ b/tests/test_datachecks.py
@@ -1,0 +1,27 @@
+import torch as th
+from pytest import raises
+
+from poprox_recommender.datachecks import assert_tensor_size
+
+
+def test_tensor_size_ok():
+    assert_tensor_size(th.randn(10, 50), 10, 50)
+
+
+def test_tensor_size_fail():
+    with raises(AssertionError, match=r"^unexpected tensor size"):
+        assert_tensor_size(th.randn(10, 40), 10, 50)
+
+
+def test_tensor_size_fail_label():
+    with raises(AssertionError, match=r"^test: unexpected tensor size"):
+        assert_tensor_size(th.randn(10, 40), 10, 50, label="test")
+
+
+def test_tensor_size_prefix():
+    assert_tensor_size(th.randn(10, 50, 25), 10, 50, label="test")
+
+
+def test_tensor_size_no_prefix():
+    with raises(AssertionError, match=r"^test: unexpected tensor size"):
+        assert_tensor_size(th.randn(10, 50, 25), 10, 50, label="test", prefix=False)


### PR DESCRIPTION
This adds a cache to cache the article embeddings in a pipeline instance to reduce recomputation in evaluation.

It also adds a `datachecks` module with a function to do assertion checks on tensor sizes with useful error messages.