### PR TITLE
Update to use Copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 098456f
+_commit: 5bdf2a5
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: ba0b8ca
+_commit: 098456f
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,6 @@
+# Changes here will be overwritten by Copier
+_commit: ba0b8ca
+_src_path: https://github.com/CCRI-POPROX/poprox-repo-template
+package_name: poprox_recommender
+project_descr: POPROX recommender implementation and infrastructure.
+project_name: poprox-recommender

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 5bdf2a5
+_commit: c4194d6
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,14 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
+# C and Cython bits
+cython_debug/
 *.so
+*.dll
+*.pyd
+*.o
+*.obj
+*.a
 
 # Distribution / packaging
 .Python
@@ -20,17 +26,12 @@ parts/
 sdist/
 var/
 wheels/
+out/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
 MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
 
 # Installer logs
 pip-log.txt
@@ -50,6 +51,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.nyc_output
 
 # Translations
 *.mo
@@ -68,46 +70,12 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
 # Jupyter Notebook
-.ipynb_checkpoints
+.ipynb_checkpoints/
 
 # IPython
 profile_default/
 ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -115,9 +83,6 @@ __pypackages__/
 # Celery stuff
 celerybeat-schedule
 celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -132,34 +97,56 @@ venv.bak/
 .spyderproject
 .spyproject
 
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
+# type checker caches
 .mypy_cache/
 .dmypy.json
 dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
 
 # Serverless directories
 .serverless
-node_modules
 .requirements*
+
+# Logs and profiler output
+logs/
+*.log*
+*.prof
+*.lprof
+perf.data*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Node-related runtime things
+node_modules/
+jspm_packages/
+web_modules/
+bower_components/
+*.tsbuildinfo
+.eslintcache
+.npm
+.node_repl_history
+.cache/
+
+# Web-related things
+.stylelintcache
+.rpt2_cache/
+.rts2_cache_*/
+.next
+.nuxt
+
+# Editors
+.idea
+
+# OS junk
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+Thumbs.db
+[Dd]esktop.ini
+$RECYCLE.BIN/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
       - id: check-yaml
+        exclude: cloudformation\.yml
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -18,7 +19,7 @@ repos:
     hooks:
       - id: yamlfmt
         name: format yaml files
-        exclude: conda-lock.*\.yml
+        exclude: (cloudformation|conda-lock.*)\.yml
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.4.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN micromamba install -p /opt/poprox -c conda-forge awslambdaric
 
 # Copy the soure code into the image to install it
 # TODO do we want to copy the sdist or wheel instead?
-COPY pyproject.toml README.md /src/poprox-recommender/
+COPY pyproject.toml README.md LICENSE.md /src/poprox-recommender/
 COPY src/ /src/poprox-recommender/src/
 WORKDIR /src/poprox-recommender
 # Install the poprox-recommender module

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+Copyright (c) 2023–2024 POPROX Collaborators
+- Regents of the University of Minnesota
+- Regents of the University of Colorado
+- Drexel University
+- Clemson University
+- Northwestern University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -1,8 +1,8 @@
-# Dependencies needed for working on the this code and repo.
-# This does *not* include the dependencies of poprox-recommender itself —
-# it is only the tooling and dependencies for development, image building,
-# etc.  It is included in the conda lockfile as the 'dev' category, and
-# can be directly installed in CI for repo manipulation.
+# Dependencies needed for working on the this code and repo. This does *not*
+# include the dependencies of the code itself — it is only the tooling and
+# dependencies for development, image building, etc.  It is included in the
+# conda lockfile as the 'dev' category, and can be directly installed in CI for
+# repo manipulation.
 category: dev
 dependencies:
   - hatch

--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -1,29 +1,29 @@
-# Dependencies needed for working on the poprox-recommender code and repo.
+# Dependencies needed for working on the this code and repo.
 # This does *not* include the dependencies of poprox-recommender itself —
 # it is only the tooling and dependencies for development, image building,
 # etc.  It is included in the conda lockfile as the 'dev' category, and
 # can be directly installed in CI for repo manipulation.
 category: dev
 dependencies:
+  - hatch
+  # dependencies for tests
+  - coverage >=6.5
+  - pytest >=8
+  # tooling for code validation
+  - pre-commit >=3.7,<4
+  - ruff >=0.4
+  - pyright >=1.1,<2
   # tooling for environments and data
   - dvc >=3.51,<4
   - dvc-s3
   - conda-lock >=2.5,<3
-  - yq
-  - hatch
   # dependencies for development scripts
   - docopt >=0.6
   # requests is a pulled in by other things. omit here to avoid screwing up categories.
   # - requests >=2.31,<3
   # dependencies for tests
-  - pytest >=7
-  - coverage >=6.5
   - pexpect~=4.9
   - pandas==2.*
-  # tooling for code validation
-  - pre-commit >=3.7,<4
-  - ruff >=0.4
-  - pyright >=1.1,<2
   # tooling for interactive Python for dev work
   - ipython >=8
   - notebook >=7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "poprox-recommender"
