### PR TITLE
Vectorize MMR for speedup

### DIFF
--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -65,4 +65,4 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
         # step 2: find the largest value
         S[k] = torch.argmax(scores)
 
-    return S.tolist()
+    return S[S >= 0].tolist()

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -2,6 +2,7 @@ import torch
 
 from poprox_concepts import ArticleSet, InterestProfile
 from poprox_recommender.lkpipeline import Component
+from poprox_recommender.pytorch.datachecks import assert_tensor_size
 from poprox_recommender.pytorch.decorators import torch_inference
 
 
@@ -17,9 +18,8 @@ class MMRDiversifier(Component):
 
         similarity_matrix = compute_similarity_matrix(candidate_articles.embeddings)
 
-        article_indices = mmr_diversification(
-            candidate_articles.scores, similarity_matrix, theta=self.theta, topk=self.num_slots
-        )
+        scores = torch.as_tensor(candidate_articles.scores).to(similarity_matrix.device)
+        article_indices = mmr_diversification(scores, similarity_matrix, theta=self.theta, topk=self.num_slots)
 
         return ArticleSet(articles=[candidate_articles.articles[int(idx)] for idx in article_indices])
 
@@ -29,7 +29,7 @@ def compute_similarity_matrix(todays_article_vectors):
     # M is (n, k), where n = # articles & k = embed. dim.
     # M M^T is (n, n) matrix of pairwise dot products
     similarity_matrix = todays_article_vectors @ todays_article_vectors.T
-    assert similarity_matrix.size == (num_values, num_values)
+    assert_tensor_size(similarity_matrix, num_values, num_values, label="sim-matrix", prefix=False)
     return similarity_matrix
 
 
@@ -37,19 +37,20 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
     # MR_i = \theta * reward_i - (1 - \theta)*max_{j \in S} sim(i, j) # S us
     # R is all candidates (not selected yet)
 
-    S = []  # final recommendation (topk index)
+    S = torch.full((topk,), -1, dtype=torch.int32)
     # first recommended item
-    S.append(rewards.argmax())
+    S[0] = rewards.argmax()
 
-    for k in range(topk - 1):
+    for k in range(1, topk):
         # find the best combo of reward and max sim to existing item
         # first, let's pare the matrix: candidates on rows, selected items on cols
-        M = similarity_matrix[:, S]
+        Sset = S[S >= 0]
+        M = similarity_matrix[:, Sset]
 
         # for each target item, we want to find the *max* simialrity to an existing.
         # we do this by taking the max of each row.
-        scores = torch.max(M, axis=1)
-        assert len(scores) == len(rewards)
+        scores, _maxes = torch.max(M, axis=1)
+        assert_tensor_size(scores, len(rewards), label="scores", prefix=False)
 
         # now, we want to compute θ*r - (1-θ)*s. let's do that *in-place* using
         # this scores vector. To start, multiply by θ-1 (-(1-θ)):
@@ -60,8 +61,8 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
 
         # now, we're looking for the *max* score in this list. we can do this
         # in two steps. step 1: clear the items we already have:
-        scores[S] = -torch.inf
+        scores[Sset] = -torch.inf
         # step 2: find the largest value
-        S.append(torch.argmax(scores).item())
+        S[k] = torch.argmax(scores)
 
-    return S
+    return S.tolist()

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -49,6 +49,7 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
         # for each target item, we want to find the *max* simialrity to an existing.
         # we do this by taking the min of each row.
         scores = torch.min(M, axis=1)
+        assert len(scores) == len(rewards)
 
         # now, we want to compute θ*r - (1-θ)*s. let's do that *in-place* using
         # this scores vector. To start, multiply by θ-1 (-(1-θ)):

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -55,8 +55,8 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
         # this scores vector. To start, multiply by θ-1 (-(1-θ)):
         scores *= theta - 1
 
-        # with this, we can theta * rewards in-place:
-        scores.add_(rewards, theta)
+        # with this, we can add theta * rewards in-place:
+        scores.add_(rewards, alpha=theta)
 
         # now, we're looking for the *max* score in this list. we can do this
         # in two steps. step 1: clear the items we already have:

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -1,6 +1,3 @@
-import numpy as np
-from tqdm import tqdm
-
 from poprox_concepts import ArticleSet, InterestProfile
 from poprox_recommender.lkpipeline import Component
 from poprox_recommender.pytorch.decorators import torch_inference
@@ -27,13 +24,10 @@ class MMRDiversifier(Component):
 
 def compute_similarity_matrix(todays_article_vectors):
     num_values = len(todays_article_vectors)
-    similarity_matrix = np.zeros((num_values, num_values))
-    for i, value1 in tqdm(enumerate(todays_article_vectors), total=num_values):
-        value1 = value1.detach().cpu()
-        for j, value2 in enumerate(todays_article_vectors):
-            if i <= j:
-                value2 = value2.detach().cpu()
-                similarity_matrix[i, j] = similarity_matrix[j, i] = np.dot(value1, value2)
+    # M is (n, k), where n = # articles & k = embed. dim.
+    # M M^T is (n, n) matrix of pairwise dot products
+    similarity_matrix = todays_article_vectors @ todays_article_vectors.T
+    assert similarity_matrix.size == (num_values, num_values)
     return similarity_matrix
 
 

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -48,7 +48,7 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
 
         # for each target item, we want to find the *max* simialrity to an existing.
         # we do this by taking the min of each row.
-        scores = torch.min(M, axis=1)
+        scores = torch.max(M, axis=1)
         assert len(scores) == len(rewards)
 
         # now, we want to compute θ*r - (1-θ)*s. let's do that *in-place* using

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -62,6 +62,6 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
         # in two steps. step 1: clear the items we already have:
         scores[S] = -torch.inf
         # step 2: find the largest value
-        S.append(torch.argmax(scores))
+        S.append(torch.argmax(scores).item())
 
     return S

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -47,7 +47,7 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
         M = similarity_matrix[:, S]
 
         # for each target item, we want to find the *max* simialrity to an existing.
-        # we do this by taking the min of each row.
+        # we do this by taking the max of each row.
         scores = torch.max(M, axis=1)
         assert len(scores) == len(rewards)
 

--- a/src/poprox_recommender/components/diversifiers/mmr.py
+++ b/src/poprox_recommender/components/diversifiers/mmr.py
@@ -37,6 +37,7 @@ def mmr_diversification(rewards, similarity_matrix, theta: float, topk: int):
     # MR_i = \theta * reward_i - (1 - \theta)*max_{j \in S} sim(i, j) # S us
     # R is all candidates (not selected yet)
 
+    # final recommendation (topk index) - initialize to invalid indexes
     S = torch.full((topk,), -1, dtype=torch.int32)
     # first recommended item
     S[0] = rewards.argmax()


### PR DESCRIPTION
This is a low-hanging fruit optimization to replace nested loops in MMR with vectorized PyTorch operations. If the embeddings remain on the GPU, then this should be doing most of MMR on the GPU as well.