### PR TITLE
Apply topic calibration even without clicks (using onboarding topics)

### DIFF
--- a/src/poprox_recommender/topics.py
+++ b/src/poprox_recommender/topics.py
@@ -11,7 +11,7 @@ from poprox_recommender.paths import model_file_path
 NEWS_MODEL_NAME = "news-category-classifier-distilbert"
 
 
-def extract_general_topics(article: Article):
+def extract_general_topics(article: Article) -> set[str]:
     article_topics = set([mention.entity.name for mention in article.mentions])
     return article_topics.intersection(GENERAL_TOPICS)
 


### PR DESCRIPTION
This creates article scores from onboarding topic selections when there are no clicks for the model to use. In that case, the normal article scorer returns `None`, which is a signal to downstream components to fill in the gap if they need to.

Here the scores computation is very rough and just good enough to let topic calibration proceed as usual: the weights of onboarding topic selections that match article topics are summed and the resulting vector of article scores is divided by its max value to normalize the scores into the [0.0,1.0] range.

Adding this to topic calibration was the easiest place to start, but I think there's an argument to be made that this could/should be a fallback scorer in all the pipelines with their various rerankers/diversifiers. 