-dynamic = ["version"]
-description = ''
-readme = "README.md"
-requires-python = ">=3.11"
-keywords = []
+description = "POPROX recommender implementation and infrastructure."
 authors = [{ name = "Karl Higley", email = "khigley@umn.edu" }]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+]
+requires-python = ">= 3.11"
+readme = "README.md"
+license = { file = "LICENSE.md" }
+dynamic = ["version"]
 dependencies = [
   "lenskit==0.14.*",
   "nltk>=3.8,<4",
@@ -27,10 +31,11 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/CCRI-POPROX/poprox-recommender#readme"
-Issues = "https://github.com/CCRI-POPROX/poprox-recommender/issues"
-Source = "https://github.com/CCRI-POPROX/poprox-recommender"
+Homepage = "https://docs.poprox.ai"
+GitHub = "https://github.com/CCRI-POPROX/poprox-recommender"
 
+###### build and environment configurations ######
+# basic hatch config
 [tool.hatch.metadata]
 allow-direct-references = true
 
@@ -39,67 +44,68 @@ path = "src/poprox_recommender/__about__.py"
 
 [tool.hatch.envs.default]
 python = "3.11"
-# keep these dependencies in sync with dev/dev-environment.yml
+# keep these dependencies in sync with dev/environment.yml if it exists
 dependencies = [
+  # testing and coverage
+  "coverage[toml]>=6.5",
+  "pytest>=8",
+  # development tooling
+  "pre-commit >=3.7,<4",
+  "ruff >=0.4",
+  "pyright >=1.1,<2",
+  # recommender-specific deps
   "dvc[s3] ~=3.51",
   "docopt~=0.6",
   "pandas==2.*",
   "requests~=2.13",
-  "coverage[toml]>=6.5",
-  "pytest>=8",
   "pexpect~=4.9",
 ]
+
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
-cov-report = ["- coverage combine", "coverage report"]
-cov = ["test-cov", "cov-report"]
 
+# tooling just for code validation
 [tool.hatch.envs.lint]
 detached = true
 dependencies = ["ruff>=0.4", "pyright>=1.1,<2"]
+
 [tool.hatch.envs.lint.scripts]
 typing = "pyright {args:src/poprox_recommender tests}"
 style = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 fmt = ["ruff format {args:.}", "ruff check --fix {args:.}", "style"]
 all = ["style", "typing"]
 
+# environment for project meta-tasks
+[tool.hatch.envs.meta]
+detached = true
+dependencies = ["copier==9.*"]
+
+[tool.hatch.envs.meta.scripts]
+update-template = "copier update"
+
+###### tooling configurations ######
+# ruff — formatting and lints
 [tool.ruff]
 target-version = "py311"
 line-length = 120
 
 [tool.ruff.lint]
 select = ["F", "I", "E"]
-ignore = [
-  # Allow non-abstract empty methods in abstract base classes
-  "B027",
-  # Allow boolean positional values in function calls, like `dict.get(... True)`
-  "FBT003",
-  # Ignore checks for possible passwords
-  "S105",
-  "S106",
-  "S107",
-  # Ignore complexity
-  "C901",
-  "PLR0911",
-  "PLR0912",
-  "PLR0913",
-  "PLR0915",
-]
 unfixable = [
   # Don't touch unused imports
   "F401",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# tests can have unused imports (for pytest fixtures)
+"tests/**/*" = ["F401"]
+
 [tool.ruff.isort]
-known-first-party = ["poprox_recommender", "poprox_concepts"]
+known-first-party = ["poprox_*"]
 
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"
-
-[tool.ruff.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.coverage.run]
 source_pkgs = ["poprox_recommender", "tests"]
@@ -108,11 +114,8 @@ parallel = true
 omit = ["src/poprox_recommender/__about__.py"]
 
 [tool.coverage.paths]
-poprox_recommender = [
-  "src/poprox_recommender",
-  "*/poprox-recommender/src/poprox_recommender",
-]
-tests = ["tests", "*/poprox-recommender/tests"]
+poprox_recommender = ["src/poprox_recommender"]
+tests = ["tests"]
 
 [tool.coverage.report]
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ GitHub = "https://github.com/CCRI-POPROX/poprox-recommender"
 [tool.hatch.metadata]
 allow-direct-references = true
 
+[tool.hatch.build.targets.sdist]
+only-include = ["src", "tests", "LICENSE.md", "README.md"]
+
 [tool.hatch.version]
 path = "src/poprox_recommender/__about__.py"
 

--- a/src/poprox_recommender/__init__.py
+++ b/src/poprox_recommender/__init__.py
@@ -1,0 +1,3 @@
+"""
+POPROX recommender implementation and infrastructure.
+"""


### PR DESCRIPTION
This updates the repo to use the new Copier template ([CCRI-POPROX/poprox-repo-template](https://github.com/CCRI-POPROX/poprox-repo-template)).

The actual changes are mostly noise, reordering things with some better comments and to facilitate reusability across POPROX projects.