### PR TITLE
Use article IDs to filter backups to reduce sampling costs

### DIFF
--- a/src/poprox_recommender/components/filters/topic.py
+++ b/src/poprox_recommender/components/filters/topic.py
@@ -1,5 +1,9 @@
+import logging
+
 from poprox_concepts import ArticleSet, InterestProfile
 from poprox_recommender.lkpipeline import Component
+
+logger = logging.getLogger(__name__)
 
 
 class TopicFilter(Component):
@@ -21,4 +25,10 @@ class TopicFilter(Component):
             if len(profile_topics.intersection(article_topics)) > 0:
                 topical_articles.append(article)
 
+        logger.debug(
+            "filter accepted %d of %d articles for user %s",
+            len(topical_articles),
+            len(candidate.articles),
+            interest_profile.profile_id,
+        )
         return ArticleSet(articles=topical_articles)

--- a/src/poprox_recommender/components/samplers/uniform.py
+++ b/src/poprox_recommender/components/samplers/uniform.py
@@ -12,18 +12,17 @@ class UniformSampler(Component):
         articles = {a.article_id: a for a in candidate.articles}
 
         if backup.articles:
-            backup_articles = {a.article_id: a for a in backup.articles if a.article_id not in articles}
+            backup_articles = [a for a in backup.articles if a.article_id not in articles]
         else:
             backup_articles = []
 
         # we want to sample article IDs for performance
 
-        sampled = random.sample(list(articles.keys()), min(self.num_slots, len(candidate.articles)))
+        sampled = random.sample(candidate.articles, min(self.num_slots, len(candidate.articles)))
 
         if len(sampled) < self.num_slots and backup_articles:
             # add backups to articles, but allow articles to override
             num_backups = min(self.num_slots - len(sampled), len(backup_articles))
-            sampled += random.sample(list(backup_articles.keys()), num_backups)
+            sampled += random.sample(backup_articles, num_backups)
 
-        all_articles = articles | backup_articles
-        return ArticleSet(articles=[all_articles[aid] for aid in sampled])
+        return ArticleSet(articles=sampled)

--- a/src/poprox_recommender/components/samplers/uniform.py
+++ b/src/poprox_recommender/components/samplers/uniform.py
@@ -9,22 +9,21 @@ class UniformSampler(Component):
         self.num_slots = num_slots
 
     def __call__(self, candidate: ArticleSet, backup: ArticleSet | None = None) -> ArticleSet:
-        backup_articles = list(
-            filter(
-                lambda article: article not in candidate.articles,
-                backup.articles if backup else [],
-            )
-        )
+        articles = {a.article_id: a for a in candidate.articles}
+
+        if backup.articles:
+            backup_articles = {a.article_id: a for a in backup.articles if a.article_id not in articles}
+        else:
+            backup_articles = []
 
         # we want to sample article IDs for performance
-        articles = {a.article_id: a for a in candidate.articles}
-        sampled = random.sample(articles.keys(), min(self.num_slots, len(candidate.articles)))
+
+        sampled = random.sample(list(articles.keys()), min(self.num_slots, len(candidate.articles)))
 
         if len(sampled) < self.num_slots and backup_articles:
-            backups = {b.article_id: b for b in backup_articles}
             # add backups to articles, but allow articles to override
-            articles = backups | articles
             num_backups = min(self.num_slots - len(sampled), len(backup_articles))
-            sampled += random.sample(backups.keys(), num_backups)
+            sampled += random.sample(list(backup_articles.keys()), num_backups)
 
-        return ArticleSet(articles=[articles[aid] for aid in sampled])
+        all_articles = articles | backup_articles
+        return ArticleSet(articles=[all_articles[aid] for aid in sampled])

--- a/src/poprox_recommender/components/samplers/uniform.py
+++ b/src/poprox_recommender/components/samplers/uniform.py
@@ -16,12 +16,9 @@ class UniformSampler(Component):
         else:
             backup_articles = []
 
-        # we want to sample article IDs for performance
-
         sampled = random.sample(candidate.articles, min(self.num_slots, len(candidate.articles)))
 
         if len(sampled) < self.num_slots and backup_articles:
-            # add backups to articles, but allow articles to override
             num_backups = min(self.num_slots - len(sampled), len(backup_articles))
             sampled += random.sample(backup_articles, num_backups)
 

--- a/src/poprox_recommender/components/samplers/uniform.py
+++ b/src/poprox_recommender/components/samplers/uniform.py
@@ -16,10 +16,15 @@ class UniformSampler(Component):
             )
         )
 
-        sampled = random.sample(candidate.articles, min(self.num_slots, len(candidate.articles)))
+        # we want to sample article IDs for performance
+        articles = {a.article_id: a for a in candidate.articles}
+        sampled = random.sample(articles.keys(), min(self.num_slots, len(candidate.articles)))
 
         if len(sampled) < self.num_slots and backup_articles:
+            backups = {b.article_id: b for b in backup_articles}
+            # add backups to articles, but allow articles to override
+            articles = backups | articles
             num_backups = min(self.num_slots - len(sampled), len(backup_articles))
-            sampled += random.sample(backup_articles, num_backups)
+            sampled += random.sample(backups.keys(), num_backups)
 
-        return ArticleSet(articles=sampled)
+        return ArticleSet(articles=[articles[aid] for aid in sampled])

--- a/src/poprox_recommender/components/samplers/uniform.py
+++ b/src/poprox_recommender/components/samplers/uniform.py
@@ -1,7 +1,10 @@
+import logging
 import random
 
 from poprox_concepts import ArticleSet
 from poprox_recommender.lkpipeline import Component
+
+logger = logging.getLogger(__name__)
 
 
 class UniformSampler(Component):
@@ -11,10 +14,14 @@ class UniformSampler(Component):
     def __call__(self, candidate: ArticleSet, backup: ArticleSet | None = None) -> ArticleSet:
         articles = {a.article_id: a for a in candidate.articles}
 
-        if backup.articles:
+        if backup and backup.articles:
             backup_articles = [a for a in backup.articles if a.article_id not in articles]
         else:
             backup_articles = []
+
+        logger.debug(
+            "sampling %d from %d articles with %d backups", self.num_slots, len(articles), len(backup_articles)
+        )
 
         sampled = random.sample(candidate.articles, min(self.num_slots, len(candidate.articles)))
 


### PR DESCRIPTION
Profiling revealed that the evaluation was spending 10% of its time checking full article objects for equality, I believe while filtering candidates out of the backups.

This PR changes the sampler use article IDs for backup filtering.