### PR TITLE
Rename article `title` and `content` to `headline` and `subhead`

### DIFF
--- a/conda-lock-cuda.yml
+++ b/conda-lock-cuda.yml
@@ -15,7 +15,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 07ff711fff4b49c0ca6c6c1cfc287b715ca593e4dc2fa315dd2d3e82d6687d9b
+    linux-64: 6c8a70cb28b4af58259102245eb79910bef3daae1a09066a9ac84adadc1351c1
   channels:
   - url: pytorch
     used_env_vars: []
@@ -53,6 +53,17 @@ package:
     sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
   category: main
   optional: false
+- name: _sysroot_linux-64_curr_repodata_hack
+  version: '3'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-64_curr_repodata_hack-3-h69a702a_16.conda
+  hash:
+    md5: 1c005af0c6ff22814b7c52ee448d4bea
+    sha256: 6ac30acdbfd3136ee7a1de28af4355165291627e905715611726e674499b0786
+  category: main
+  optional: false
 - name: aiobotocore
   version: 2.13.2
   manager: conda
@@ -70,19 +81,19 @@ package:
   category: dev
   optional: true
 - name: aiohappyeyeballs
-  version: 2.3.5
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d904abda207d2dba054fd820d34bbaee
-    sha256: 37ac19a57d429670dcd2c716232e6f842b7f357cecd0977b1d4fd30b8446a30a
+    md5: 0482cd2217e27b3ce47676d570ac3d45
+    sha256: 5d318408a7ad62c1dbff90060795287f1fd3bdbec13b733bc82f1fadb2c9244e
   category: main
   optional: false
 - name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -96,10 +107,10 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.3-py311h61187de_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.5-py311h61187de_0.conda
   hash:
-    md5: b3b58253d1691fafecc512f7a995e12b
-    sha256: 18075c677baa159d97d879ab5c678707c62954ed3744114d32b4c67610141ee7
+    md5: 4b255c4b54de2a41bc8dc63ee78098e4
+    sha256: 64a9a4eb76dc4dcf0d5d77822f190124eb7084eb2123ad8ada6d3e61e1d6765c
   category: main
   optional: false
 - name: aiohttp-retry
@@ -350,15 +361,15 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-hff137af_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h15d0e8c_6.conda
   hash:
-    md5: 1f05e3e75005a8e7cce98322e19cde41
-    sha256: 7e927e0da639cb9a873f7cab0b42102488d3a1a74fd8d301653d0a3044a8141a
+    md5: e0d292ba383ac09598c664186c0144cd
+    sha256: 0680ca18238e17d319f87bb8390d116292592c6f5534c66404542665d6149fae
   category: main
   optional: false
 - name: aws-c-cal
@@ -367,57 +378,57 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h7970872_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h8dac057_2.conda
   hash:
-    md5: 902105f82c52abed505e1e1917c1c23b
-    sha256: 8a5a0f661e1a4cc3bf0bf2ba7cd980c5a932c12db70a634de6aab8683e6c07e0
+    md5: 577509458a061ddc9b089602ac6e1e98
+    sha256: bfd4f73855e926e6c7c9db700a17ef3ddb0e848b85edd04d766d50a008835407
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.25-h4bc722e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.27-h4bc722e_0.conda
   hash:
-    md5: 8ae3ebc6f412a923466ae673a3b3953f
-    sha256: af6dbf129de978b8960b1d130770878e5052d992232cbdd4ddf99d2ea705f931
+    md5: 817119e8a21a45d325f65d0d54710052
+    sha256: b1725a5ec43bcf606d6bdb248312aa51386b30339dd83a1f16edf620fe03d941
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.18
+  version: 0.2.19
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-hc649ecc_8.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    libgcc-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-haa50ccc_0.conda
   hash:
-    md5: b72e4162acb0cf997185fc1da432a63e
-    sha256: ef8666bd07183f32219e7de3faf26c16d6acdd42769be0bb15b3668d0c89deba
+    md5: 00c38c49d0befb632f686cf67ee8c9f5
+    sha256: d7cca92ff47e5de9e53ce6ea90186d578883b35d4c665b166ada2754d7786d05
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.2
+  version: 0.4.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h04a40c0_20.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h570d160_0.conda
   hash:
-    md5: 3c1a3aa8f0dd19e1a917b39620fda32c
-    sha256: 7b0611ec00f0433db9163f1050cc0289abe380f43a499a7b09aed5976e94afa0
+    md5: 1c121949295cac86798be8f369768d7c
+    sha256: 608225f14f0befcc351860c2961ae9734f7bf097b3ffb88aea69727c65843689
   category: main
   optional: false
 - name: aws-c-http
@@ -427,14 +438,14 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-compression: '>=0.2.19,<0.2.20.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-he2d3600_3.conda
+    libgcc-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-h1c59cda_5.conda
   hash:
-    md5: 3beadf1544937956b66eef343734d71e
-    sha256: 7e8452ce2e51bd344003e77ffee717dfe71e96031fc4e7d4891b7f8fc26dec45
+    md5: 0fc88e5bb5f095bdf4129282411c50c9
+    sha256: c498aa33b2066f04afc61f504dde43bbbcb3322f31ecb6ddca73602739614ab1
   category: main
   optional: false
 - name: aws-c-io
@@ -444,13 +455,13 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.5.0,<1.5.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h7d46f39_3.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    libgcc-ng: '>=13'
+    s2n: '>=1.5.1,<1.5.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-hf5b9b93_6.conda
   hash:
-    md5: cf970c7fde2c61b82759f3d3c141b0ec
-    sha256: d0c7c5105a7fd48ad6b5419f20602232ec42fd057b99d005dfdd78ab231bc102
+    md5: 8fd43c2719355d795f5c7cef11f08ec0
+    sha256: 3640f15a08bc22cf0b7321d177535517f16c360f961306d291e006296f111d7d
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -459,14 +470,14 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-h674cf7e_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hc14a930_17.conda
   hash:
-    md5: a96a7cd318b665b8784cbe7e67916f66
-    sha256: 759a15d367ef69f24448ace52843c4999e1795710c4393ea86d7768b1934db93
+    md5: f0e3f95a9f545d5975e8573f80cdb5fa
+    sha256: bc176d82875700e0ee51ddaef188fd6ca2a44b2efc69e0cb434460319216049b
   category: main
   optional: false
 - name: aws-c-s3
@@ -477,16 +488,16 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h28a8003_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h558cea2_8.conda
   hash:
-    md5: 5d1ea2ae5ca0de171c81c77e0e7e247c
-    sha256: 0ddb4ccd1adf6f49ffbfd365acb7687a54ef3bba3437c04bf04390a64bdee51f
+    md5: af03e7b03e929396fb80ffac1a676c89
+    sha256: 8206b63d89e1cf08a0e4bc4852cb15080bc9754df48acbc5e59fbe2ec50b3da8
   category: main
   optional: false
 - name: aws-c-sdkutils
@@ -495,12 +506,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-hc649ecc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h038f3f9_2.conda
   hash:
-    md5: f1d4b80dfc062bc55cecc20148eb925a
-    sha256: dc1eaf29c3a4092ae653b3ce80d5c8dfdc73a20d70c62c25f6a0faff059cd3a1
+    md5: 6861cab6cddb5d713cb3db95c838d30f
+    sha256: 5612c9cad56662db50a1bcc2d8dca1fe273f7abad6f670fef328e4044beabc75
   category: main
   optional: false
 - name: aws-checksums
@@ -509,35 +520,35 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-hc649ecc_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h038f3f9_10.conda
   hash:
-    md5: 178504fd14f8486ce3153fa16371ceef
-    sha256: 63ccb2a0b471dac505e95d6a623b041e00e8a2a734fd33fd101f7d3a0018becf
+    md5: 4bf9c8fcf2bb6793c55e5c5758b9b011
+    sha256: a94547ff766fb420c368bb8d4fd1c8d99b13088d176c43ad7bb7458ef47e45bc
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.27.5
+  version: 0.27.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
     aws-c-s3: '>=0.6.4,<0.6.5.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-heec6497_6.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.6-h1966bd9_0.conda
   hash:
-    md5: d99cb216fba6ec1576db0bb5901b956f
-    sha256: 17ebb0d468354e85986f2e8137c43e9714353238fe039086bda070746455cfd2
+    md5: 30b59fa809914489974fe275a0fb7c7e
+    sha256: f45a23fc50e9df01f3235672d805b9175ca05d8966a32351c3fb98970b94d2d1
   category: main
   optional: false
 - name: aws-sdk-cpp
@@ -546,19 +557,19 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     libcurl: '>=8.9.1,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-he20dfa5_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-hf9693f6_5.conda
   hash:
-    md5: 25a12549e0aeeaa2718035c3e54ff520
-    sha256: a43661e14ad9d51c0c9330effbc86d9960096484181402dd43bd9617c803f67b
+    md5: 18a4bf7e8a65006b26ca53700fcf2362
+    sha256: 5267e5a24249d89368226caa3a9b64d53e2c8e481650c57755cad90a9d0578bf
   category: main
   optional: false
 - name: azure-core-cpp
@@ -1310,7 +1321,7 @@ package:
   category: main
   optional: false
 - name: datasets
-  version: 2.20.0
+  version: 2.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1330,10 +1341,10 @@ package:
     pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.21.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7e2c046cd09a2498bac484413771a9df
-    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
+    md5: 1b2d7c700663bfec50f6c553e5449da2
+    sha256: b3fb3f2731eb4c5ec49fe07ed3ae4964d5775984d7b7a73c7ee807b11e4e85b5
   category: main
   optional: false
 - name: dbus
@@ -1490,7 +1501,7 @@ package:
   category: dev
   optional: true
 - name: dvc
-  version: 3.53.2
+  version: 3.54.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1501,7 +1512,7 @@ package:
     distro: '>=1.3'
     dpath: <3,>=2.1.0
     dulwich: ''
-    dvc-data: '>=3.15,<3.16'
+    dvc-data: '>=3.16.2,<3.17'
     dvc-http: '>=2.29.0'
     dvc-objects: ''
     dvc-render: '>=1.0.1,<2'
@@ -1537,14 +1548,14 @@ package:
     tqdm: <5,>=4.63.1
     voluptuous: '>=0.11.7'
     zc.lockfile: '>=1.2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.53.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.54.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 45b90099c4216812be21151bcab2b0dd
-    sha256: ee6327d592c52cb8a3bdaf5d63788fd2f1c43e6fcc15c8c7978b797c34cc4fb5
+    md5: b58f720d5a7d57b286a154e08528f1da
+    sha256: 8ecb06cfe9b6f6ec67b56003347c2b0d0fc13a498ca3d78af3d133ebdb8765b8
   category: dev
   optional: true
 - name: dvc-data
-  version: 3.15.2
+  version: 3.16.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -1554,14 +1565,15 @@ package:
     dvc-objects: '>=4.0.1,<6'
     fsspec: '>=2024.2.0'
     funcy: '>=1.14'
+    orjson: '>=3,<4'
     pygtrie: '>=2.3.2'
     python: '>=3.9'
     sqltrie: '>=0.11.0,<1'
     tqdm: '>=4.63.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.16.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a42b220684a1bcbf378dfe05de0ea2d
-    sha256: 0d59a6e54b00d3205e552bbaabd5b0ef7a15275c70a761e6482fcb9e009ae706
+    md5: f8764d1c5e647ec2af7f91fee9466909
+    sha256: 035ae81cfb370e14b298277ee496fa7284d3e4ddb20bf7377b33f93aad71453f
   category: dev
   optional: true
 - name: dvc-http
@@ -2330,7 +2342,7 @@ package:
   category: dev
   optional: true
 - name: huggingface_hub
-  version: 0.24.5
+  version: 0.24.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -2342,10 +2354,10 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c7bf55cfeefe35d28a15685c466ff61e
-    sha256: 6c163b98df32c151638ec2586f917a47e87d487d599165e4d49f260018436c6e
+    md5: 129d512e741eccfd55c51335b45647bb
+    sha256: 46bdcaa7f3058838615ef87580beb95f19a7f6b3fc584a30d277816e19011426
   category: main
   optional: false
 - name: hydra-core
@@ -2429,41 +2441,41 @@ package:
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.4.0-pyha770c72_0.conda
   hash:
-    md5: c261d14fc7f49cdd403868998a18c318
-    sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
+    md5: 6e3dbc422d3749ad72659243d6ac8b2b
+    sha256: 02c95f6f62675012e0b2ab945eba6fc14fa6a693c17bced3554db7b62d586f0c
   category: dev
   optional: true
 - name: importlib_metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=8.2.0,<8.2.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.4.0,<8.4.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.4.0-hd8ed1ab_0.conda
   hash:
-    md5: 0fd030dce707a6654472cf7619b0b01b
-    sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
+    md5: 01b7411c765c3d863dcc920207f258bd
+    sha256: c9c782fdf59fb169220b69ea0bbefc3fdc7f58c9fdbdf2d6ff734aa033647b59
   category: dev
   optional: true
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.4.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: 99aa3edd3f452d61c305a30e78140513
+    sha256: 13e277624eaef453af3ff4d925ba1169376baa7008eabd8eaae7c5772bec9fc2
   category: dev
   optional: true
 - name: iniconfig
@@ -2923,6 +2935,18 @@ package:
     sha256: e0e904bcc18a3b31dc79b05f98a3fd46c9e52b27e7942856f767f0c0b815ae15
   category: dev
   optional: true
+- name: kernel-headers_linux-64
+  version: 3.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _sysroot_linux-64_curr_repodata_hack: 3.*
+  url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-h4a8ded7_16.conda
+  hash:
+    md5: ff7f38675b226cfb855aebfc32a13e31
+    sha256: a55044e0f61058a5f6bab5e1dd7f15a1fa7a08ec41501dbfca5ab0fc50b9c0c1
+  category: main
+  optional: false
 - name: keyring
   version: 25.3.0
   manager: conda
@@ -3052,7 +3076,7 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     aws-sdk-cpp: '>=1.11.379,<1.11.380.0a0'
     azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
     azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
@@ -3064,22 +3088,22 @@ package:
     libabseil: '>=20240116.2,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libgoogle-cloud: '>=2.28.0,<2.29.0a0'
     libgoogle-cloud-storage: '>=2.28.0,<2.29.0a0'
     libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
+    libstdcxx-ng: '>=13'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h03aeac6_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h9d17f36_9_cpu.conda
   hash:
-    md5: 25225d90d4fb125c5fbb6f87cc1aa309
-    sha256: 745e9f84761da075f0bbe0f0279f0b74aeb1c29811e3eaa9d46f8de1ad897887
+    md5: bfae79329f50d5bd960e1ac289625096
+    sha256: 0f0123e7e7eddfa8cf56b71534570d43304d730e4891a8c26c5754cb8d0b4e5f
   category: main
   optional: false
 - name: libarrow-acero
@@ -3089,12 +3113,12 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libarrow: 17.0.0
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_7_cpu.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-h5888daf_9_cpu.conda
   hash:
-    md5: 64ba31c035986db4e46f98410607498e
-    sha256: d0f5d0ae8266d83de7b1398c061d5b499c6899742029d80a262f34d3b613012d
+    md5: cace9fe91c532c67ff828937a633fb1c
+    sha256: 52e550e5bad1e05e0d286ace999b27f0781a6913461914f069aa7f5214d9ec42
   category: main
   optional: false
 - name: libarrow-dataset
@@ -3105,13 +3129,13 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libarrow: 17.0.0
     libarrow-acero: 17.0.0
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libparquet: 17.0.0
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_7_cpu.conda
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-h5888daf_9_cpu.conda
   hash:
-    md5: ad26d57360f2019840af562ddf3cb7d2
-    sha256: 8ff60afa166498ec5372e851c80a7616c3298c1ac4bcfb386767c62c0acf6a35
+    md5: 4df21168065a9e21372a442783dfd547
+    sha256: 8767bf188e327ee316677dbd25fd23412ab892c96088c9cfe284a59bf4e616db
   category: main
   optional: false
 - name: libarrow-substrait
@@ -3124,13 +3148,13 @@ package:
     libarrow: 17.0.0
     libarrow-acero: 17.0.0
     libarrow-dataset: 17.0.0
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_7_cpu.conda
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hf54134d_9_cpu.conda
   hash:
-    md5: a0207293ee147d04b46b44d60266d964
-    sha256: 88177f0e86b87579e1fbb3f7c8bc9a128d364d342efb971f65df2f514ddb96f3
+    md5: 239401053cfbf93d24795b12dec89c56
+    sha256: c1441e1f6b16078e8451cd82934a84ec0e97b9f5eb54d2105d4a96f5d1991746
   category: main
   optional: false
 - name: libblas
@@ -3521,40 +3545,40 @@ package:
   category: main
   optional: false
 - name: libmagma
-  version: 2.7.2
+  version: 2.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
+    __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
     cudatoolkit: '>=11.8,<12'
     libblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.7.2-h09b5827_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.8.0-hfdb99dd_0.conda
   hash:
-    md5: f6de79234f35c2fcc2e49dc66436601d
-    sha256: 4dd54775f2cfa9c09f4b4cc58a6db00bad50b30e65adf62ffe4213a30d962766
+    md5: 842933649aae204d7d738ab02936856f
+    sha256: 0d92bbf2d1f335b1610169b84ea132bb50d7d4c8f0c7c83eeb84e689b2faa008
   category: main
   optional: false
 - name: libmagma_sparse
-  version: 2.7.2
+  version: 2.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17'
+    __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
     cudatoolkit: '>=11.8,<12'
     libblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
     liblapack: '>=3.9.0,<4.0a0'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
+    libmagma: '>=2.8.0,<2.8.1.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma_sparse-2.7.2-h09b5827_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmagma_sparse-2.8.0-h9ddd185_0.conda
   hash:
-    md5: 53157a5777c664896654d8dbc9fd6bf9
-    sha256: ee4a2367446763e6a4ef6d2fa5aea06adfd4ff44853f7390a02b0da77c6f129c
+    md5: f4eb3cfeaf9d91e72d5b2b8706bf059f
+    sha256: cd3b1e6dfde6b609e0fb9be73bf6fd55829528c3454ec31caf3f62e90ebff30b
   category: main
   optional: false
 - name: libnghttp2
@@ -3593,14 +3617,14 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libarrow: 17.0.0
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     libthrift: '>=0.20.0,<0.20.1.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-h39682fd_9_cpu.conda
   hash:
-    md5: 7448f406b12fc479eb5a7dbf485c0428
-    sha256: 93ccb279a9a60fc1c713bbf5eb224eb1eeedadac3f6114a7c00a3880e2a4b172
+    md5: 0efe4b18e72f519298f57ff75a9adf07
+    sha256: 441fc3d681cb5945f724d67a9b60f93331faf65ac9754c44769e6fe6caacbb79
   category: main
   optional: false
 - name: libpng
@@ -3646,7 +3670,7 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.58.2
+  version: 2.58.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -3660,10 +3684,10 @@ package:
     libpng: '>=1.6.43,<1.7.0a0'
     libxml2: '>=2.12.7,<3.0a0'
     pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.2-h9564881_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.3-h9564881_0.conda
   hash:
-    md5: c6a47e6f551890e82e92e4c1b84be353
-    sha256: 74221fe0218f537dfd1db9c451e81d0fed7df6b3128a46e6b0dc493db02f332d
+    md5: a7045ed6fb8b68ef7be002ce615e3bf6
+    sha256: 45f98c031891178ff2d83adf96d05610e842a0df62996ffc31fdcb93ec529020
   category: dev
   optional: true
 - name: libsodium
@@ -3755,7 +3779,7 @@ package:
   category: dev
   optional: true
 - name: libtorch
-  version: 2.3.0
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3766,18 +3790,19 @@ package:
     libabseil: '>=20240116.2,<20240117.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: '>=2.7.2,<2.7.3.0a0'
+    libmagma: '>=2.8.0,<2.8.1.0a0'
+    libmagma_sparse: '>=2.8.0,<2.8.1.0a0'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
     libuv: '>=1.48.0,<2.0a0'
     mkl: '>=2023.2.0,<2024.0a0'
-    nccl: '>=2.21.5.1,<3.0a0'
-    sleef: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.3.0-cuda118_h8db9d67_301.conda
+    nccl: '>=2.22.3.1,<3.0a0'
+    sleef: '>=3.6.1,<4.0a0'
+    sysroot_linux-64: '>=2.17'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.4.0-cuda118_h8db9d67_300.conda
   hash:
-    md5: 0f86d22d72104b70cbe8403cd3eeab16
-    sha256: 6a273012f5aaa0128c8a37b7deed40e67313f62dd9c3e7d4d76eca3f79b4ea10
+    md5: 628e6cb929af957ba309643ed554c724
+    sha256: ea4d1d826a3c037325f66f6897117ed801e42eeced1cae3cd6426781db1e9be7
   category: main
   optional: false
 - name: libutf8proc
@@ -3833,14 +3858,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=13'
     pthread-stubs: ''
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hb9d3cd8_1.conda
   hash:
-    md5: 151cba22b85a989c2d6ef9633ffee1e4
-    sha256: 7180375f37fd264bb50672a63da94536d4abd81ccec059e932728ae056324b3a
+    md5: 3601598f0db0470af28985e3e7ad0158
+    sha256: 33aa5fc997468b07ab3020b142eacc5479e4e2c2169f467b20ab220f33dd08de
   category: dev
   optional: true
 - name: libxcrypt
@@ -4226,19 +4252,19 @@ package:
   category: main
   optional: false
 - name: nltk
-  version: 3.8.1
+  version: 3.9.1
   manager: conda
   platform: linux-64
   dependencies:
     click: ''
     joblib: ''
-    python: '>=3.7'
+    python: '>=3.8'
     regex: '>=2021.8.3'
     tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 518c769ca4273480a99be6e559a26192
-    sha256: ac5403c253608cb76e7f14e51902f02516cbc18edb9eebf62f1bcd0648d0ac6b
+    md5: 7e580f0694e487c3890d3ce67d5df98c
+    sha256: c08385f927550125aebe7880cafc7071f4e1c3aeebf72920e2f9ccb63e486a33
   category: main
   optional: false
 - name: nodeenv
@@ -4322,20 +4348,21 @@ package:
   category: main
   optional: false
 - name: numcodecs
-  version: 0.12.1
+  version: 0.13.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     msgpack-python: ''
     numpy: '>=1.7'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py311h4332511_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.13.0-py311h044e617_0.conda
   hash:
-    md5: 887aa6096851eab5c34fe95ed1641591
-    sha256: 40683eac07dc08ff26d64434cbd594b124791d6dd80c7e3c84664382ed6a1095
+    md5: 9d783b29b6fc53e4d9a94f5befdfd34b
+    sha256: ebd6ea0ad41f7a6d6fca5cf9091317729897b77a5f241106fa0b4904ca84b3c4
   category: main
   optional: false
 - name: numpy
@@ -4378,30 +4405,31 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
+    libgcc-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-hb9d3cd8_3.conda
   hash:
-    md5: e1b454497f9f7c1147fdde4b53f1b512
-    sha256: b294b3cc706ad1048cdb514f0db3da9f37ae3fcc0c53a7104083dd0918adb200
+    md5: 6c566a46baae794daf34775d41eb180a
+    sha256: 9e27441b273a7cf9071f6e88ba9ad565d926d8083b154c64a74b99fba167b137
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
   hash:
-    md5: 3bf65f0d8e7322a1cfe8b670fa35ec81
-    sha256: d340c67b23fb0e1ef7e13574dd4a428f360bfce93b2a588b3b63625926b038d6
+    md5: 1e6c10f7d749a490612404efeb179eb8
+    sha256: 8a126e0be7f87c499f0a9b5229efa4321e60fc4ae46abdec9b13240631cb1746
   category: main
   optional: false
 - name: orjson
@@ -4964,20 +4992,20 @@ package:
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.376
+  version: 1.1.377
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     nodeenv: '>=1.6.0'
     nodejs: ''
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.376-py311h61187de_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.377-py311h9ecbd09_0.conda
   hash:
-    md5: 664f0dce002a6d5962abdd645f5e3330
-    sha256: cce588073b65758ae66ec771b07d1a049b1eb6e9f69bc93c3c760534ad131425
+    md5: 793a0fe37ce71a174f9be8910660eca1
+    sha256: e112a737d76b6f2fe368d8f7d03bf7ee6417ac1b411c952543a23bd43b0cedbf
   category: dev
   optional: true
 - name: pysocks
@@ -5120,18 +5148,19 @@ package:
   category: main
   optional: false
 - name: python-xxhash
-  version: 3.4.1
+  version: 3.5.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     xxhash: '>=0.8.2,<0.8.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.4.1-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.5.0-py311h61187de_0.conda
   hash:
-    md5: 60b5332b3989fda37884b92c7afd6a91
-    sha256: 91293b2ca0f36ac580f2be4b9c0858cdaec52eff95473841231dcd044acd2e12
+    md5: 44bac99d0125c748894b9ffb6ce97811
+    sha256: 55007bbd768e7e4556f3bbdf912079607b1899b3f7d10ae2cfa739b18b35c91c
   category: main
   optional: false
 - name: python_abi
@@ -5139,14 +5168,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   hash:
-    md5: d786502c97404c94d7d58d258a445a65
-    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+    md5: 139a8d40c8a2f430df31048949e450de
+    sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
   category: main
   optional: false
 - name: pytorch
-  version: 2.3.0
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5161,37 +5190,38 @@ package:
     libabseil: '>=20240116.2,<20240117.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
-    libmagma: '>=2.7.2,<2.7.3.0a0'
-    libmagma_sparse: '>=2.7.2,<2.7.3.0a0'
+    libmagma: '>=2.8.0,<2.8.1.0a0'
+    libmagma_sparse: '>=2.8.0,<2.8.1.0a0'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-    libtorch: 2.3.0.*
+    libtorch: 2.4.0.*
     libuv: '>=1.48.0,<2.0a0'
     mkl: '>=2023.2.0,<2024.0a0'
-    nccl: '>=2.21.5.1,<3.0a0'
+    nccl: '>=2.22.3.1,<3.0a0'
     networkx: ''
     numpy: '>=1.19,<3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-    sleef: '>=3.5.1,<4.0a0'
-    sympy: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.3.0-cuda118_py311h4ee7bbc_301.conda
+    sleef: '>=3.6.1,<4.0a0'
+    sympy: '>=1.13.1'
+    sysroot_linux-64: '>=2.17'
+    typing_extensions: '>=4.8.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.4.0-cuda118_py311h4ee7bbc_300.conda
   hash:
-    md5: 2526bbf00844d4d5aba0a1b9209fdaaa
-    sha256: c11e58cce24552d3309c16a2d708f63e3283f2c1e00d635c729c120826d2f637
+    md5: baf6ca474e033a8869c997227c2cc18a
+    sha256: f623d1a785f8dff1b5b7798f27d83143ef227f5959e17a515f102d4faa26e578
   category: main
   optional: false
 - name: pytorch-gpu
-  version: 2.3.0
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    pytorch: 2.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-gpu-2.3.0-cuda118py311h7c9cd31_301.conda
+    pytorch: 2.4.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytorch-gpu-2.4.0-cuda118py311h9433a6d_300.conda
   hash:
-    md5: e4be5ab2d7e0c9fbe27f8745c40b389d
-    sha256: ee1bbe3dd4d9703788df55dea4edb4bb08d1158fc6282e5b6a09b5ccad7f051c
+    md5: ee50018c08f300d7a0595da4aa6d26fc
+    sha256: 8b05466a599f8761a2f816f65d6e17340805f609671919b4f796521bf277fead
   category: main
   optional: false
 - name: pytz
@@ -5236,21 +5266,21 @@ package:
   category: main
   optional: false
 - name: pyzmq
-  version: 26.1.0
+  version: 26.2.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
+    libstdcxx-ng: '>=13'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.0-py311h759c1eb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_0.conda
   hash:
-    md5: cb593185b7ad0343158081c2da456bfc
-    sha256: 2f4f4a52ed4453979fb1f6b46d074decda8c8e555c9d8cc5aae73a8fdec63a49
+    md5: 536c998639c24ff56b79e86f9e422272
+    sha256: c2ac0bf749bef13439ffb56f198800e971f55bfc65e44107c39e9320154e06c5
   category: dev
   optional: true
 - name: re2
@@ -5408,33 +5438,33 @@ package:
   category: dev
   optional: true
 - name: ruff
-  version: 0.5.7
+  version: 0.6.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py311hce3a109_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.2-py311ha8c6e60_0.conda
   hash:
-    md5: 55c78cc0ce5f309fa245ff06313dc162
-    sha256: f427970399970c17809dd79508861cca81b461b011d9943045e993fc2b768d07
+    md5: 7a63ee5319642e0851d219c91ae8cd2e
+    sha256: 6d0428a6b5b9a114a32bc3af90be347986bd046efd11df7b9e12c709cb56ff5b
   category: dev
   optional: true
 - name: s2n
-  version: 1.5.0
+  version: 1.5.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.0-h3400bea_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.1-h3400bea_0.conda
   hash:
-    md5: 5f17883266c5312a1fc73583f28ebae5
-    sha256: 594878a49b1c4d657795f80ffbe87f15a16cd2162f28383a5b794d301d6cbc65
+    md5: bf136eb7f8e15fcf8915c1a04b0aec6f
+    sha256: 2717b0fa534aee9aca152ae980731f3d201542d12c19403563aaa07194021041
   category: main
   optional: false
 - name: s3fs
@@ -5481,24 +5511,25 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.14.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    libgfortran5: '>=13.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.19,<3'
+    libstdcxx-ng: '>=13'
+    numpy: '>=1.23.5'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py311h517d4fd_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he1f765f_0.conda
   hash:
-    md5: 481fd009b2d863f526f60ca19cb7880b
-    sha256: 55bb5502a4795b5b271bd3879846665ad9ac7ffeeea418ba6334accd8d5c71f4
+    md5: eb7e2a849cd47483d7e9eeb728c7a8c5
+    sha256: 36fd14d01a746bad1f9bc56045aa4fcfcdfe7b064a6d0c5a415dcdc8c0056983
   category: main
   optional: false
 - name: scmrepo
@@ -5579,15 +5610,15 @@ package:
   category: dev
   optional: true
 - name: setuptools
-  version: 72.1.0
+  version: 72.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e06d4c26df4f958a8d38696f2c344d15
-    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
+    md5: 1462aa8b243aad09ef5d0841c745eb89
+    sha256: 0252f6570de8ff29d489958fc7826677a518061b1aa5e1828a427eec8a7928a4
   category: main
   optional: false
 - name: shellingham
@@ -5645,11 +5676,12 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.6.1-h3400bea_1.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.6.1-h1b44611_2.conda
   hash:
-    md5: ac00525f47c9fd0e0456a64caef525a6
-    sha256: 4d841e582fef207a7323351ae267e36870b2dd0aa59d01b482f9ba342af77325
+    md5: b5ffc53a2eb33075b38f3a99f52a4aef
+    sha256: c5f0fe5512ecab151f8c2d2add3c738a932a032a158fcc9af4c656ffc5b46222
   category: main
   optional: false
 - name: smart-open
@@ -5769,6 +5801,20 @@ package:
   hash:
     md5: 7327125b427c98b81564f164c4a75d4c
     sha256: ef2e841c53aff71fcbf5922883543374040a9799d064d152516b30ff6694e022
+  category: main
+  optional: false
+- name: sysroot_linux-64
+  version: '2.17'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _sysroot_linux-64_curr_repodata_hack: 3.*
+    kernel-headers_linux-64: 3.10.0
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h4a8ded7_16.conda
+  hash:
+    md5: 223fe8a3ff6d5e78484a9d58eb34d055
+    sha256: b892b0b9c6dc8efe8b9b5442597d1ab8d65c0dc7e4e5a80f822cbdf0a639bd77
   category: main
   optional: false
 - name: tabulate
@@ -5944,7 +5990,7 @@ package:
   category: dev
   optional: true
 - name: transformers
-  version: 4.44.0
+  version: 4.44.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -5960,10 +6006,10 @@ package:
     safetensors: '>=0.4.1'
     tokenizers: '>=0.19,<0.20'
     tqdm: '>=4.27'
-  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 4785ae8c9ae74b8745d17e8c05a04470
-    sha256: 2e7d99fd408ede238fd6b71dc6c870fd6497a7d96f8b8abead75cee733f2fda6
+    md5: 00d239b9219b2453736c8b1d816d793a
+    sha256: ff42271f3650525a8c7250618bcf763dd800088eed300baeb0e15c9856131f2a
   category: main
   optional: false
 - name: trove-classifiers
@@ -5979,56 +6025,56 @@ package:
   category: dev
   optional: true
 - name: typer
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    typer-slim-standard: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: f905d31da5631dfb35e0895a7d8446f8
+    sha256: 0662dabe0c77a7ab86db8a3b2dc6af8e0efa542da48423718c9119fe8acac1ba
   category: dev
   optional: true
 - name: typer-slim
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0.0'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: c68f47e7b02694f3d0f8eea00b5d9a17
+    sha256: c3042feb1f70b008759a09a7a010e617294dcf43cb111c13ec48546ed3e92b74
   category: dev
   optional: true
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: linux-64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.4-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 7ad257f55c47dde09e8cce723de7ba23
+    sha256: 14d484828bfb1f080f0fff92205c495f18cfbd8fd23af89cf74989b7ba8d9ad0
   category: dev
   optional: true
 - name: types-python-dateutil
-  version: 2.9.0.20240316
+  version: 2.9.0.20240821
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240821-pyhd8ed1ab_0.conda
   hash:
-    md5: 7831efa91d57475373ee52fb92e8d137
-    sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+    md5: a0637bb6a2428c10448807b9d87f082c
+    sha256: 26b5939438e31ffc9ea5c56aaea5799804186887bd0d8d639d8fad1898f07bdd
   category: dev
   optional: true
 - name: typing-extensions
@@ -6134,17 +6180,17 @@ package:
   category: dev
   optional: true
 - name: uv
-  version: 0.2.36
+  version: 0.3.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.36-he0f44a0_0.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.3.2-h0f3a69f_0.conda
   hash:
-    md5: fa2c54710e6cafa0e337c6b58a198d58
-    sha256: 075cbc45c237695703dc1217738d9e67f2931b6327c198c22e95c42b687b8736
+    md5: 9ad5fe4b2f7a684ba8d244f0a86c2d13
+    sha256: d0f0c59da38d3966040277305da8a50ffb71872a1bbca7236dd506bc8dce365b
   category: dev
   optional: true
 - name: vine
@@ -6179,11 +6225,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 0993e524b9b6afdd5d963f7bbb7df29a
-    sha256: 55654fa3014552ed98cdac00642d7059078a8673e5b3f220914b5be89aafeb24
+    md5: 431b457267ff0efd4242f66b32f2fe99
+    sha256: 00433a475e17af57a17f7ae71297e5ee407d927f125a4c1c8fef59e2f10f5102
   category: dev
   optional: true
 - name: wcwidth
@@ -6544,13 +6590,13 @@ package:
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   hash:
-    sha256: ef167d47d2e686e95ccb3f599ef685ab09181867
+    sha256: f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   optional: false
 - name: progress-api
   version: 0.1.0a9

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -15,9 +15,9 @@
 version: 1
 metadata:
   content_hash:
-    win-64: 1220098b054364f2074ae08fade476706ee948541f8e8022b9c7be6b16c6485f
-    linux-64: fff711e7bb0c8bfb65b52b85bd16996c6d05f773ecaf4aa0642bb959fa913068
-    osx-arm64: 4327d7107f714cfd665594ebc8f60424583a44904c64585c95e04438937de447
+    win-64: 0f7278d0d7e738a121fa60b4383fff16c7ce1d7416fc875b615b93f8daf45473
+    linux-64: cd4aa92c4b59224edd14409bd4bd877c49741fc1f734bdca22d79977b92b12f2
+    osx-arm64: e7346ff883b00c76a000a04d86687283bad10d0134e353e779ed34eaef755d99
   channels:
   - url: pytorch
     used_env_vars: []
@@ -78,11 +78,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    botocore: '>=1.34.70,<1.34.132'
   url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.2-pyhd8ed1ab_0.conda
   hash:
     md5: c188c514ef97f345144d7840128c0a1d
@@ -94,11 +94,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    aiohttp: '>=3.9.2,<4.0.0'
+    aioitertools: '>=0.5.1,<1.0.0'
+    botocore: '>=1.34.70,<1.34.132'
     python: '>=3.8'
     wrapt: '>=1.10.10,<2.0.0'
-    aioitertools: '>=0.5.1,<1.0.0'
-    aiohttp: '>=3.9.2,<4.0.0'
-    botocore: '>=1.34.70,<1.34.132'
   url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-2.13.2-pyhd8ed1ab_0.conda
   hash:
     md5: c188c514ef97f345144d7840128c0a1d
@@ -106,43 +106,43 @@ package:
   category: dev
   optional: true
 - name: aiohappyeyeballs
-  version: 2.3.5
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d904abda207d2dba054fd820d34bbaee
-    sha256: 37ac19a57d429670dcd2c716232e6f842b7f357cecd0977b1d4fd30b8446a30a
+    md5: 0482cd2217e27b3ce47676d570ac3d45
+    sha256: 5d318408a7ad62c1dbff90060795287f1fd3bdbec13b733bc82f1fadb2c9244e
   category: main
   optional: false
 - name: aiohappyeyeballs
-  version: 2.3.5
+  version: 2.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d904abda207d2dba054fd820d34bbaee
-    sha256: 37ac19a57d429670dcd2c716232e6f842b7f357cecd0977b1d4fd30b8446a30a
+    md5: 0482cd2217e27b3ce47676d570ac3d45
+    sha256: 5d318408a7ad62c1dbff90060795287f1fd3bdbec13b733bc82f1fadb2c9244e
   category: main
   optional: false
 - name: aiohappyeyeballs
-  version: 2.3.5
+  version: 2.4.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.3.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d904abda207d2dba054fd820d34bbaee
-    sha256: 37ac19a57d429670dcd2c716232e6f842b7f357cecd0977b1d4fd30b8446a30a
+    md5: 0482cd2217e27b3ce47676d570ac3d45
+    sha256: 5d318408a7ad62c1dbff90060795287f1fd3bdbec13b733bc82f1fadb2c9244e
   category: main
   optional: false
 - name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -156,14 +156,14 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.3-py311h61187de_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.5-py311h61187de_0.conda
   hash:
-    md5: b3b58253d1691fafecc512f7a995e12b
-    sha256: 18075c677baa159d97d879ab5c678707c62954ed3744114d32b4c67610141ee7
+    md5: 4b255c4b54de2a41bc8dc63ee78098e4
+    sha256: 64a9a4eb76dc4dcf0d5d77822f190124eb7084eb2123ad8ada6d3e61e1d6765c
   category: main
   optional: false
 - name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -176,14 +176,14 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.3-py311hd3f4193_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.5-py311hd3f4193_0.conda
   hash:
-    md5: 930081210cd0b919e46a2cedc53cc001
-    sha256: 73ce6fa6262846141082e32581f1545317457c8cff29ae2a22aa9fe301313420
+    md5: 43a945add29565ba0539f7a4bba936aa
+    sha256: 1e78b3b438a4a858b3c0164e62b6b92d94e31612e9f5577451963189c6af697a
   category: main
   optional: false
 - name: aiohttp
-  version: 3.10.3
+  version: 3.10.5
   manager: conda
   platform: win-64
   dependencies:
@@ -198,10 +198,10 @@ package:
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     yarl: '>=1.0,<2.0'
-  url: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.10.3-py311he736701_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.10.5-py311he736701_0.conda
   hash:
-    md5: cd99f38467b9a08a1b38f937b2c8d20f
-    sha256: 94c4308ae424296a5f4b648d7ddc4b715980f247aa23759f6c0887404b227bc9
+    md5: 35e609f98b02db915cf3cb9d7e1c86a4
+    sha256: 042e15585d8b7c31ac7175d45d78434b31c9d0adc9d837f59baa8951d25ab8f7
   category: main
   optional: false
 - name: aiohttp-retry
@@ -300,8 +300,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -313,8 +313,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -466,8 +466,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.6'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyconfig-0.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6db9c8d8592eeb6ee25a8a90f137fe25
@@ -479,8 +479,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.6'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyconfig-0.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6db9c8d8592eeb6ee25a8a90f137fe25
@@ -508,11 +508,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
     python: '>=3.8'
     sniffio: '>=1.1'
     typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
@@ -524,11 +524,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
     python: '>=3.8'
     sniffio: '>=1.1'
     typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
@@ -602,9 +602,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+    typing-extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -616,9 +616,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+    typing-extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -813,8 +813,8 @@ package:
   platform: osx-arm64
   dependencies:
     cryptography: ''
-    python: '>=3.4'
     pyopenssl: '>=17.0.0'
+    python: '>=3.4'
     python-gssapi: '>=1.2.0'
     typing_extensions: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
@@ -829,8 +829,8 @@ package:
   platform: win-64
   dependencies:
     cryptography: ''
-    python: '>=3.4'
     pyopenssl: '>=17.0.0'
+    python: '>=3.4'
     python-gssapi: '>=1.2.0'
     typing_extensions: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/asyncssh-2.14.1-pyhd8ed1ab_0.conda
@@ -947,15 +947,15 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-hff137af_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h15d0e8c_6.conda
   hash:
-    md5: 1f05e3e75005a8e7cce98322e19cde41
-    sha256: 7e927e0da639cb9a873f7cab0b42102488d3a1a74fd8d301653d0a3044a8141a
+    md5: e0d292ba383ac09598c664186c0144cd
+    sha256: 0680ca18238e17d319f87bb8390d116292592c6f5534c66404542665d6149fae
   category: main
   optional: false
 - name: aws-c-auth
@@ -965,14 +965,14 @@ package:
   dependencies:
     __osx: '>=11.0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.25-hb292504_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.25-hd1432f0_6.conda
   hash:
-    md5: 0f1e67a4f33d7d07fcb04ae0bb524eef
-    sha256: 913e9bb791ebcbea19e9cd08e8cfa65aec49bcf33a4f2324aadd73ef6463e6f1
+    md5: eb4e83993ec5fb4eebcfaf931d8217dd
+    sha256: 312444985a6c09849cc81c36a4187720efc4f39258e2ec8cafc595a5b252d3c1
   category: main
   optional: false
 - name: aws-c-auth
@@ -981,17 +981,17 @@ package:
   platform: win-64
   dependencies:
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-hb20dbd5_5.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-h7db803d_6.conda
   hash:
-    md5: a90d04dfb5880240eccadfce6ff90484
-    sha256: 2c85b5901ac56ddda36a154df8eb976684dabc3f9b1d93863fa8e538d1f43bd1
+    md5: c17d2724a6f73adcaaf39d1271ca20b1
+    sha256: 9dcb467b8f6b33c44fb4644501bcfe8dd0df9cd066b27e725aae22688a3fda01
   category: main
   optional: false
 - name: aws-c-cal
@@ -1000,13 +1000,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h7970872_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h8dac057_2.conda
   hash:
-    md5: 902105f82c52abed505e1e1917c1c23b
-    sha256: 8a5a0f661e1a4cc3bf0bf2ba7cd980c5a932c12db70a634de6aab8683e6c07e0
+    md5: 577509458a061ddc9b089602ac6e1e98
+    sha256: bfd4f73855e926e6c7c9db700a17ef3ddb0e848b85edd04d766d50a008835407
   category: main
   optional: false
 - name: aws-c-cal
@@ -1015,12 +1015,12 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.3-h98f14e4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.7.3-h85401af_2.conda
   hash:
-    md5: dbf7a53b2b9b1a7d19d9fe4ab3c63eca
-    sha256: 20c8fb5c250f8a47eb50a685668950f265b2e3f04645c9df859010d87cedff7e
+    md5: 4adcf0d38e19822d4597d592fb746912
+    sha256: 9b8fc6484fea032552ac61f2a45f073cbb28d7bc37f2166e27c8e0247ac857a2
   category: main
   optional: false
 - name: aws-c-cal
@@ -1028,146 +1028,146 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     openssl: '>=3.3.1,<4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.3-h0240d57_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.3-ha1e9ad3_2.conda
   hash:
-    md5: 57a06a844af4b0e5e6401b6b78f5df5e
-    sha256: a3603b786b567aad26d38af3477e2cf3dc28acd1c8203233cf2411887a1dedb9
+    md5: c763ff9c4c712558ef72a460e4a2dbae
+    sha256: 1bb4570afeb28f6b4693b4cb037d823308b40020b779f42d508d42dab0b44eaa
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.25-h4bc722e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.27-h4bc722e_0.conda
   hash:
-    md5: 8ae3ebc6f412a923466ae673a3b3953f
-    sha256: af6dbf129de978b8960b1d130770878e5052d992232cbdd4ddf99d2ea705f931
+    md5: 817119e8a21a45d325f65d0d54710052
+    sha256: b1725a5ec43bcf606d6bdb248312aa51386b30339dd83a1f16edf620fe03d941
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.25-h99b78c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.27-h99b78c6_0.conda
   hash:
-    md5: 4d8839ae6eff84cc59296b7bc9fae58e
-    sha256: 0a103d849e90a8c9bf036dc97985e585ba376535c06c38633ef9405ef154bd9a
+    md5: b92f3870b54249178462862413137ca1
+    sha256: 6c5a03e6e8436b307c6e36a257ceb24a95338e5d82de48c7462ceb921adadb35
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.25-h2466b09_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.27-h2466b09_0.conda
   hash:
-    md5: 5d3cd0031dbfcd800f6f5a4122e84dc7
-    sha256: ce2a6a0c430bb70f250ac58ca65fce111513e744d27acc0c408d8c5cb9f55e26
+    md5: 8355fbefc33c680fa1a96ba7d3365dfa
+    sha256: 6d59ceca0f648ef0e6d6bce00dc3824a9340bf8fbffeafc80d4dbd230860579b
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.18
+  version: 0.2.19
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-hc649ecc_8.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    libgcc-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.19-haa50ccc_0.conda
   hash:
-    md5: b72e4162acb0cf997185fc1da432a63e
-    sha256: ef8666bd07183f32219e7de3faf26c16d6acdd42769be0bb15b3668d0c89deba
+    md5: 00c38c49d0befb632f686cf67ee8c9f5
+    sha256: d7cca92ff47e5de9e53ce6ea90186d578883b35d4c665b166ada2754d7786d05
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.18
+  version: 0.2.19
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h98f14e4_8.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.19-h41e72e7_0.conda
   hash:
-    md5: 216c9074a19acb5fccfc69b538ef275d
-    sha256: 688be60bdf4338a15ecd94f1d64e21194064adbdf4d93719c957960a23f8b50b
+    md5: c0fa07c8ba0434260ee3e6a05d4ddfa4
+    sha256: e61ee499ca9db361bca4d8c8f9bf3db439dfc25bd71f1405d6ec97e74699ef3f
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.18
+  version: 0.2.19
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-h0240d57_8.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.19-ha1e9ad3_0.conda
   hash:
-    md5: f8edfe3c145f2d12c7a94055238e3979
-    sha256: 9c7f3e6544987df22f8f5f38e14eac2d0d954659875e928f91a4d83b4857edca
+    md5: 275ed97d3db3f2858a94e8597c777392
+    sha256: 468b22529b0e73985f057259930439310e15b0542dc354a2419aa12d52b5d14c
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.2
+  version: 0.4.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h04a40c0_20.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.3-h570d160_0.conda
   hash:
-    md5: 3c1a3aa8f0dd19e1a917b39620fda32c
-    sha256: 7b0611ec00f0433db9163f1050cc0289abe380f43a499a7b09aed5976e94afa0
+    md5: 1c121949295cac86798be8f369768d7c
+    sha256: 608225f14f0befcc351860c2961ae9734f7bf097b3ffb88aea69727c65843689
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.2
+  version: 0.4.3
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-hf1484eb_20.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.3-h79ff00d_0.conda
   hash:
-    md5: c7274d4c42bb06eaee73853eecbaf39f
-    sha256: 229aab7e93d4aa2045761673a2836c124b969b005de45051a0e456d218d594e1
+    md5: 05dc0c49ea75ee73735416e2b3612c56
+    sha256: bc45ee6a05f45b0ba2a8f014b2ac67e1aa33b98ec2f95286482bd9af37025fc7
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.2
+  version: 0.4.3
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h330dd76_20.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.3-hf2a634e_0.conda
   hash:
-    md5: 7c396e1c1004e9a968cc77ebf6034a3c
-    sha256: 0580d2999a2ed936345aefd85fec917daef7bf75d0b066760b421692ac4f8f0f
+    md5: 91dcbc9c8ae48e5f1ddc4674193cd37b
+    sha256: af6296494de3a68ac0d2d1fc1e7f2597f8555be419f90d199174e30cf6c6ecd9
   category: main
   optional: false
 - name: aws-c-http
@@ -1177,14 +1177,14 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-compression: '>=0.2.19,<0.2.20.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-he2d3600_3.conda
+    libgcc-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-h1c59cda_5.conda
   hash:
-    md5: 3beadf1544937956b66eef343734d71e
-    sha256: 7e8452ce2e51bd344003e77ffee717dfe71e96031fc4e7d4891b7f8fc26dec45
+    md5: 0fc88e5bb5f095bdf4129282411c50c9
+    sha256: c498aa33b2066f04afc61f504dde43bbbcb3322f31ecb6ddca73602739614ab1
   category: main
   optional: false
 - name: aws-c-http
@@ -1194,13 +1194,13 @@ package:
   dependencies:
     __osx: '>=11.0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-compression: '>=0.2.19,<0.2.20.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.7-h0745562_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.7-ha3a5f06_5.conda
   hash:
-    md5: b5a54c8202b062acbf2c421db07e620c
-    sha256: dfb40321cfdb6f607279d07edbf9bcdf8f99615a03fe6738044ff907127062fa
+    md5: 36c9f6c831a3f1ec5f23990584b94512
+    sha256: 149f4b42f67fd1a585024abdf16f8048976fa7333c7ab71cf6f553e46fd0a557
   category: main
   optional: false
 - name: aws-c-http
@@ -1209,16 +1209,16 @@ package:
   platform: win-64
   dependencies:
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-compression: '>=0.2.19,<0.2.20.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h3d472a8_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h7d4ba70_5.conda
   hash:
-    md5: d2b41c435ee60e66e487188cd95952ca
-    sha256: 329cfc629594710adc9f38d3166a17ee0ac22bfc41c65f582ec735ac1f4cb37a
+    md5: b8f007046d97c8a1ff52b70aeaf4c860
+    sha256: 3ca8b4b6594a603e2c89023ce541598b0afbceb3ccd5bcb377b2d0cc64fd04c1
   category: main
   optional: false
 - name: aws-c-io
@@ -1228,13 +1228,13 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.5.0,<1.5.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h7d46f39_3.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    libgcc-ng: '>=13'
+    s2n: '>=1.5.1,<1.5.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-hf5b9b93_6.conda
   hash:
-    md5: cf970c7fde2c61b82759f3d3c141b0ec
-    sha256: d0c7c5105a7fd48ad6b5419f20602232ec42fd057b99d005dfdd78ab231bc102
+    md5: 8fd43c2719355d795f5c7cef11f08ec0
+    sha256: 3640f15a08bc22cf0b7321d177535517f16c360f961306d291e006296f111d7d
   category: main
   optional: false
 - name: aws-c-io
@@ -1244,11 +1244,11 @@ package:
   dependencies:
     __osx: '>=11.0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.18-h9c4697d_3.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.18-h43341e6_6.conda
   hash:
-    md5: 2ae347790b7841cf73190f29e9da5707
-    sha256: 39027d099e039ec15b1eea3599c1f7203355cd09adafee9af75d52068f511194
+    md5: af3beb5ed6d55cbf88dee4671e5c616e
+    sha256: ff8c95d55410da8788c232c69e441f6fd39cdaee0859f50fb0536b4de6bb12b5
   category: main
   optional: false
 - name: aws-c-io
@@ -1257,14 +1257,14 @@ package:
   platform: win-64
   dependencies:
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-hb7d5f83_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h8d4122e_6.conda
   hash:
-    md5: 21672885f557c7446c858893e96398f7
-    sha256: 4ffda58aa274813058c2feff07b8df59d275340da8df167ad8d9f8d188021ea0
+    md5: 81818d850fcf9d276dac5e5bcedbb273
+    sha256: 99de2be593516ffa646622e3bde3d546d3dc336b40cdd673a2bd5160fb19411e
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -1273,14 +1273,14 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-h674cf7e_16.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hc14a930_17.conda
   hash:
-    md5: a96a7cd318b665b8784cbe7e67916f66
-    sha256: 759a15d367ef69f24448ace52843c4999e1795710c4393ea86d7768b1934db93
+    md5: f0e3f95a9f545d5975e8573f80cdb5fa
+    sha256: bc176d82875700e0ee51ddaef188fd6ca2a44b2efc69e0cb434460319216049b
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -1289,13 +1289,13 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.4-h8469d54_16.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.4-h64da278_17.conda
   hash:
-    md5: b48411d5db102d80c0dc828727d72c6e
-    sha256: 67ed006fb6910a3837d35585be221f9db3b64699f63396498315994952930c60
+    md5: 8b68d3ffa6799ba33340eafd952acae0
+    sha256: 413f0c6518edc16c7f5f52e64835abd5fdc8154889a2696f125a2efb0d3f5481
   category: main
   optional: false
 - name: aws-c-mqtt
@@ -1303,16 +1303,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h1efefa3_16.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h827f298_17.conda
   hash:
-    md5: 1de479e343cd06db94e05062ab9af2e0
-    sha256: 4ca34b6277f62f0cc56da0e9bbff8529d7f749853c4ace9de6dd3833d1aac2e5
+    md5: e623bc494578a42b34d439472e20a9b2
+    sha256: 9804a9027ff17955953ef934c48e7344db43f8b0d90a7c45fa5afeecb4f8ae9e
   category: main
   optional: false
 - name: aws-c-s3
@@ -1323,16 +1323,16 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h28a8003_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h558cea2_8.conda
   hash:
-    md5: 5d1ea2ae5ca0de171c81c77e0e7e247c
-    sha256: 0ddb4ccd1adf6f49ffbfd365acb7687a54ef3bba3437c04bf04390a64bdee51f
+    md5: af03e7b03e929396fb80ffac1a676c89
+    sha256: 8206b63d89e1cf08a0e4bc4852cb15080bc9754df48acbc5e59fbe2ec50b3da8
   category: main
   optional: false
 - name: aws-c-s3
@@ -1343,14 +1343,14 @@ package:
     __osx: '>=11.0'
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.4-haa8919f_7.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.6.4-h3f26dbc_8.conda
   hash:
-    md5: dda969f2ed3a9cf99ef4d48a1f42cca1
-    sha256: 873210a323c510b4b15d6dc26ce2722a94842b7cd4815a2f6db6be8a4440184d
+    md5: 2a93a85d64e31922f2bd28691fac9556
+    sha256: 2e9259cd3a8e26162bd2eddc55f83d6af6cefaf8f79e0eaad0fe08d9ae98c835
   category: main
   optional: false
 - name: aws-c-s3
@@ -1360,17 +1360,17 @@ package:
   dependencies:
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h9a9d544_7.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h21392f2_8.conda
   hash:
-    md5: deb154f8af541505a680b0db44f1c469
-    sha256: 8af3f3ce7dbcc915b6563387f64678a64d8be14e02d46f137c6e0b03d25a4b2a
+    md5: 15db0136544c378e00fd7158bf019a21
+    sha256: 8137069560d3778e790618a2817eb0c5da4e1a97cd5ff91c778e365b3147b737
   category: main
   optional: false
 - name: aws-c-sdkutils
@@ -1379,12 +1379,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-hc649ecc_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h038f3f9_2.conda
   hash:
-    md5: f1d4b80dfc062bc55cecc20148eb925a
-    sha256: dc1eaf29c3a4092ae653b3ce80d5c8dfdc73a20d70c62c25f6a0faff059cd3a1
+    md5: 6861cab6cddb5d713cb3db95c838d30f
+    sha256: 5612c9cad56662db50a1bcc2d8dca1fe273f7abad6f670fef328e4044beabc75
   category: main
   optional: false
 - name: aws-c-sdkutils
@@ -1393,11 +1393,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.19-h98f14e4_0.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.19-h85401af_2.conda
   hash:
-    md5: 4e46163b63fd4e51dfb93b14cf5756c3
-    sha256: b121ef5e6343beb24cdb269689101ab11bcd8b3dd379beed251140bf11f395a4
+    md5: 23183f9ce785058346cbb89c4327b02b
+    sha256: faf9f32a7b3f312f370e77cf52e6afe512c6cce4cd9709fe039ff08acd877f5a
   category: main
   optional: false
 - name: aws-c-sdkutils
@@ -1405,14 +1405,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-h0240d57_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-ha1e9ad3_2.conda
   hash:
-    md5: facd2e7d595af64ab74d0ffd0d70fb4f
-    sha256: 2cd6632ec4fc50e868cb9b11acaa98405283cf7104136bbc16e22ab729cc2f98
+    md5: da087023762ab6dc62fd1d374b6cc30f
+    sha256: c87e00f73686c3b43f0a2d6ff480f28d2a8f07811bad5e406bbe0ca8240bbba4
   category: main
   optional: false
 - name: aws-checksums
@@ -1421,12 +1421,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-hc649ecc_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h038f3f9_10.conda
   hash:
-    md5: 178504fd14f8486ce3153fa16371ceef
-    sha256: 63ccb2a0b471dac505e95d6a623b041e00e8a2a734fd33fd101f7d3a0018becf
+    md5: 4bf9c8fcf2bb6793c55e5c5758b9b011
+    sha256: a94547ff766fb420c368bb8d4fd1c8d99b13088d176c43ad7bb7458ef47e45bc
   category: main
   optional: false
 - name: aws-checksums
@@ -1435,11 +1435,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h98f14e4_8.conda
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h85401af_10.conda
   hash:
-    md5: daacf29419901e2f8e75166581ab6551
-    sha256: 9dc4e7ba552d98d1928da6b6f2aea8187b251d70a9e966cb4abaed32aecc4a42
+    md5: 446c0b024a1cbf4b769d271da2bfdce2
+    sha256: aeafa3581c3b82d5ac9b13a041795706c3cb0efe3764ee6825f0042a7f52041e
   category: main
   optional: false
 - name: aws-checksums
@@ -1447,70 +1447,70 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-h0240d57_8.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-ha1e9ad3_10.conda
   hash:
-    md5: f419be1f5cfd2645fa7f68bf410c8548
-    sha256: 7ee5937729c1ee8fc05022c73423749a0486bbd6fe7f01e958532a5f7ee9d1ed
+    md5: 93c84eec0955253bf07b5fbff95c6200
+    sha256: d992544ad6ab4fc55bae80bdff9ab6c9d71b021c91297e835e3999b9cab4645c
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.27.5
+  version: 0.27.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
     aws-c-s3: '>=0.6.4,<0.6.5.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-heec6497_6.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.6-h1966bd9_0.conda
   hash:
-    md5: d99cb216fba6ec1576db0bb5901b956f
-    sha256: 17ebb0d468354e85986f2e8137c43e9714353238fe039086bda070746455cfd2
+    md5: 30b59fa809914489974fe275a0fb7c7e
+    sha256: f45a23fc50e9df01f3235672d805b9175ca05d8966a32351c3fb98970b94d2d1
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.27.5
+  version: 0.27.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
     aws-c-s3: '>=0.6.4,<0.6.5.0a0'
     aws-c-sdkutils: '>=0.1.19,<0.1.20.0a0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.27.5-hac97e13_6.conda
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.27.6-h3fdcf82_0.conda
   hash:
-    md5: 52b612edcc9af8bb5b83ca8580e14903
-    sha256: 941aec751ec92a9504f2afcb52959582597e69631c82f47d7a93afb4c15c4ec0
+    md5: c78b061e9af81b1122da4dcd00769e35
+    sha256: 2dfb60783d944de57ece842fe1a6532a45e41444229d98c25fe9e727098a0d98
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.27.5
+  version: 0.27.6
   manager: conda
   platform: win-64
   dependencies:
     aws-c-auth: '>=0.7.25,<0.7.26.0a0'
     aws-c-cal: '>=0.7.3,<0.7.4.0a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-c-http: '>=0.8.7,<0.8.8.0a0'
     aws-c-io: '>=0.14.18,<0.14.19.0a0'
     aws-c-mqtt: '>=0.10.4,<0.10.5.0a0'
@@ -1519,10 +1519,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h2c0bb8d_6.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.6-h6fef074_0.conda
   hash:
-    md5: 92b0c34cf2059b8505a79552bfae6762
-    sha256: 38198926e460fffa826d21a6a5834ba71a713cd5e9eb29ddcb8091c5940ca9c7
+    md5: cde08e29f68adaae135c0fefba04c70f
+    sha256: ae13f758658c97d2769697bff00f1c1f26eb3bbb10e22b3e04141dfc0844a5aa
   category: main
   optional: false
 - name: aws-sdk-cpp
@@ -1531,19 +1531,19 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     libcurl: '>=8.9.1,<9.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-he20dfa5_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-hf9693f6_5.conda
   hash:
-    md5: 25a12549e0aeeaa2718035c3e54ff520
-    sha256: a43661e14ad9d51c0c9330effbc86d9960096484181402dd43bd9617c803f67b
+    md5: 18a4bf7e8a65006b26ca53700fcf2362
+    sha256: 5267e5a24249d89368226caa3a9b64d53e2c8e481650c57755cad90a9d0578bf
   category: main
   optional: false
 - name: aws-sdk-cpp
@@ -1552,18 +1552,18 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     libcurl: '>=8.9.1,<9.0a0'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.379-h0db37eb_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.379-h34e68ec_5.conda
   hash:
-    md5: d9996884741f0db39dc34be34dd87596
-    sha256: cda6ed6e15cc04b0f513d8009c67fc6c6db4756be7d3f6b732a6fd8bdac3e520
+    md5: ecf5bf7cb7d86b8ac38b8ed40e5a0105
+    sha256: d00d23735b03beb14a90ab951b53bc22c6c8390698b7ee25e282a8cad7520bdd
   category: main
   optional: false
 - name: aws-sdk-cpp
@@ -1571,18 +1571,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.25,<0.9.26.0a0'
-    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-common: '>=0.9.27,<0.9.28.0a0'
+    aws-c-event-stream: '>=0.4.3,<0.4.4.0a0'
     aws-checksums: '>=0.1.18,<0.1.19.0a0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h2205d66_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-hd66f94a_5.conda
   hash:
-    md5: 6abcadee194e8becd912c9a0b75eddc0
-    sha256: 4c64f829f589fdb36e77ecc63f9c289d69052be2b7b4d7a6dfe22d842bc6f0cd
+    md5: 9e944136425de314ea70472ddbf44913
+    sha256: 2d37d00e2448402ad30f82ba5081066a625d6ccd5e9fbcffccf32fde3058c1bf
   category: main
   optional: false
 - name: azure-core-cpp
@@ -1763,9 +1763,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    pytz: ''
     python: '>=3.7'
+    pytz: ''
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9669586875baeced8fc30c0826c3270e
@@ -1777,9 +1777,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
-    pytz: ''
     python: '>=3.7'
+    pytz: ''
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9669586875baeced8fc30c0826c3270e
@@ -2002,10 +2002,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    numcodecs: ''
-    python-blosc: ''
-    python: '>=3.8'
     msgpack-python: '>=1.0'
+    numcodecs: ''
+    python: '>=3.8'
+    python-blosc: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binpickle-0.3.4-pyhd8ed1ab_2.conda
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
@@ -2017,10 +2017,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    numcodecs: ''
-    python-blosc: ''
-    python: '>=3.8'
     msgpack-python: '>=1.0'
+    numcodecs: ''
+    python: '>=3.8'
+    python-blosc: ''
   url: https://conda.anaconda.org/conda-forge/noarch/binpickle-0.3.4-pyhd8ed1ab_2.conda
   hash:
     md5: 8d8a54fa0007d026dfd737cede5dbcaa
@@ -2060,11 +2060,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     packaging: ''
-    webencodings: ''
     python: '>=3.6'
+    setuptools: ''
     six: '>=1.9.0'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -2076,11 +2076,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     packaging: ''
-    webencodings: ''
     python: '>=3.6'
+    setuptools: ''
     six: '>=1.9.0'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -2123,10 +2123,10 @@ package:
   platform: win-64
   dependencies:
     __win: ''
+    jinxed: '>=0.5.4'
     python: '>=3.8'
     six: '>=1.9.0'
     wcwidth: '>=0.1.4'
-    jinxed: '>=0.5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/blessed-1.19.1-pyh95a074a_2.tar.bz2
   hash:
     md5: cbfae8732ee6ecb78d871a7179cc15cf
@@ -2205,10 +2205,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
     botocore: '>=1.34.131,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
     md5: 16cbd51eb7f0fc40a88c636006437c85
@@ -2220,10 +2220,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    jmespath: '>=0.7.1,<2.0.0'
-    s3transfer: '>=0.10.0,<0.11.0'
     botocore: '>=1.34.131,<1.35.0'
+    jmespath: '>=0.7.1,<2.0.0'
+    python: '>=3.8'
+    s3transfer: '>=0.10.0,<0.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.131-pyhd8ed1ab_0.conda
   hash:
     md5: 16cbd51eb7f0fc40a88c636006437c85
@@ -2250,9 +2250,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
@@ -2265,9 +2265,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python-dateutil: '>=2.1,<3.0.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.10'
+    python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,!=2.2.0,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.131-pyge310_1234567_0.conda
   hash:
@@ -2450,9 +2450,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-    msgpack-python: '>=0.5.2,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: a54e449940b3e4bb2129b8daae0c1f65
@@ -2464,9 +2464,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    msgpack-python: '>=0.5.2,<2.0.0'
     python: '>=3.7'
     requests: '>=2.16.0'
-    msgpack-python: '>=0.5.2,<2.0.0'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: a54e449940b3e4bb2129b8daae0c1f65
@@ -2492,9 +2492,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
     cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: 42a12b0b21d64b36a9ab9a24a04eb910
@@ -2506,9 +2506,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    filelock: '>=3.8.0'
     cachecontrol: 0.14.0
+    filelock: '>=3.8.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/cachecontrol-with-filecache-0.14.0-pyhd8ed1ab_1.conda
   hash:
     md5: 42a12b0b21d64b36a9ab9a24a04eb910
@@ -2725,18 +2725,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
+    billiard: '>=4.2.0,<5.0'
     click: '>=8.1.2,<9.0'
     click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
+    click-plugins: '>=1.1.1'
+    click-repl: '>=0.2.0'
+    importlib-metadata: '>=3.6'
     kombu: '>=5.3.4,<6.0'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    python-tzdata: '>=2022.7'
+    vine: '>=5.1.0,<6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/celery-5.4.0-pyhd8ed1ab_1.conda
   hash:
     md5: 2e025e22e58648d8f8c7ee96b4aa96bf
@@ -2748,18 +2748,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     backports.zoneinfo: '>=0.2.1'
-    python-dateutil: '>=2.8.2'
-    importlib-metadata: '>=3.6'
-    click-plugins: '>=1.1.1'
-    click-repl: '>=0.2.0'
+    billiard: '>=4.2.0,<5.0'
     click: '>=8.1.2,<9.0'
     click-didyoumean: '>=0.3.0'
-    python-tzdata: '>=2022.7'
-    billiard: '>=4.2.0,<5.0'
-    vine: '>=5.1.0,<6.0'
+    click-plugins: '>=1.1.1'
+    click-repl: '>=0.2.0'
+    importlib-metadata: '>=3.6'
     kombu: '>=5.3.4,<6.0'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    python-tzdata: '>=2022.7'
+    vine: '>=5.1.0,<6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/celery-5.4.0-pyhd8ed1ab_1.conda
   hash:
     md5: 2e025e22e58648d8f8c7ee96b4aa96bf
@@ -2955,8 +2955,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    colorama: ''
     __win: ''
+    colorama: ''
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
   hash:
@@ -3060,8 +3060,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
     click: '>=3.0'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -3073,8 +3073,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: ''
     click: '>=3.0'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -3101,10 +3101,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     click: ''
     prompt_toolkit: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
@@ -3116,10 +3116,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     click: ''
     prompt_toolkit: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-repl-0.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 27eb8f68250666c1a19d1b6ec9d12c4e
@@ -3145,9 +3145,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    pylev: '>=1.3,<2.0'
     pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
@@ -3159,9 +3159,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    pylev: '>=1.3,<2.0'
     pastel: '>=0.2.0,<0.3.0'
+    pylev: '>=1.3,<2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/clikit-0.6.2-pyhd8ed1ab_2.conda
   hash:
     md5: 02abb7b66b02e8b9f5a9b05454400087
@@ -3324,31 +3324,31 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    typing_extensions: ''
-    jinja2: ''
-    ruamel.yaml: ''
-    tomli: ''
-    click-default-group: ''
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    click: '>=8.0'
-    packaging: '>=20.4'
-    requests: '>=2.18'
-    pydantic: '>=1.10'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    keyring: '>=21.2.0'
-    html5lib: '>=1.0'
+    cachecontrol-with-filecache: '>=0.12.9'
     cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
     clikit: '>=0.6.2'
     crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
     pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
     tomlkit: '>=0.7.0'
-    virtualenv: '>=20.0.26'
     toolz: '>=0.12.0,<1.0.0'
-    cachecontrol-with-filecache: '>=0.12.9'
+    typing_extensions: ''
     urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
   url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
@@ -3360,31 +3360,31 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
-    typing_extensions: ''
-    jinja2: ''
-    ruamel.yaml: ''
-    tomli: ''
-    click-default-group: ''
-    python: '>=3.8'
-    pyyaml: '>=5.1'
-    click: '>=8.0'
-    packaging: '>=20.4'
-    requests: '>=2.18'
-    pydantic: '>=1.10'
-    ensureconda: '>=1.3'
-    gitpython: '>=3.1.30'
-    keyring: '>=21.2.0'
-    html5lib: '>=1.0'
+    cachecontrol-with-filecache: '>=0.12.9'
     cachy: '>=0.3.0'
+    click: '>=8.0'
+    click-default-group: ''
     clikit: '>=0.6.2'
     crashtest: '>=0.3.0'
+    ensureconda: '>=1.3'
+    gitpython: '>=3.1.30'
+    html5lib: '>=1.0'
+    jinja2: ''
+    keyring: '>=21.2.0'
+    packaging: '>=20.4'
     pkginfo: '>=1.4'
+    pydantic: '>=1.10'
+    python: '>=3.8'
+    pyyaml: '>=5.1'
+    requests: '>=2.18'
+    ruamel.yaml: ''
+    setuptools: ''
+    tomli: ''
     tomlkit: '>=0.7.0'
-    virtualenv: '>=20.0.26'
     toolz: '>=0.12.0,<1.0.0'
-    cachecontrol-with-filecache: '>=0.12.9'
+    typing_extensions: ''
     urllib3: '>=1.26.5,<2.0'
+    virtualenv: '>=20.0.26'
   url: https://conda.anaconda.org/conda-forge/noarch/conda-lock-2.5.7-pyhd8ed1ab_0.conda
   hash:
     md5: 154d0c643be6a9ce6fbe655d007d8e4e
@@ -3409,8 +3409,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
@@ -3422,8 +3422,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/configobj-5.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 04c71f400324538d4396407ea2ffb34f
@@ -3620,7 +3620,7 @@ package:
   category: main
   optional: false
 - name: datasets
-  version: 2.20.0
+  version: 2.21.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3640,64 +3640,64 @@ package:
     pyyaml: '>=5.1'
     requests: '>=2.32.2'
     tqdm: '>=4.66.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.21.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7e2c046cd09a2498bac484413771a9df
-    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
+    md5: 1b2d7c700663bfec50f6c553e5449da2
+    sha256: b3fb3f2731eb4c5ec49fe07ed3ae4964d5775984d7b7a73c7ee807b11e4e85b5
   category: main
   optional: false
 - name: datasets
-  version: 2.20.0
+  version: 2.21.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: ''
-    packaging: ''
-    filelock: ''
-    python-xxhash: ''
-    multiprocess: ''
-    pyarrow-hotfix: ''
-    pyyaml: '>=5.1'
-    numpy: '>=1.17'
-    python: '>=3.8.0'
     aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
-    requests: '>=2.32.2'
-    huggingface_hub: '>=0.21.2'
-    pyarrow: '>=15.0.0'
-    tqdm: '>=4.66.3'
+    filelock: ''
     fsspec: '>=2023.1.0,<=2024.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
+    huggingface_hub: '>=0.21.2'
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=15.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
+    requests: '>=2.32.2'
+    tqdm: '>=4.66.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.21.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7e2c046cd09a2498bac484413771a9df
-    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
+    md5: 1b2d7c700663bfec50f6c553e5449da2
+    sha256: b3fb3f2731eb4c5ec49fe07ed3ae4964d5775984d7b7a73c7ee807b11e4e85b5
   category: main
   optional: false
 - name: datasets
-  version: 2.20.0
+  version: 2.21.0
   manager: conda
   platform: win-64
   dependencies:
-    pandas: ''
-    packaging: ''
-    filelock: ''
-    python-xxhash: ''
-    multiprocess: ''
-    pyarrow-hotfix: ''
-    pyyaml: '>=5.1'
-    numpy: '>=1.17'
-    python: '>=3.8.0'
     aiohttp: '!=4.0.0a0,!=4.0.0a1'
     dill: '>=0.3.0,<0.3.9'
-    requests: '>=2.32.2'
-    huggingface_hub: '>=0.21.2'
-    pyarrow: '>=15.0.0'
-    tqdm: '>=4.66.3'
+    filelock: ''
     fsspec: '>=2023.1.0,<=2024.5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.20.0-pyhd8ed1ab_0.conda
+    huggingface_hub: '>=0.21.2'
+    multiprocess: ''
+    numpy: '>=1.17'
+    packaging: ''
+    pandas: ''
+    pyarrow: '>=15.0.0'
+    pyarrow-hotfix: ''
+    python: '>=3.8.0'
+    python-xxhash: ''
+    pyyaml: '>=5.1'
+    requests: '>=2.32.2'
+    tqdm: '>=4.66.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/datasets-2.21.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7e2c046cd09a2498bac484413771a9df
-    sha256: fc8ef02c03076571171a4e2f4abf0a99f2f1614ce2c39e82b1e13b2df1db2c81
+    md5: 1b2d7c700663bfec50f6c553e5449da2
+    sha256: b3fb3f2731eb4c5ec49fe07ed3ae4964d5775984d7b7a73c7ee807b11e4e85b5
   category: main
   optional: false
 - name: dbus
@@ -4133,7 +4133,7 @@ package:
   category: dev
   optional: true
 - name: dvc
-  version: 3.53.2
+  version: 3.54.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4144,7 +4144,7 @@ package:
     distro: '>=1.3'
     dpath: <3,>=2.1.0
     dulwich: ''
-    dvc-data: '>=3.15,<3.16'
+    dvc-data: '>=3.16.2,<3.17'
     dvc-http: '>=2.29.0'
     dvc-objects: ''
     dvc-render: '>=1.0.1,<2'
@@ -4180,122 +4180,122 @@ package:
     tqdm: <5,>=4.63.1
     voluptuous: '>=0.11.7'
     zc.lockfile: '>=1.2.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.53.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.54.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 45b90099c4216812be21151bcab2b0dd
-    sha256: ee6327d592c52cb8a3bdaf5d63788fd2f1c43e6fcc15c8c7978b797c34cc4fb5
+    md5: b58f720d5a7d57b286a154e08528f1da
+    sha256: 8ecb06cfe9b6f6ec67b56003347c2b0d0fc13a498ca3d78af3d133ebdb8765b8
   category: dev
   optional: true
 - name: dvc
-  version: 3.53.2
+  version: 3.54.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    dvc-objects: ''
-    omegaconf: ''
+    attrs: '>=22.2.0'
     celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    requests: '>=2.22'
-    configobj: '>=5.0.6'
     colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
+    configobj: '>=5.0.6'
+    distro: '>=1.3'
+    dpath: <3,>=2.1.0
+    dulwich: ''
+    dvc-data: '>=3.16.2,<3.17'
+    dvc-http: '>=2.29.0'
+    dvc-objects: ''
+    dvc-render: '>=1.0.1,<2'
+    dvc-studio-client: '>=0.21,<1'
+    dvc-task: '>=0.3.0,<1'
+    flatten-dict: <1,>=0.4.1
+    flufl.lock: '>=8.1.0,<9'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    grandalf: <1,>=0.7
+    gto: '>=1.6.0,<2'
+    hydra-core: '>=1.1'
+    iterative-telemetry: '>=0.0.7'
+    kombu: ''
+    networkx: '>=2.5'
+    omegaconf: ''
     packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
+    pathspec: '>=0.10.3'
+    platformdirs: <4,>=3.1.1
+    psutil: '>=5.8'
     pydot: '>=1.2.4'
+    pygtrie: '>=2.3.2'
+    pyparsing: '>=2.4.7'
+    python: '>=3.9'
+    requests: '>=2.22'
+    rich: '>=12'
+    ruamel.yaml: '>=0.17.11'
+    scmrepo: '>=3.3.4,<4'
+    shortuuid: '>=0.5'
+    shtab: <2,>=1.3.4
+    tabulate: '>=0.8.7'
+    tomlkit: '>=0.11.1'
+    tqdm: <5,>=4.63.1
     voluptuous: '>=0.11.7'
     zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    attrs: '>=22.2.0'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
-    dvc-task: '>=0.3.0,<1'
-    fsspec: '>=2024.2.0'
-    gto: '>=1.6.0,<2'
-    dvc-render: '>=1.0.1,<2'
-    dvc-data: '>=3.15,<3.16'
-    scmrepo: '>=3.3.4,<4'
-    dvc-studio-client: '>=0.21,<1'
-    flufl.lock: '>=8.1.0,<9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.53.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.54.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 45b90099c4216812be21151bcab2b0dd
-    sha256: ee6327d592c52cb8a3bdaf5d63788fd2f1c43e6fcc15c8c7978b797c34cc4fb5
+    md5: b58f720d5a7d57b286a154e08528f1da
+    sha256: 8ecb06cfe9b6f6ec67b56003347c2b0d0fc13a498ca3d78af3d133ebdb8765b8
   category: dev
   optional: true
 - name: dvc
-  version: 3.53.2
+  version: 3.54.1
   manager: conda
   platform: win-64
   dependencies:
-    dvc-objects: ''
-    omegaconf: ''
+    attrs: '>=22.2.0'
     celery: ''
-    dulwich: ''
-    kombu: ''
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    networkx: '>=2.5'
-    tabulate: '>=0.8.7'
-    requests: '>=2.22'
-    configobj: '>=5.0.6'
     colorama: '>=0.3.9'
-    pathspec: '>=0.10.3'
+    configobj: '>=5.0.6'
+    distro: '>=1.3'
+    dpath: <3,>=2.1.0
+    dulwich: ''
+    dvc-data: '>=3.16.2,<3.17'
+    dvc-http: '>=2.29.0'
+    dvc-objects: ''
+    dvc-render: '>=1.0.1,<2'
+    dvc-studio-client: '>=0.21,<1'
+    dvc-task: '>=0.3.0,<1'
+    flatten-dict: <1,>=0.4.1
+    flufl.lock: '>=8.1.0,<9'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    grandalf: <1,>=0.7
+    gto: '>=1.6.0,<2'
+    hydra-core: '>=1.1'
+    iterative-telemetry: '>=0.0.7'
+    kombu: ''
+    networkx: '>=2.5'
+    omegaconf: ''
     packaging: '>=19'
-    ruamel.yaml: '>=0.17.11'
-    tomlkit: '>=0.11.1'
+    pathspec: '>=0.10.3'
+    platformdirs: <4,>=3.1.1
+    psutil: '>=5.8'
     pydot: '>=1.2.4'
+    pygtrie: '>=2.3.2'
+    pyparsing: '>=2.4.7'
+    python: '>=3.9'
+    requests: '>=2.22'
+    rich: '>=12'
+    ruamel.yaml: '>=0.17.11'
+    scmrepo: '>=3.3.4,<4'
+    shortuuid: '>=0.5'
+    shtab: <2,>=1.3.4
+    tabulate: '>=0.8.7'
+    tomlkit: '>=0.11.1'
+    tqdm: <5,>=4.63.1
     voluptuous: '>=0.11.7'
     zc.lockfile: '>=1.2.1'
-    pyparsing: '>=2.4.7'
-    iterative-telemetry: '>=0.0.7'
-    dvc-http: '>=2.29.0'
-    rich: '>=12'
-    platformdirs: <4,>=3.1.1
-    hydra-core: '>=1.1'
-    psutil: '>=5.8'
-    distro: '>=1.3'
-    shortuuid: '>=0.5'
-    attrs: '>=22.2.0'
-    dpath: <3,>=2.1.0
-    flatten-dict: <1,>=0.4.1
-    grandalf: <1,>=0.7
-    shtab: <2,>=1.3.4
-    tqdm: <5,>=4.63.1
-    dvc-task: '>=0.3.0,<1'
-    fsspec: '>=2024.2.0'
-    gto: '>=1.6.0,<2'
-    dvc-render: '>=1.0.1,<2'
-    dvc-data: '>=3.15,<3.16'
-    scmrepo: '>=3.3.4,<4'
-    dvc-studio-client: '>=0.21,<1'
-    flufl.lock: '>=8.1.0,<9'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.53.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-3.54.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 45b90099c4216812be21151bcab2b0dd
-    sha256: ee6327d592c52cb8a3bdaf5d63788fd2f1c43e6fcc15c8c7978b797c34cc4fb5
+    md5: b58f720d5a7d57b286a154e08528f1da
+    sha256: 8ecb06cfe9b6f6ec67b56003347c2b0d0fc13a498ca3d78af3d133ebdb8765b8
   category: dev
   optional: true
 - name: dvc-data
-  version: 3.15.2
+  version: 3.16.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -4305,56 +4305,59 @@ package:
     dvc-objects: '>=4.0.1,<6'
     fsspec: '>=2024.2.0'
     funcy: '>=1.14'
+    orjson: '>=3,<4'
     pygtrie: '>=2.3.2'
     python: '>=3.9'
     sqltrie: '>=0.11.0,<1'
     tqdm: '>=4.63.1,<5'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.16.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a42b220684a1bcbf378dfe05de0ea2d
-    sha256: 0d59a6e54b00d3205e552bbaabd5b0ef7a15275c70a761e6482fcb9e009ae706
+    md5: f8764d1c5e647ec2af7f91fee9466909
+    sha256: 035ae81cfb370e14b298277ee496fa7284d3e4ddb20bf7377b33f93aad71453f
   category: dev
   optional: true
 - name: dvc-data
-  version: 3.15.2
+  version: 3.16.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
     attrs: '>=21.3.0'
-    diskcache: '>=5.2.1'
     dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
-    sqltrie: '>=0.11.0,<1'
+    diskcache: '>=5.2.1'
     dvc-objects: '>=4.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.2-pyhd8ed1ab_0.conda
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    orjson: '>=3,<4'
+    pygtrie: '>=2.3.2'
+    python: '>=3.9'
+    sqltrie: '>=0.11.0,<1'
+    tqdm: '>=4.63.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.16.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a42b220684a1bcbf378dfe05de0ea2d
-    sha256: 0d59a6e54b00d3205e552bbaabd5b0ef7a15275c70a761e6482fcb9e009ae706
+    md5: f8764d1c5e647ec2af7f91fee9466909
+    sha256: 035ae81cfb370e14b298277ee496fa7284d3e4ddb20bf7377b33f93aad71453f
   category: dev
   optional: true
 - name: dvc-data
-  version: 3.15.2
+  version: 3.16.4
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
     attrs: '>=21.3.0'
-    diskcache: '>=5.2.1'
     dictdiffer: '>=0.8.1'
-    tqdm: '>=4.63.1,<5'
-    fsspec: '>=2024.2.0'
-    sqltrie: '>=0.11.0,<1'
+    diskcache: '>=5.2.1'
     dvc-objects: '>=4.0.1,<6'
-  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.15.2-pyhd8ed1ab_0.conda
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    orjson: '>=3,<4'
+    pygtrie: '>=2.3.2'
+    python: '>=3.9'
+    sqltrie: '>=0.11.0,<1'
+    tqdm: '>=4.63.1,<5'
+  url: https://conda.anaconda.org/conda-forge/noarch/dvc-data-3.16.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 0a42b220684a1bcbf378dfe05de0ea2d
-    sha256: 0d59a6e54b00d3205e552bbaabd5b0ef7a15275c70a761e6482fcb9e009ae706
+    md5: f8764d1c5e647ec2af7f91fee9466909
+    sha256: 035ae81cfb370e14b298277ee496fa7284d3e4ddb20bf7377b33f93aad71453f
   category: dev
   optional: true
 - name: dvc-http
@@ -4376,9 +4379,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    aiohttp-retry: '>=2.5.0'
     fsspec: ''
     python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
@@ -4390,9 +4393,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    aiohttp-retry: '>=2.5.0'
     fsspec: ''
     python: '>=3.8'
-    aiohttp-retry: '>=2.5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-http-2.32.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6915a9612a2aacf4df13cf87cb291576
@@ -4418,9 +4421,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
     fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
@@ -4432,9 +4435,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    funcy: '>=1.14'
     fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    python: '>=3.9'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-objects-5.1.0-pyhd8ed1ab_1.conda
   hash:
     md5: 1fcbd36b4bbe66ad5aec71220109148e
@@ -4461,10 +4464,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    flatten-dict: '>=0.4.1'
+    funcy: '>=1.17'
     python: '>=3.7'
     tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
@@ -4476,10 +4479,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    flatten-dict: '>=0.4.1'
+    funcy: '>=1.17'
     python: '>=3.7'
     tabulate: '>=0.8.7'
-    funcy: '>=1.17'
-    flatten-dict: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-render-1.0.2-pyhd8ed1ab_0.conda
   hash:
     md5: 33300000fa304dba183023f1251d7a5e
@@ -4506,9 +4509,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    boto3: '>=1.9.201'
     dvc: ''
     python: '>=3.8'
-    boto3: '>=1.9.201'
     s3fs: '>=2021.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -4521,9 +4524,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    boto3: '>=1.9.201'
     dvc: ''
     python: '>=3.8'
-    boto3: '>=1.9.201'
     s3fs: '>=2021.11.0'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-s3-3.2.0-pyhd8ed1ab_0.conda
   hash:
@@ -4551,10 +4554,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
-    voluptuous: ''
     dulwich: ''
     python: '>=3.8'
+    requests: ''
+    voluptuous: ''
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.21.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6d7a1b396bdbb394ed4da8b801615e4f
@@ -4566,10 +4569,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
-    voluptuous: ''
     dulwich: ''
     python: '>=3.8'
+    requests: ''
+    voluptuous: ''
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-studio-client-0.21.0-pyhd8ed1ab_0.conda
   hash:
     md5: 6d7a1b396bdbb394ed4da8b801615e4f
@@ -4598,12 +4601,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pywin32-on-windows: ''
+    celery: '>=5.3.0,<6'
+    funcy: '>=1.17'
     kombu: ''
     python: '>=3.7'
-    funcy: '>=1.17'
+    pywin32-on-windows: ''
     shortuuid: '>=1.0.8'
-    celery: '>=5.3.0,<6'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
@@ -4615,12 +4618,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pywin32-on-windows: ''
+    celery: '>=5.3.0,<6'
+    funcy: '>=1.17'
     kombu: ''
     python: '>=3.7'
-    funcy: '>=1.17'
+    pywin32-on-windows: ''
     shortuuid: '>=1.0.8'
-    celery: '>=5.3.0,<6'
   url: https://conda.anaconda.org/conda-forge/noarch/dvc-task-0.4.0-pyhd8ed1ab_0.conda
   hash:
     md5: 99dd2e9046ade98deadd415ad5b143fe
@@ -4727,12 +4730,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     appdirs: ''
+    click: '>=5.1'
     filelock: ''
+    packaging: ''
     python: '>=3.7'
     requests: '>=2'
-    click: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
@@ -4744,12 +4747,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     appdirs: ''
+    click: '>=5.1'
     filelock: ''
+    packaging: ''
     python: '>=3.7'
     requests: '>=2'
-    click: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/ensureconda-1.4.4-pyhd8ed1ab_0.conda
   hash:
     md5: e54a91c3a65491b13c68f7696425bac8
@@ -4957,9 +4960,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
-    python: '>=3.6'
     pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
     six: '>=1.12,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
   hash:
@@ -4972,9 +4975,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
-    python: '>=3.6'
     pathlib2: '>=2.3,<3.0'
+    python: '>=3.6'
+    setuptools: ''
     six: '>=1.12,<2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/flatten-dict-0.4.2-pyhd8ed1ab_1.tar.bz2
   hash:
@@ -5001,8 +5004,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    psutil: ''
     atpublic: ''
+    psutil: ''
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-8.1.0-pyhd8ed1ab_0.conda
   hash:
@@ -5015,8 +5018,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    psutil: ''
     atpublic: ''
+    psutil: ''
     python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/flufl.lock-8.1.0-pyhd8ed1ab_0.conda
   hash:
@@ -5260,10 +5263,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
     font-ttf-ubuntu: ''
-    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -5275,10 +5278,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
     font-ttf-ubuntu: ''
-    font-ttf-dejavu-sans-mono: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -5695,9 +5698,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-    gitdb: '>=4.0.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
@@ -5709,9 +5712,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-    gitdb: '>=4.0.1,<5'
   url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
   hash:
     md5: 0b2154c1818111e17381b1df5b4b0176
@@ -6030,16 +6033,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    rich: ''
-    ruamel.yaml: ''
     entrypoints: ''
     funcy: ''
-    python: '>=3.9'
-    typer: '>=0.4.1'
-    tabulate: '>=0.8.10'
-    scmrepo: '>=3,<4'
     pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
     semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
@@ -6051,16 +6054,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    rich: ''
-    ruamel.yaml: ''
     entrypoints: ''
     funcy: ''
-    python: '>=3.9'
-    typer: '>=0.4.1'
-    tabulate: '>=0.8.10'
-    scmrepo: '>=3,<4'
     pydantic: '>=1.9.0,<3,!=2.0.0'
+    python: '>=3.9'
+    rich: ''
+    ruamel.yaml: ''
+    scmrepo: '>=3,<4'
     semver: '>=2.13.0'
+    tabulate: '>=0.8.10'
+    typer: '>=0.4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/gto-1.7.1-pyhd8ed1ab_1.conda
   hash:
     md5: ed39fb2671c7beeb6e87f8471392da64
@@ -6127,8 +6130,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
     python: '>=3'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -6140,8 +6143,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ''
     python: '>=3'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -6167,9 +6170,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -6181,9 +6184,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -6279,23 +6282,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    tomlkit: '>=0.11.1'
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
     httpx: '>=0.22.0'
     hyperlink: '>=21.0.0'
-    platformdirs: '>=2.5.0'
     keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
     shellingham: '>=1.4.0'
     tomli-w: '>=1.0'
-    packaging: '>=23.2'
-    click: '>=8.0.6'
-    zstandard: <1.0
-    hatchling: '>=1.24.2'
-    pexpect: '>=4.8,<5'
+    tomlkit: '>=0.11.1'
     userpath: '>=1.7,<2'
     uv: '>=0.1.35'
     virtualenv: '>=20.26.1'
+    zstandard: <1.0
   url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
   hash:
     md5: 75ef4cd9ebf1c870d9389d2af8c67a42
@@ -6307,23 +6310,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    rich: '>=11.2.0'
-    tomlkit: '>=0.11.1'
+    click: '>=8.0.6'
+    hatchling: '>=1.24.2'
     httpx: '>=0.22.0'
     hyperlink: '>=21.0.0'
-    platformdirs: '>=2.5.0'
     keyring: '>=23.5.0'
+    packaging: '>=23.2'
+    pexpect: '>=4.8,<5'
+    platformdirs: '>=2.5.0'
+    python: '>=3.8'
+    rich: '>=11.2.0'
     shellingham: '>=1.4.0'
     tomli-w: '>=1.0'
-    packaging: '>=23.2'
-    click: '>=8.0.6'
-    zstandard: <1.0
-    hatchling: '>=1.24.2'
-    pexpect: '>=4.8,<5'
+    tomlkit: '>=0.11.1'
     userpath: '>=1.7,<2'
     uv: '>=0.1.35'
     virtualenv: '>=20.26.1'
+    zstandard: <1.0
   url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.12.0-pyhd8ed1ab_0.conda
   hash:
     md5: 75ef4cd9ebf1c870d9389d2af8c67a42
@@ -6354,14 +6357,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: ''
-    trove-classifiers: ''
-    python: '>=3.7'
-    packaging: '>=21.3'
-    pluggy: '>=1.0.0'
-    pathspec: '>=0.10.1'
-    tomli: '>=1.2.2'
     editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7571d6e5561b04aef679a11904dfcebf
@@ -6373,14 +6376,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    importlib-metadata: ''
-    trove-classifiers: ''
-    python: '>=3.7'
-    packaging: '>=21.3'
-    pluggy: '>=1.0.0'
-    pathspec: '>=0.10.1'
-    tomli: '>=1.2.2'
     editables: '>=0.3'
+    importlib-metadata: ''
+    packaging: '>=21.3'
+    pathspec: '>=0.10.1'
+    pluggy: '>=1.0.0'
+    python: '>=3.7'
+    tomli: '>=1.2.2'
+    trove-classifiers: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.25.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7571d6e5561b04aef679a11904dfcebf
@@ -6443,8 +6446,8 @@ package:
   platform: osx-arm64
   dependencies:
     python: ''
-    webencodings: ''
     six: '>=1.9'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: b2355343d6315c892543200231d7154a
@@ -6457,8 +6460,8 @@ package:
   platform: win-64
   dependencies:
     python: ''
-    webencodings: ''
     six: '>=1.9'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
   hash:
     md5: b2355343d6315c892543200231d7154a
@@ -6487,12 +6490,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
   hash:
     md5: a6b9a0158301e697e4d0a36a3d60e133
@@ -6504,12 +6507,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
   hash:
     md5: a6b9a0158301e697e4d0a36a3d60e133
@@ -6538,12 +6541,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    certifi: ''
-    idna: ''
-    sniffio: ''
     anyio: ''
-    python: '>=3.8'
+    certifi: ''
     httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9f359af5a886fd6ca6b2b6ea02e58332
@@ -6555,12 +6558,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    certifi: ''
-    idna: ''
-    sniffio: ''
     anyio: ''
-    python: '>=3.8'
+    certifi: ''
     httpcore: 1.*
+    idna: ''
+    python: '>=3.8'
+    sniffio: ''
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
   hash:
     md5: 9f359af5a886fd6ca6b2b6ea02e58332
@@ -6568,7 +6571,7 @@ package:
   category: dev
   optional: true
 - name: huggingface_hub
-  version: 0.24.5
+  version: 0.24.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -6580,48 +6583,48 @@ package:
     requests: ''
     tqdm: '>=4.42.1'
     typing-extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c7bf55cfeefe35d28a15685c466ff61e
-    sha256: 6c163b98df32c151638ec2586f917a47e87d487d599165e4d49f260018436c6e
+    md5: 129d512e741eccfd55c51335b45647bb
+    sha256: 46bdcaa7f3058838615ef87580beb95f19a7f6b3fc584a30d277816e19011426
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.24.5
+  version: 0.24.6
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
     filelock: ''
+    fsspec: '>=2023.5.0'
+    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.9'
-    fsspec: '>=2023.5.0'
-    typing-extensions: '>=3.7.4.3'
+    requests: ''
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.5-pyhd8ed1ab_0.conda
+    typing-extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c7bf55cfeefe35d28a15685c466ff61e
-    sha256: 6c163b98df32c151638ec2586f917a47e87d487d599165e4d49f260018436c6e
+    md5: 129d512e741eccfd55c51335b45647bb
+    sha256: 46bdcaa7f3058838615ef87580beb95f19a7f6b3fc584a30d277816e19011426
   category: main
   optional: false
 - name: huggingface_hub
-  version: 0.24.5
+  version: 0.24.6
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
     filelock: ''
+    fsspec: '>=2023.5.0'
+    packaging: '>=20.9'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.9'
-    fsspec: '>=2023.5.0'
-    typing-extensions: '>=3.7.4.3'
+    requests: ''
     tqdm: '>=4.42.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.5-pyhd8ed1ab_0.conda
+    typing-extensions: '>=3.7.4.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.24.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c7bf55cfeefe35d28a15685c466ff61e
-    sha256: 6c163b98df32c151638ec2586f917a47e87d487d599165e4d49f260018436c6e
+    md5: 129d512e741eccfd55c51335b45647bb
+    sha256: 46bdcaa7f3058838615ef87580beb95f19a7f6b3fc584a30d277816e19011426
   category: main
   optional: false
 - name: hydra-core
@@ -6645,11 +6648,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    importlib_resources: ''
-    python: '>=3.6'
     antlr-python-runtime: 4.9.*
+    importlib_resources: ''
     omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
@@ -6661,11 +6664,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    importlib_resources: ''
-    python: '>=3.6'
     antlr-python-runtime: 4.9.*
+    importlib_resources: ''
     omegaconf: '>=2.2,<2.4'
+    packaging: ''
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/hydra-core-1.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: 297d09ccdcec5b347d44c88f2b61cf03
@@ -6726,8 +6729,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
     idna: '>=2.6'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
   hash:
     md5: 1303beb57b40f8f4ff6fb1bb23bf0553
@@ -6739,8 +6742,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: ''
     idna: '>=2.6'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyhd3deb0d_0.tar.bz2
   hash:
     md5: 1303beb57b40f8f4ff6fb1bb23bf0553
@@ -6804,8 +6807,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    ukkonen: ''
     python: '>=3.6'
+    ukkonen: ''
   url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: f80cc5989f445f23b1622d6c455896d9
@@ -6817,8 +6820,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ukkonen: ''
     python: '>=3.6'
+    ukkonen: ''
   url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
   hash:
     md5: f80cc5989f445f23b1622d6c455896d9
@@ -6862,117 +6865,117 @@ package:
   category: main
   optional: false
 - name: importlib-metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.4.0-pyha770c72_0.conda
   hash:
-    md5: c261d14fc7f49cdd403868998a18c318
-    sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
+    md5: 6e3dbc422d3749ad72659243d6ac8b2b
+    sha256: 02c95f6f62675012e0b2ab945eba6fc14fa6a693c17bced3554db7b62d586f0c
   category: dev
   optional: true
 - name: importlib-metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.4.0-pyha770c72_0.conda
   hash:
-    md5: c261d14fc7f49cdd403868998a18c318
-    sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
+    md5: 6e3dbc422d3749ad72659243d6ac8b2b
+    sha256: 02c95f6f62675012e0b2ab945eba6fc14fa6a693c17bced3554db7b62d586f0c
   category: dev
   optional: true
 - name: importlib-metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
     zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.4.0-pyha770c72_0.conda
   hash:
-    md5: c261d14fc7f49cdd403868998a18c318
-    sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
+    md5: 6e3dbc422d3749ad72659243d6ac8b2b
+    sha256: 02c95f6f62675012e0b2ab945eba6fc14fa6a693c17bced3554db7b62d586f0c
   category: dev
   optional: true
 - name: importlib_metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=8.2.0,<8.2.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.4.0,<8.4.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.4.0-hd8ed1ab_0.conda
   hash:
-    md5: 0fd030dce707a6654472cf7619b0b01b
-    sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
+    md5: 01b7411c765c3d863dcc920207f258bd
+    sha256: c9c782fdf59fb169220b69ea0bbefc3fdc7f58c9fdbdf2d6ff734aa033647b59
   category: dev
   optional: true
 - name: importlib_metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib-metadata: '>=8.2.0,<8.2.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.4.0,<8.4.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.4.0-hd8ed1ab_0.conda
   hash:
-    md5: 0fd030dce707a6654472cf7619b0b01b
-    sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
+    md5: 01b7411c765c3d863dcc920207f258bd
+    sha256: c9c782fdf59fb169220b69ea0bbefc3fdc7f58c9fdbdf2d6ff734aa033647b59
   category: dev
   optional: true
 - name: importlib_metadata
-  version: 8.2.0
+  version: 8.4.0
   manager: conda
   platform: win-64
   dependencies:
-    importlib-metadata: '>=8.2.0,<8.2.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
+    importlib-metadata: '>=8.4.0,<8.4.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.4.0-hd8ed1ab_0.conda
   hash:
-    md5: 0fd030dce707a6654472cf7619b0b01b
-    sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
+    md5: 01b7411c765c3d863dcc920207f258bd
+    sha256: c9c782fdf59fb169220b69ea0bbefc3fdc7f58c9fdbdf2d6ff734aa033647b59
   category: dev
   optional: true
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.4.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: 99aa3edd3f452d61c305a30e78140513
+    sha256: 13e277624eaef453af3ff4d925ba1169376baa7008eabd8eaae7c5772bec9fc2
   category: dev
   optional: true
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.4.4
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: 99aa3edd3f452d61c305a30e78140513
+    sha256: 13e277624eaef453af3ff4d925ba1169376baa7008eabd8eaae7c5772bec9fc2
   category: dev
   optional: true
 - name: importlib_resources
-  version: 6.4.0
+  version: 6.4.4
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c5d3907ad8bd7bf557521a1833cf7e6d
-    sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
+    md5: 99aa3edd3f452d61c305a30e78140513
+    sha256: 13e277624eaef453af3ff4d925ba1169376baa7008eabd8eaae7c5772bec9fc2
   category: dev
   optional: true
 - name: iniconfig
@@ -7012,14 +7015,14 @@ package:
   category: dev
   optional: true
 - name: intel-openmp
-  version: 2024.2.0
+  version: 2024.2.1
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
   hash:
-    md5: 9c28c39e64871a0adef7d1195bd58655
-    sha256: e3ddfb67e0a922868e68f83d0b56755ff1c280ffa959a0c5ee6a922aaf7022b0
+    md5: 2d89243bfb53652c182a7c73182cce4f
+    sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
   category: main
   optional: false
 - name: ipykernel
@@ -7052,20 +7055,20 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    psutil: ''
-    nest-asyncio: ''
     __osx: ''
     appnope: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
     matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
     pyzmq: '>=24'
-    comm: '>=0.1.1'
+    tornado: '>=6.1'
     traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
   hash:
@@ -7078,19 +7081,19 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    psutil: ''
     __win: ''
-    nest-asyncio: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
     matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
     pyzmq: '>=24'
-    comm: '>=0.1.1'
+    tornado: '>=6.1'
     traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
   hash:
@@ -7130,14 +7133,14 @@ package:
     __unix: ''
     decorator: ''
     exceptiongroup: ''
-    matplotlib-inline: ''
-    stack_data: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
     jedi: '>=0.16'
+    matplotlib-inline: ''
     pexpect: '>4.3'
+    pickleshare: ''
     prompt-toolkit: '>=3.0.41,<3.1.0'
+    pygments: '>=2.4.0'
+    python: '>=3.10'
+    stack_data: ''
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
@@ -7151,17 +7154,17 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    colorama: ''
     __win: ''
+    colorama: ''
     decorator: ''
     exceptiongroup: ''
-    matplotlib-inline: ''
-    stack_data: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
     jedi: '>=0.16'
+    matplotlib-inline: ''
+    pickleshare: ''
     prompt-toolkit: '>=3.0.41,<3.1.0'
+    pygments: '>=2.4.0'
+    python: '>=3.10'
+    stack_data: ''
     traitlets: '>=5.13.0'
     typing_extensions: '>=4.6'
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
@@ -7188,8 +7191,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     arrow: '>=0.15.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -7201,8 +7204,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     arrow: '>=0.15.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -7230,11 +7233,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
     appdirs: ''
-    filelock: ''
     distro: ''
+    filelock: ''
     python: '>=3.7'
+    requests: ''
   url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
@@ -7246,11 +7249,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
     appdirs: ''
-    filelock: ''
     distro: ''
+    filelock: ''
     python: '>=3.7'
+    requests: ''
   url: https://conda.anaconda.org/conda-forge/noarch/iterative-telemetry-0.0.8-pyhd8ed1ab_0.conda
   hash:
     md5: 6eb5ad35a97da6f5efe7689ead4ab79f
@@ -7392,8 +7395,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -7405,8 +7408,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
     parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -7443,8 +7446,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -7456,8 +7459,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -7532,8 +7535,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -7545,8 +7548,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -7651,11 +7654,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
     jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
@@ -7669,11 +7672,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
     jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
@@ -7701,8 +7704,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     importlib_resources: '>=1.4.0'
+    python: '>=3.8'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
   hash:
@@ -7715,8 +7718,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     importlib_resources: '>=1.4.0'
+    python: '>=3.8'
     referencing: '>=0.31.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
   hash:
@@ -7749,14 +7752,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
     fqdn: ''
+    idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    rfc3986-validator: '>0.1.0'
     jsonschema: '>=4.23.0,<4.23.1.0a0'
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
     webcolors: '>=24.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
   hash:
@@ -7769,14 +7772,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
     fqdn: ''
+    idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    rfc3986-validator: '>0.1.0'
     jsonschema: '>=4.23.0,<4.23.1.0a0'
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
     webcolors: '>=24.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
   hash:
@@ -7803,9 +7806,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 885867f6adab3d7ecdf8ab6ca0785f51
@@ -7817,9 +7820,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 885867f6adab3d7ecdf8ab6ca0785f51
@@ -7849,13 +7852,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    tornado: '>=6.2'
     pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: 3cdbb2fa84490e5fd44c9f9806c0d292
@@ -7867,13 +7870,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    tornado: '>=6.2'
     pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: 3cdbb2fa84490e5fd44c9f9806c0d292
@@ -7950,14 +7953,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
     md5: ed45423c41b3da15ea1df39b1f80c2ca
@@ -7969,14 +7972,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
     md5: ed45423c41b3da15ea1df39b1f80c2ca
@@ -8018,24 +8021,24 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    jinja2: '>=3.0.3'
-    pyzmq: '>=24'
-    packaging: '>=22.0'
-    nbconvert-core: '>=6.4.4'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
     anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
-    jupyter_events: '>=0.9.0'
     argon2-cffi: '>=21.1'
+    jinja2: '>=3.0.3'
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.9.0'
     jupyter_server_terminals: '>=0.4.4'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
     overrides: '>=5.0'
+    packaging: '>=22.0'
     prometheus_client: '>=0.9'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
   hash:
@@ -8048,24 +8051,24 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    jinja2: '>=3.0.3'
-    pyzmq: '>=24'
-    packaging: '>=22.0'
-    nbconvert-core: '>=6.4.4'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
     anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
-    jupyter_events: '>=0.9.0'
     argon2-cffi: '>=21.1'
+    jinja2: '>=3.0.3'
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.9.0'
     jupyter_server_terminals: '>=0.4.4'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
     overrides: '>=5.0'
+    packaging: '>=22.0'
     prometheus_client: '>=0.9'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
   hash:
@@ -8145,23 +8148,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    tomli: '>=1.2.2'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
     async-lru: '>=1.0.0'
-    notebook-shim: '>=0.2'
-    setuptools: '>=40.1.0'
     httpx: '>=0.25.0'
-    jupyterlab_server: '>=2.27.1,<3'
+    importlib_metadata: '>=4.8.3'
+    importlib_resources: '>=1.4'
     ipykernel: '>=6.5.0'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    setuptools: '>=40.1.0'
+    tomli: '>=1.2.2'
+    tornado: '>=6.2.0'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 28f3334e97c39de2b7ac15743b041784
@@ -8173,23 +8176,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    tomli: '>=1.2.2'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
     async-lru: '>=1.0.0'
-    notebook-shim: '>=0.2'
-    setuptools: '>=40.1.0'
     httpx: '>=0.25.0'
-    jupyterlab_server: '>=2.27.1,<3'
+    importlib_metadata: '>=4.8.3'
+    importlib_resources: '>=1.4'
     ipykernel: '>=6.5.0'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    setuptools: '>=40.1.0'
+    tomli: '>=1.2.2'
+    tornado: '>=6.2.0'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 28f3334e97c39de2b7ac15743b041784
@@ -8214,8 +8217,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     pygments: '>=2.4.1,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -8227,8 +8230,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     pygments: '>=2.4.1,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -8260,15 +8263,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.21,<3'
-    requests: '>=2.31'
     babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
     json5: '>=0.9.0'
     jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
   hash:
     md5: af8239bf1ba7e8c69b689f780f653488
@@ -8280,15 +8283,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.21,<3'
-    requests: '>=2.31'
     babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
     json5: '>=0.9.0'
     jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
   hash:
     md5: af8239bf1ba7e8c69b689f780f653488
@@ -8318,13 +8321,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pyyaml: ''
-    packaging: ''
-    tomli: ''
-    nbformat: ''
-    mdit-py-plugins: ''
-    python: '>=3.8'
     markdown-it-py: '>=1.0'
+    mdit-py-plugins: ''
+    nbformat: ''
+    packaging: ''
+    python: '>=3.8'
+    pyyaml: ''
+    tomli: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.4-pyh80e38bb_0.conda
   hash:
     md5: 1df7fd1594a7f2f6496ff23834a099bf
@@ -8336,13 +8339,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pyyaml: ''
-    packaging: ''
-    tomli: ''
-    nbformat: ''
-    mdit-py-plugins: ''
-    python: '>=3.8'
     markdown-it-py: '>=1.0'
+    mdit-py-plugins: ''
+    nbformat: ''
+    packaging: ''
+    python: '>=3.8'
+    pyyaml: ''
+    tomli: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.16.4-pyh80e38bb_0.conda
   hash:
     md5: 1df7fd1594a7f2f6496ff23834a099bf
@@ -8374,13 +8377,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    importlib_resources: ''
     __osx: ''
-    jaraco.classes: ''
-    jaraco.functools: ''
-    jaraco.context: ''
-    python: '>=3.8'
     importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.3.0-pyh534df25_0.conda
   hash:
     md5: 3644a2cfda8f481d83edd95feacc4cf7
@@ -8392,13 +8395,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    importlib_resources: ''
     __win: ''
-    jaraco.classes: ''
-    jaraco.functools: ''
-    jaraco.context: ''
-    python: '>=3.8'
     importlib_metadata: '>=4.11.4'
+    importlib_resources: ''
+    jaraco.classes: ''
+    jaraco.context: ''
+    jaraco.functools: ''
+    python: '>=3.8'
     pywin32-ctypes: '>=0.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.3.0-pyh7428d3b_0.conda
   hash:
@@ -8549,16 +8552,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: '>=1.0'
-    numpy: '>=1.19'
-    scipy: '>=1.2'
-    python: '>=3.7.0'
-    psutil: '>=5'
     binpickle: '>=0.3.2'
     cffi: '>=1.12.2'
     csr: '>=0.3.1'
-    seedbank: '>=0.1.0'
     numba: '>=0.51,<0.59'
+    numpy: '>=1.19'
+    pandas: '>=1.0'
+    psutil: '>=5'
+    python: '>=3.7.0'
+    scipy: '>=1.2'
+    seedbank: '>=0.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/lenskit-0.14.4-pyhd8ed1ab_0.conda
   hash:
     md5: d3f95eaf0ca981e4831d603f3eb87e2f
@@ -8570,16 +8573,16 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pandas: '>=1.0'
-    numpy: '>=1.19'
-    scipy: '>=1.2'
-    python: '>=3.7.0'
-    psutil: '>=5'
     binpickle: '>=0.3.2'
     cffi: '>=1.12.2'
     csr: '>=0.3.1'
-    seedbank: '>=0.1.0'
     numba: '>=0.51,<0.59'
+    numpy: '>=1.19'
+    pandas: '>=1.0'
+    psutil: '>=5'
+    python: '>=3.7.0'
+    scipy: '>=1.2'
+    seedbank: '>=0.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/lenskit-0.14.4-pyhd8ed1ab_0.conda
   hash:
     md5: d3f95eaf0ca981e4831d603f3eb87e2f
@@ -8671,7 +8674,7 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     aws-sdk-cpp: '>=1.11.379,<1.11.380.0a0'
     azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
     azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
@@ -8683,22 +8686,22 @@ package:
     libabseil: '>=20240116.2,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libgoogle-cloud: '>=2.28.0,<2.29.0a0'
     libgoogle-cloud-storage: '>=2.28.0,<2.29.0a0'
     libre2-11: '>=2023.9.1,<2024.0a0'
-    libstdcxx-ng: '>=12'
+    libstdcxx-ng: '>=13'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h03aeac6_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h9d17f36_9_cpu.conda
   hash:
-    md5: 25225d90d4fb125c5fbb6f87cc1aa309
-    sha256: 745e9f84761da075f0bbe0f0279f0b74aeb1c29811e3eaa9d46f8de1ad897887
+    md5: bfae79329f50d5bd960e1ac289625096
+    sha256: 0f0123e7e7eddfa8cf56b71534570d43304d730e4891a8c26c5754cb8d0b4e5f
   category: main
   optional: false
 - name: libarrow
@@ -8707,7 +8710,7 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     aws-sdk-cpp: '>=1.11.379,<1.11.380.0a0'
     azure-core-cpp: '>=1.13.0,<1.13.1.0a0'
     azure-identity-cpp: '>=1.8.0,<1.8.1.0a0'
@@ -8725,14 +8728,14 @@ package:
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h8291d6d_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h99ce08b_9_cpu.conda
   hash:
-    md5: 7d9804101f27f7574660b5ab86893311
-    sha256: 886fcffced2e968d1f48768c846ab2ea44017bc62af3ee42774c236bb4fb9487
+    md5: a6575c429addf689ef5c8f1b20d32c30
+    sha256: 90fe38e3491fd51b1817eaf92ee278c391a649e73d4452c1a2eeb4a06db2d080
   category: main
   optional: false
 - name: libarrow
@@ -8740,7 +8743,7 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aws-crt-cpp: '>=0.27.5,<0.27.6.0a0'
+    aws-crt-cpp: '>=0.27.6,<0.27.7.0a0'
     aws-sdk-cpp: '>=1.11.379,<1.11.380.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     libabseil: '>=20240116.2,<20240117.0a0'
@@ -8754,17 +8757,17 @@ package:
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=2.0.1,<2.0.2.0a0'
+    orc: '>=2.0.2,<2.0.3.0a0'
     re2: ''
     snappy: '>=1.2.1,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h009c9d4_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-hd7a7e94_9_cpu.conda
   hash:
-    md5: de9fcb1a5fcb0071ef97547cb387c99e
-    sha256: ee2cd257ffdb6ace2e3989261562f3e71dd032414e8e8668fdb8065e5f84d974
+    md5: 2da51853728cf3a917c24d8a6090f9e2
+    sha256: 46b35304267d328bfec5380dd686027f413160edb4faa7f60a40efa566b6ca35
   category: main
   optional: false
 - name: libarrow-acero
@@ -8774,12 +8777,12 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libarrow: 17.0.0
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_7_cpu.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-h5888daf_9_cpu.conda
   hash:
-    md5: 64ba31c035986db4e46f98410607498e
-    sha256: d0f5d0ae8266d83de7b1398c061d5b499c6899742029d80a262f34d3b613012d
+    md5: cace9fe91c532c67ff828937a633fb1c
+    sha256: 52e550e5bad1e05e0d286ace999b27f0781a6913461914f069aa7f5214d9ec42
   category: main
   optional: false
 - name: libarrow-acero
@@ -8790,10 +8793,10 @@ package:
     __osx: '>=11.0'
     libarrow: 17.0.0
     libcxx: '>=17'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-hf9b8971_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-hf9b8971_9_cpu.conda
   hash:
-    md5: 71db0266dc5ac9af106661fce2425879
-    sha256: 4f33d6e2e468fa17cedd7b35919ec6435cf59d6ce09c8b1d334e7f66c61b9b1b
+    md5: d31e18b377c26bcfe0661c476e6f87ef
+    sha256: 6b86e90891d60f8bb04120bbae137942ea2bc74f001725f89712dd8036c7d574
   category: main
   optional: false
 - name: libarrow-acero
@@ -8805,10 +8808,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_9_cpu.conda
   hash:
-    md5: 0e9e900f3b3d9e3601bc1103bc8a3e66
-    sha256: d3b6d7f16e3ad80c4838d29ae04dc2e98a6c7490f98dbdcd61879577df3f0c3c
+    md5: cff768559d393e7d7d4ef73321ad6b92
+    sha256: fa3b9331927dc558b4c4f63f6448c17ac1493ae522070d7bb81c65a08d246bed
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8819,13 +8822,13 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libarrow: 17.0.0
     libarrow-acero: 17.0.0
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libparquet: 17.0.0
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_7_cpu.conda
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-h5888daf_9_cpu.conda
   hash:
-    md5: ad26d57360f2019840af562ddf3cb7d2
-    sha256: 8ff60afa166498ec5372e851c80a7616c3298c1ac4bcfb386767c62c0acf6a35
+    md5: 4df21168065a9e21372a442783dfd547
+    sha256: 8767bf188e327ee316677dbd25fd23412ab892c96088c9cfe284a59bf4e616db
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8838,10 +8841,10 @@ package:
     libarrow-acero: 17.0.0
     libcxx: '>=17'
     libparquet: 17.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf9b8971_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf9b8971_9_cpu.conda
   hash:
-    md5: 9ffdcd17c28f0a9f1460e348a35b1b34
-    sha256: 0fa20fe8db8c75b22b7d774adb0ef819a99514ce943444b5223ca59c9855f7c1
+    md5: 048d15076603af57e6176a73c174378c
+    sha256: 7d19b262a556dc748ef1f3bb78a69b71877b233258269d500085732ca6178112
   category: main
   optional: false
 - name: libarrow-dataset
@@ -8855,10 +8858,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_9_cpu.conda
   hash:
-    md5: 8061090285b4938e67d540e0b9ff5db4
-    sha256: 71e8115bdf27c6018ef6e979a20cf012b0690c37d5e5dc23ecdfb8e9fd260323
+    md5: 5c81b03ba270a713450bfd8d2f7beeab
+    sha256: dd2468687935255cba721c951e1861c4ab7ea4d50edd0165ab4cfbe992fc904b
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8871,13 +8874,13 @@ package:
     libarrow: 17.0.0
     libarrow-acero: 17.0.0
     libarrow-dataset: 17.0.0
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_7_cpu.conda
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hf54134d_9_cpu.conda
   hash:
-    md5: a0207293ee147d04b46b44d60266d964
-    sha256: 88177f0e86b87579e1fbb3f7c8bc9a128d364d342efb971f65df2f514ddb96f3
+    md5: 239401053cfbf93d24795b12dec89c56
+    sha256: c1441e1f6b16078e8451cd82934a84ec0e97b9f5eb54d2105d4a96f5d1991746
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8892,10 +8895,10 @@ package:
     libarrow-dataset: 17.0.0
     libcxx: '>=17'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-hbf8b706_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-hbf8b706_9_cpu.conda
   hash:
-    md5: 56d81c943b2312e4e687c011615892c5
-    sha256: 280d2928bb967191c0418eedefc0f3bcdb008f753720ee5adc4f07d5ee084e36
+    md5: 90b1e4d2909aac9b77507542c6fd7b31
+    sha256: 9d8e24dfc6ae7b204b7ef79a219a5fb1be536ace7ffa733df12d096c852d3667
   category: main
   optional: false
 - name: libarrow-substrait
@@ -8911,10 +8914,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_9_cpu.conda
   hash:
-    md5: 401e5d425e17ecdb2720e61027d28e17
-    sha256: 84ed8cebf00e27e2642295c633e7d45ec919b66ae3ec848d7a50d95156c131bd
+    md5: d8869ddb1e03839e929db4ee656a8d8b
+    sha256: 3608bb2174f05ee9f9dadda260145e8bababe1a8182783a36b77729e33f4702c
   category: main
   optional: false
 - name: libblas
@@ -10091,14 +10094,14 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libarrow: 17.0.0
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     libthrift: '>=0.20.0,<0.20.1.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-h39682fd_9_cpu.conda
   hash:
-    md5: 7448f406b12fc479eb5a7dbf485c0428
-    sha256: 93ccb279a9a60fc1c713bbf5eb224eb1eeedadac3f6114a7c00a3880e2a4b172
+    md5: 0efe4b18e72f519298f57ff75a9adf07
+    sha256: 441fc3d681cb5945f724d67a9b60f93331faf65ac9754c44769e6fe6caacbb79
   category: main
   optional: false
 - name: libparquet
@@ -10111,10 +10114,10 @@ package:
     libcxx: '>=17'
     libthrift: '>=0.20.0,<0.20.1.0a0'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-hf0ba9ef_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-hf0ba9ef_9_cpu.conda
   hash:
-    md5: f56bbf8ee8e0eb23996680f5d756f7f5
-    sha256: 12afb9888832454ba3d2c1500dd8216c7f2d010e948932b6bff6761489a732ca
+    md5: de447a5f54986bf01a02363bba8a9c11
+    sha256: 7450a46f7e21fe60c62f7a4fe89392f1c1452e08d22a73170d0501a163df654f
   category: main
   optional: false
 - name: libparquet
@@ -10128,10 +10131,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_7_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_9_cpu.conda
   hash:
-    md5: d79854c11a34dc6b2f81153c0222394a
-    sha256: a84c8174e168146f6a50d96ea89bb80e440615b55301badfb86f49544d527a6e
+    md5: 091a44732b7510b795553f5b75723bd2
+    sha256: db5c3874e7ecda8114db421dd750512f31880ad8c780400b280ddf96ec5c3874
   category: main
   optional: false
 - name: libpng
@@ -10262,7 +10265,7 @@ package:
   category: main
   optional: false
 - name: librsvg
-  version: 2.58.2
+  version: 2.58.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -10276,14 +10279,14 @@ package:
     libpng: '>=1.6.43,<1.7.0a0'
     libxml2: '>=2.12.7,<3.0a0'
     pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.2-h9564881_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.3-h9564881_0.conda
   hash:
-    md5: c6a47e6f551890e82e92e4c1b84be353
-    sha256: 74221fe0218f537dfd1db9c451e81d0fed7df6b3128a46e6b0dc493db02f332d
+    md5: a7045ed6fb8b68ef7be002ce615e3bf6
+    sha256: 45f98c031891178ff2d83adf96d05610e842a0df62996ffc31fdcb93ec529020
   category: dev
   optional: true
 - name: librsvg
-  version: 2.58.2
+  version: 2.58.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10293,10 +10296,10 @@ package:
     libglib: '>=2.80.3,<3.0a0'
     libxml2: '>=2.12.7,<3.0a0'
     pango: '>=1.54.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.2-h1db61d3_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.58.3-h1db61d3_0.conda
   hash:
-    md5: c8113d5911f1d6a6259e47e729db6751
-    sha256: ec39d4e8c4da23243875edeb565f7ef948f590de481fb3d2a15b66115621bf81
+    md5: 7f3d6302615698e74d0b5e28d680b744
+    sha256: f283c67631655cb951f4cba4b4f4429d369d0984f32b3e507c4877d7b85d7238
   category: dev
   optional: true
 - name: libsodium
@@ -10560,7 +10563,7 @@ package:
   category: main
   optional: false
 - name: libtorch
-  version: 2.3.1
+  version: 2.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -10576,10 +10579,10 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     sleef: '>=3.5.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.3.1-cpu_generic_hac4f340_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.4.0-cpu_generic_hac4f340_0.conda
   hash:
-    md5: a9a9930a9a027acb05c5b32db5e6a76e
-    sha256: 6b1b293e4e023534964b1f51e1e5573dcc58d9b913029d9a4499ecfe373fc09c
+    md5: d82068558ca935c91d2bddb3d8e985de
+    sha256: 1d90e546b83ba720915145cbd9bff3cc3d736695790117628079b98d341b0b68
   category: main
   optional: false
 - name: libutf8proc
@@ -10727,14 +10730,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc-ng: '>=13'
     pthread-stubs: ''
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hb9d3cd8_1.conda
   hash:
-    md5: 151cba22b85a989c2d6ef9633ffee1e4
-    sha256: 7180375f37fd264bb50672a63da94536d4abd81ccec059e932728ae056324b3a
+    md5: 3601598f0db0470af28985e3e7ad0158
+    sha256: 33aa5fc997468b07ab3020b142eacc5479e4e2c2169f467b20ab220f33dd08de
   category: dev
   optional: true
 - name: libxcb
@@ -10747,10 +10751,10 @@ package:
     pthread-stubs: ''
     xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-h013a479_1.conda
   hash:
-    md5: 7c1217d3b075f195ab17370f2d550f5d
-    sha256: 3b1f3b04baa370cfb1c350cfa829e6236519df5f03e3f57ea2cb2eb044eb8616
+    md5: f0b599acdc82d5bc7e3b105833e7c5c8
+    sha256: abae56e12a4c62730b899fdfb82628a9ac171c4ce144fc9f34ae024957a82a0e
   category: dev
   optional: true
 - name: libxcrypt
@@ -11038,8 +11042,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     mdurl: '>=0.1,<1'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
@@ -11051,8 +11055,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     mdurl: '>=0.1,<1'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: 93a8e71256479c62074356ef6ebf501b
@@ -11120,8 +11124,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    traitlets: ''
     python: '>=3.6'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
     md5: 779345c95648be40d22aaa89de7d4254
@@ -11133,8 +11137,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    traitlets: ''
     python: '>=3.6'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
     md5: 779345c95648be40d22aaa89de7d4254
@@ -11159,8 +11163,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     markdown-it-py: '>=1.0.0,<4.0.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: eb90dd178bcdd0260dfaa6e1cbccf042
@@ -11172,8 +11176,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     markdown-it-py: '>=1.0.0,<4.0.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.1-pyhd8ed1ab_0.conda
   hash:
     md5: eb90dd178bcdd0260dfaa6e1cbccf042
@@ -11558,10 +11562,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
+    python: '>=3.8'
     traitlets: '>=5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
   hash:
@@ -11574,10 +11578,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
+    python: '>=3.8'
     traitlets: '>=5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
   hash:
@@ -11618,23 +11622,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     beautifulsoup4: ''
-    defusedxml: ''
     bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
+    defusedxml: ''
     entrypoints: '>=0.2.2'
-    markupsafe: '>=2.0'
+    jinja2: '>=3.0'
     jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
+    jupyterlab_pygments: ''
+    markupsafe: '>=2.0'
     mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
   hash:
     md5: e2d2abb421c13456a9a9f80272fdf543
@@ -11646,23 +11650,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     beautifulsoup4: ''
-    defusedxml: ''
     bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
+    defusedxml: ''
     entrypoints: '>=0.2.2'
-    markupsafe: '>=2.0'
+    jinja2: '>=3.0'
     jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
+    jupyterlab_pygments: ''
+    markupsafe: '>=2.0'
     mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
   hash:
     md5: e2d2abb421c13456a9a9f80272fdf543
@@ -11690,11 +11694,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '>=4.12,!=5.0.*'
-    traitlets: '>=5.1'
     jsonschema: '>=2.6'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
     python-fastjsonschema: '>=2.15'
+    traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
     md5: 0b57b5368ab7fc7cdc9e3511fa867214
@@ -11706,11 +11710,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '>=4.12,!=5.0.*'
-    traitlets: '>=5.1'
     jsonschema: '>=2.6'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
     python-fastjsonschema: '>=2.15'
+    traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
     md5: 0b57b5368ab7fc7cdc9e3511fa867214
@@ -11813,51 +11817,51 @@ package:
   category: main
   optional: false
 - name: nltk
-  version: 3.8.1
+  version: 3.9.1
   manager: conda
   platform: linux-64
   dependencies:
     click: ''
     joblib: ''
-    python: '>=3.7'
+    python: '>=3.8'
     regex: '>=2021.8.3'
     tqdm: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 518c769ca4273480a99be6e559a26192
-    sha256: ac5403c253608cb76e7f14e51902f02516cbc18edb9eebf62f1bcd0648d0ac6b
+    md5: 7e580f0694e487c3890d3ce67d5df98c
+    sha256: c08385f927550125aebe7880cafc7071f4e1c3aeebf72920e2f9ccb63e486a33
   category: main
   optional: false
 - name: nltk
-  version: 3.8.1
+  version: 3.9.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    tqdm: ''
     click: ''
     joblib: ''
-    python: '>=3.7'
+    python: '>=3.8'
     regex: '>=2021.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 518c769ca4273480a99be6e559a26192
-    sha256: ac5403c253608cb76e7f14e51902f02516cbc18edb9eebf62f1bcd0648d0ac6b
+    md5: 7e580f0694e487c3890d3ce67d5df98c
+    sha256: c08385f927550125aebe7880cafc7071f4e1c3aeebf72920e2f9ccb63e486a33
   category: main
   optional: false
 - name: nltk
-  version: 3.8.1
+  version: 3.9.1
   manager: conda
   platform: win-64
   dependencies:
-    tqdm: ''
     click: ''
     joblib: ''
-    python: '>=3.7'
+    python: '>=3.8'
     regex: '>=2021.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.8.1-pyhd8ed1ab_0.conda
+    tqdm: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 518c769ca4273480a99be6e559a26192
-    sha256: ac5403c253608cb76e7f14e51902f02516cbc18edb9eebf62f1bcd0648d0ac6b
+    md5: 7e580f0694e487c3890d3ce67d5df98c
+    sha256: c08385f927550125aebe7880cafc7071f4e1c3aeebf72920e2f9ccb63e486a33
   category: main
   optional: false
 - name: nodeenv
@@ -11878,8 +11882,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: 2.7|>=3.7
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
@@ -11891,8 +11895,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: 2.7|>=3.7
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
   hash:
     md5: dfe0528d0f1c16c1f7c528ea5536ab30
@@ -11991,12 +11995,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab: '>=4.2.0,<4.3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2,<0.3'
     python: '>=3.8'
     tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab_server: '>=2.27.1,<3'
-    jupyterlab: '>=4.2.0,<4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: 08fa71a038c2cac2e636a5a456df15d5
@@ -12008,12 +12012,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab: '>=4.2.0,<4.3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2,<0.3'
     python: '>=3.8'
     tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab_server: '>=2.27.1,<3'
-    jupyterlab: '>=4.2.0,<4.3'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: 08fa71a038c2cac2e636a5a456df15d5
@@ -12038,8 +12042,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -12051,8 +12055,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -12113,24 +12117,25 @@ package:
   category: main
   optional: false
 - name: numcodecs
-  version: 0.12.1
+  version: 0.13.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     msgpack-python: ''
     numpy: '>=1.7'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py311h4332511_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.13.0-py311h044e617_0.conda
   hash:
-    md5: 887aa6096851eab5c34fe95ed1641591
-    sha256: 40683eac07dc08ff26d64434cbd594b124791d6dd80c7e3c84664382ed6a1095
+    md5: 9d783b29b6fc53e4d9a94f5befdfd34b
+    sha256: ebd6ea0ad41f7a6d6fca5cf9091317729897b77a5f241106fa0b4904ca84b3c4
   category: main
   optional: false
 - name: numcodecs
-  version: 0.12.1
+  version: 0.13.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12140,14 +12145,14 @@ package:
     numpy: '>=1.7'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py311hb9542d7_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.13.0-py311h4b4568b_0.conda
   hash:
-    md5: a2dd6003034a0a0c708a5917e9b4b532
-    sha256: a600002fbe6eade8613fc8aa43d41bb72d7fb070b70ffef07e36a7f4ab7b9a26
+    md5: ba27f2e3815d8eb49056b2ebf373f42c
+    sha256: dffa47dc672422dfc3f7aacb9e07c9c44d38adccf454042b37533fee38ed5bec
   category: main
   optional: false
 - name: numcodecs
-  version: 0.12.1
+  version: 0.13.0
   manager: conda
   platform: win-64
   dependencies:
@@ -12158,10 +12163,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py311hda3d55a_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.13.0-py311hcf9f919_0.conda
   hash:
-    md5: 1ef4d26104201076053465f1346d0915
-    sha256: 95dca18d0e9339f8a8f5e061e470bfb9074c4f8d1fff9ebe0ccb5ff4489f80f9
+    md5: 7d27caafe308637d556039f5273aa9c4
+    sha256: 049845874967ee4eed55c3303210322e509ad6855731ee65367219b5b3b4a5fb
   category: main
   optional: false
 - name: numpy
@@ -12238,10 +12243,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
+    antlr-python-runtime: 4.9.*
     python: '>=3.7'
     pyyaml: '>=5.1.0'
-    antlr-python-runtime: 4.9.*
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
@@ -12253,10 +12258,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ''
+    antlr-python-runtime: 4.9.*
     python: '>=3.7'
     pyyaml: '>=5.1.0'
-    antlr-python-runtime: 4.9.*
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/omegaconf-2.3.0-pyhd8ed1ab_0.conda
   hash:
     md5: 23cc056834cab53849b91f78d6ee3ea0
@@ -12270,11 +12275,11 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
+    libgcc-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-hb9d3cd8_3.conda
   hash:
-    md5: e1b454497f9f7c1147fdde4b53f1b512
-    sha256: b294b3cc706ad1048cdb514f0db3da9f37ae3fcc0c53a7104083dd0918adb200
+    md5: 6c566a46baae794daf34775d41eb180a
+    sha256: 9e27441b273a7cf9071f6e88ba9ad565d926d8083b154c64a74b99fba167b137
   category: main
   optional: false
 - name: openssl
@@ -12284,10 +12289,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-h8359307_3.conda
   hash:
-    md5: 9b551a504c1cc8f8b7b22c01814da8ba
-    sha256: dd7d988636f74473ebdfe15e05c5aabdb53a1d2a846c839d62289b0c37f81548
+    md5: 644904d696d83c0ac78d594e0cf09f66
+    sha256: 9dd1ee7a8c21ff4fcbb98e9d0be0e83e5daf8a555c73589ad9e3046966b72e5e
   category: main
   optional: false
 - name: openssl
@@ -12299,68 +12304,69 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_3.conda
   hash:
-    md5: 375dbc2a4d5a2e4c738703207e8e368b
-    sha256: d86c4fa31294ad9068717788197e97e5637e056c82745ffb6d0e88fd1fef1a9d
+    md5: c6ebd3a1a2b393e040ca71c9f9ef8d97
+    sha256: 76a10564ca450f56495cff06bf60bdf0fe42e6ef7a20469276894d4ac7c0140a
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
   hash:
-    md5: 3bf65f0d8e7322a1cfe8b670fa35ec81
-    sha256: d340c67b23fb0e1ef7e13574dd4a428f360bfce93b2a588b3b63625926b038d6
+    md5: 1e6c10f7d749a490612404efeb179eb8
+    sha256: 8a126e0be7f87c499f0a9b5229efa4321e60fc4ae46abdec9b13240631cb1746
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=16'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.1-h47ade37_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.2-h75dedd0_0.conda
   hash:
-    md5: cd1013678ccef9b552335004f20a2d26
-    sha256: 567a9677258cdd03484e3045255bf10a9d8f1031c5030ef83f1fdc1a1ad6f401
+    md5: 9c89e09cede143716b479c5eacc924fb
+    sha256: a23f3a88a6b16363bd13f964b4abd12be1576abac460126f3269cbed12d04840
   category: main
   optional: false
 - name: orc
-  version: 2.0.1
+  version: 2.0.2
   manager: conda
   platform: win-64
   dependencies:
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    snappy: '>=1.2.0,<1.3.0a0'
+    snappy: '>=1.2.1,<1.3.0a0'
     tzdata: ''
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.2-h784c2ca_0.conda
   hash:
-    md5: 97012c0aeee0bf55c05b5ec42cac0864
-    sha256: 8aca1dcb6e9b3e71ffbec26c2b84f45fa682d9075b78cd30acc48044b64149ec
+    md5: dbb01d6e4f992ea4f0dcb049ab926cc7
+    sha256: f083c8f49430ca80b6d8a776c37bc1021075dc5f826527c44a85f90607a5c652
   category: main
   optional: false
 - name: orjson
@@ -12423,8 +12429,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_utils: ''
     python: '>=3.6'
+    typing_utils: ''
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -12436,8 +12442,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_utils: ''
     python: '>=3.6'
+    typing_utils: ''
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -12606,12 +12612,12 @@ package:
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
     harfbuzz: '>=9.0.0,<10.0a0'
-    libglib: '>=2.80.2,<3.0a0'
+    libglib: '>=2.80.3,<3.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.54.0-h9ee27a3_2.conda
   hash:
-    md5: 362011ec7d84f31f77ba13398c33cf6b
-    sha256: 49b70f3d230381e3b1e6c036569455972130230462e0c53870b5c7135f5de467
+    md5: af2a2118261adf2d7a350d6767b450f2
+    sha256: cfa2d11204bb75f6fbcfe1ff0cc1f6e4fc01185bf07b8eee8f698bfbd3702a79
   category: dev
   optional: true
 - name: pango
@@ -12625,15 +12631,15 @@ package:
     freetype: '>=2.12.1,<3.0a0'
     fribidi: '>=1.0.10,<2.0a0'
     harfbuzz: '>=9.0.0,<10.0a0'
-    libglib: '>=2.80.2,<3.0a0'
+    libglib: '>=2.80.3,<3.0a0'
     libpng: '>=1.6.43,<1.7.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.54.0-hbb871f6_2.conda
   hash:
-    md5: bf639fd83deb4404ac988ae927f61e9e
-    sha256: ca1189be471fb73ef742b2e61d345dde885c62ad4c256940984c02073fd1c0e1
+    md5: 409c0b778deee649c025b7106549a24f
+    sha256: 90327dd606f78ae9c881e285f85bc2b0f57d11c807be58ee3f690742354918b2
   category: dev
   optional: true
 - name: parso
@@ -12849,8 +12855,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     ptyprocess: '>=0.5'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 629f3203c99b32e0988910c93e77f3b6
@@ -12862,8 +12868,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     ptyprocess: '>=0.5'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 629f3203c99b32e0988910c93e77f3b6
@@ -12925,9 +12931,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.8'
     setuptools: ''
     wheel: ''
-    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
     md5: 6721aef6bfe5937abe70181545dd2c51
@@ -12939,9 +12945,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    python: '>=3.8'
     setuptools: ''
     wheel: ''
-    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
     md5: 6721aef6bfe5937abe70181545dd2c51
@@ -13156,11 +13162,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.9'
-    pyyaml: '>=5.1'
+    cfgv: '>=2.0.0'
     identify: '>=1.0.0'
     nodeenv: '>=0.11.1'
-    cfgv: '>=2.0.0'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
   hash:
@@ -13173,11 +13179,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.9'
-    pyyaml: '>=5.1'
+    cfgv: '>=2.0.0'
     identify: '>=1.0.0'
     nodeenv: '>=0.11.1'
-    cfgv: '>=2.0.0'
+    python: '>=3.9'
+    pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
   hash:
@@ -13275,8 +13281,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    wcwidth: ''
     python: '>=3.7'
+    wcwidth: ''
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
   hash:
     md5: 1247c861065d227781231950e14fe817
@@ -13288,8 +13294,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    wcwidth: ''
     python: '>=3.7'
+    wcwidth: ''
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
   hash:
     md5: 1247c861065d227781231950e14fe817
@@ -13615,8 +13621,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
     pyarrow: '>=0.14'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -13628,8 +13634,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.5'
     pyarrow: '>=0.14'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/pyarrow-hotfix-0.6-pyhd8ed1ab_0.conda
   hash:
     md5: ccc06e6ef2064ae129fab3286299abda
@@ -13692,10 +13698,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
     annotated-types: '>=0.4.0'
     pydantic-core: 2.18.4
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
   hash:
     md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
@@ -13707,10 +13713,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-    typing-extensions: '>=4.6.1'
     annotated-types: '>=0.4.0'
     pydantic-core: 2.18.4
+    python: '>=3.7'
+    typing-extensions: '>=4.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.7.4-pyhd8ed1ab_0.conda
   hash:
     md5: 20ebbfbc8ce3fc9d1955e9fd31accbb1
@@ -14018,8 +14024,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     cryptography: '>=41.0.5,<44'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.2.1-pyhd8ed1ab_2.conda
   hash:
     md5: 85fa2fdd26d5a38792eb57bc72463f07
@@ -14031,8 +14037,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     cryptography: '>=41.0.5,<44'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.2.1-pyhd8ed1ab_2.conda
   hash:
     md5: 85fa2fdd26d5a38792eb57bc72463f07
@@ -14076,24 +14082,24 @@ package:
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.376
+  version: 1.1.377
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     nodeenv: '>=1.6.0'
     nodejs: ''
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.376-py311h61187de_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.377-py311h9ecbd09_0.conda
   hash:
-    md5: 664f0dce002a6d5962abdd645f5e3330
-    sha256: cce588073b65758ae66ec771b07d1a049b1eb6e9f69bc93c3c760534ad131425
+    md5: 793a0fe37ce71a174f9be8910660eca1
+    sha256: e112a737d76b6f2fe368d8f7d03bf7ee6417ac1b411c952543a23bd43b0cedbf
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.376
+  version: 1.1.377
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -14102,14 +14108,14 @@ package:
     nodejs: ''
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.376-py311hd3f4193_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.377-py311h460d6c5_0.conda
   hash:
-    md5: 2c439799ae52159be2ea68a89ed09b22
-    sha256: b7d33044f0e6a12491ec7dfef60c4c1703664b6c82c6b9b66e5996675df84fe0
+    md5: 28c47f52d56a96765927a282913892a6
+    sha256: b11a80c99b8dcd561d66b19f3b55287296172be6663f5b76f57dca2741301012
   category: dev
   optional: true
 - name: pyright
-  version: 1.1.376
+  version: 1.1.377
   manager: conda
   platform: win-64
   dependencies:
@@ -14120,10 +14126,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.376-py311he736701_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.377-py311he736701_0.conda
   hash:
-    md5: 070de131afaadf14083f108457b81cc3
-    sha256: 94172f94bfd9d20035555eef0443264f759df83928f34a2b0c530cf34dff5fa7
+    md5: 0ef7053d322f81c7bcd8a8a964f07dd1
+    sha256: 2d4c3440293e9ff7d99e07e62373973986d95738794f205926fc2cc65bcc3f5d
   category: dev
   optional: true
 - name: pysocks
@@ -14158,8 +14164,8 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    win_inet_pton: ''
     python: '>=3.8'
+    win_inet_pton: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
   hash:
     md5: 56cd9fe388baac0e90c7149cfac95b60
@@ -14189,13 +14195,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     colorama: ''
-    iniconfig: ''
-    python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1'
+    iniconfig: ''
+    packaging: ''
     pluggy: <2,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: e010a224b90f1f623a917c35addbb924
@@ -14207,13 +14213,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     colorama: ''
-    iniconfig: ''
-    python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1'
+    iniconfig: ''
+    packaging: ''
     pluggy: <2,>=1.5
+    python: '>=3.8'
+    tomli: '>=1'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   hash:
     md5: e010a224b90f1f623a917c35addbb924
@@ -14539,36 +14545,38 @@ package:
   category: main
   optional: false
 - name: python-xxhash
-  version: 3.4.1
+  version: 3.5.0
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     xxhash: '>=0.8.2,<0.8.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.4.1-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-xxhash-3.5.0-py311h61187de_0.conda
   hash:
-    md5: 60b5332b3989fda37884b92c7afd6a91
-    sha256: 91293b2ca0f36ac580f2be4b9c0858cdaec52eff95473841231dcd044acd2e12
+    md5: 44bac99d0125c748894b9ffb6ce97811
+    sha256: 55007bbd768e7e4556f3bbdf912079607b1899b3f7d10ae2cfa739b18b35c91c
   category: main
   optional: false
 - name: python-xxhash
-  version: 3.4.1
+  version: 3.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     xxhash: '>=0.8.2,<0.8.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-xxhash-3.4.1-py311heffc1b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-xxhash-3.5.0-py311hd3f4193_0.conda
   hash:
-    md5: 0c889ee42c49633ae325b093b61dfb1e
-    sha256: e971e47d48c879c2f5ee5ebd0935f03e067aa333982b84e76ad675f13559a08f
+    md5: b95bbda75ed1e14b6fa05bcea3772ba7
+    sha256: dd469e89de084939a9129f2ab8bca49e968e311e63850e2027e8ae811d9202be
   category: main
   optional: false
 - name: python-xxhash
-  version: 3.4.1
+  version: 3.5.0
   manager: conda
   platform: win-64
   dependencies:
@@ -14578,10 +14586,10 @@ package:
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     xxhash: '>=0.8.2,<0.8.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-xxhash-3.4.1-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python-xxhash-3.5.0-py311he736701_0.conda
   hash:
-    md5: ce7de3bb95538821322d6e35df010172
-    sha256: bde43c358c5cd08f1890a169e3eb2bf98fb6e7c778a1aa1278316f9c0ecf0940
+    md5: 1f60425e8e8761f9f9bd13e156552a6c
+    sha256: 59573943ab369f85c326feca788979038da1da6a07d51fac8017e33497691301
   category: main
   optional: false
 - name: python_abi
@@ -14589,10 +14597,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
   hash:
-    md5: d786502c97404c94d7d58d258a445a65
-    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+    md5: 139a8d40c8a2f430df31048949e450de
+    sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
   category: main
   optional: false
 - name: python_abi
@@ -14600,10 +14608,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
   hash:
-    md5: 8d3751bc73d3bbb66f216fa2331d5649
-    sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
+    md5: 3b855e3734344134cb56c410f729c340
+    sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
   category: main
   optional: false
 - name: python_abi
@@ -14611,10 +14619,10 @@ package:
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
   hash:
-    md5: 70513332c71b56eace4ee6441e66c012
-    sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+    md5: 895b873644c11ccc0ab7dba2d8513ae6
+    sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
   category: main
   optional: false
 - name: pytorch
@@ -14649,7 +14657,7 @@ package:
   category: main
   optional: false
 - name: pytorch
-  version: 2.3.1
+  version: 2.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -14662,7 +14670,7 @@ package:
     libcxx: '>=16'
     liblapack: '>=3.9.0,<4.0a0'
     libprotobuf: '>=4.25.3,<4.25.4.0a0'
-    libtorch: 2.3.1.*
+    libtorch: 2.4.0.*
     libuv: '>=1.48.0,<2.0a0'
     llvm-openmp: '>=16.0.6'
     networkx: ''
@@ -14671,12 +14679,12 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     sleef: '>=3.5.1,<4.0a0'
-    sympy: ''
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.3.1-cpu_generic_py311h82099cb_1.conda
+    sympy: '>=1.13.1'
+    typing_extensions: '>=4.8.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.4.0-cpu_generic_py311h82099cb_0.conda
   hash:
-    md5: b33a0e6ee13f86fc2f6fce9bee560ae1
-    sha256: e13d0a1a3cb9177f6fe74faaffb58415ba3afa033fb7ed3e87fa9bc59c74aa4b
+    md5: 9b2dd0285e505dabb22601c348879109
+    sha256: c937f7db6307d3a881cc7e633527f6ed24b88932f7c765c28503c85b18f7f0cc
   category: main
   optional: false
 - name: pytorch
@@ -14715,15 +14723,15 @@ package:
   category: main
   optional: false
 - name: pytorch-cpu
-  version: 2.3.1
+  version: 2.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    pytorch: 2.3.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.3.1-cpu_generic_py311h7a66607_1.conda
+    pytorch: 2.4.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-cpu-2.4.0-cpu_generic_py311h7a66607_0.conda
   hash:
-    md5: cb622c399f12c4bb95240d66c68ea8e8
-    sha256: b42d59eb7a10f886dda06143a42f8ed4ae845fe64d41d3f20a741bdd54ddd2b6
+    md5: e106fb4c0c2f241d0ef6edf44fe768ad
+    sha256: 73a5e9716775d621b22cb5bf6652a7c90fe4c781419a092621971fd109651c42
   category: main
   optional: false
 - name: pytorch-mutex
@@ -14734,6 +14742,7 @@ package:
   url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cpu.tar.bz2
   hash:
     md5: 49565ed726991fd28d08a39885caa88d
+    sha256: d48c964188ca49660d750cffd73698d217cf94e694cd51987f9f186425435e76
   category: main
   optional: false
 - name: pytz
@@ -14832,8 +14841,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    pywin32: ''
     python: '>=2.7'
+    pywin32: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh07e9846_2.tar.bz2
   hash:
     md5: 91733394059b880d9cc0d010c20abda0
@@ -14906,42 +14915,42 @@ package:
   category: main
   optional: false
 - name: pyzmq
-  version: 26.1.0
+  version: 26.2.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
+    libstdcxx-ng: '>=13'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.0-py311h759c1eb_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_0.conda
   hash:
-    md5: cb593185b7ad0343158081c2da456bfc
-    sha256: 2f4f4a52ed4453979fb1f6b46d074decda8c8e555c9d8cc5aae73a8fdec63a49
+    md5: 536c998639c24ff56b79e86f9e422272
+    sha256: c2ac0bf749bef13439ffb56f198800e971f55bfc65e44107c39e9320154e06c5
   category: dev
   optional: true
 - name: pyzmq
-  version: 26.1.0
+  version: 26.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libsodium: '>=1.0.18,<1.0.19.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.1.0-py311h9bed540_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h137d824_0.conda
   hash:
-    md5: 51dba03371585918ec28a4d063385377
-    sha256: f7c426e1d1e48c35823b7055a41828247eae68150890a0e905942c3e4651004e
+    md5: 95502a31573bfb073c5f11039b87ada1
+    sha256: b276e7e031fea37d761fe2bc7bd0667798e6514c08eb1a18890071d101c06eef
   category: dev
   optional: true
 - name: pyzmq
-  version: 26.1.0
+  version: 26.2.0
   manager: conda
   platform: win-64
   dependencies:
@@ -14952,10 +14961,10 @@ package:
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zeromq: '>=4.3.5,<4.3.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.1.0-py311h484c95c_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_0.conda
   hash:
-    md5: 50bbdd233f5bd19165a0c23832416133
-    sha256: 78266c1d226be1199453512f705750c842f219bf541e002e161638be17ffea29
+    md5: 90200c040d03d5bb036b4bec8186664b
+    sha256: bce36e9b24fbb7a65e0779293a95aa9cfa430e9511d0d5c9a6e324c31c26cac0
   category: dev
   optional: true
 - name: re2
@@ -15038,8 +15047,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
+    python: '>=3.8'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
@@ -15052,8 +15061,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
+    python: '>=3.8'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
@@ -15127,10 +15136,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
@@ -15143,10 +15152,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
@@ -15172,8 +15181,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     python: '>=3.5'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -15185,8 +15194,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     python: '>=3.5'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -15249,10 +15258,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -15264,10 +15273,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    markdown-it-py: '>=2.2.0'
+    pygments: '>=2.13.0,<3.0.0'
     python: '>=3.7.0'
     typing_extensions: '>=4.0.0,<5.0.0'
-    pygments: '>=2.13.0,<3.0.0'
-    markdown-it-py: '>=2.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: ba445bf767ae6f0d959ff2b40c20912b
@@ -15409,38 +15418,38 @@ package:
   category: dev
   optional: true
 - name: ruff
-  version: 0.5.7
+  version: 0.6.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py311hce3a109_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.2-py311ha8c6e60_0.conda
   hash:
-    md5: 55c78cc0ce5f309fa245ff06313dc162
-    sha256: f427970399970c17809dd79508861cca81b461b011d9943045e993fc2b768d07
+    md5: 7a63ee5319642e0851d219c91ae8cd2e
+    sha256: 6d0428a6b5b9a114a32bc3af90be347986bd046efd11df7b9e12c709cb56ff5b
   category: dev
   optional: true
 - name: ruff
-  version: 0.5.7
+  version: 0.6.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
+    libcxx: '>=17'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.5.7-py311hd374d79_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.6.2-py311h18e95ce_0.conda
   hash:
-    md5: 7cb8acae32db487b941caf3fd806526e
-    sha256: 38e45bf793a83ff0ae9509bd3363e8727cef604a7d6dee847391867cd292aa3d
+    md5: 5097db109a93d7bd042d729a5db81f47
+    sha256: 45c524988abeffc2ea7a4e2ec254cce51395e9e53a19eae0c8ac4e71e6f33f50
   category: dev
   optional: true
 - name: ruff
-  version: 0.5.7
+  version: 0.6.2
   manager: conda
   platform: win-64
   dependencies:
@@ -15449,24 +15458,24 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py311ha637bb9_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.2-py311ha637bb9_0.conda
   hash:
-    md5: 4eab9c6e8794a53e45cbf123f489124f
-    sha256: 80ab63e042bbf65b47d8872eacc93b5331be92e7b3d466a0cc1c4e92ed95a998
+    md5: e80125c10557f5956a94e2ce51c73c3f
+    sha256: f1b028bf88ef86f2a6b063f02772d501de48526c36ae0ad4090ecc38521d8ce3
   category: dev
   optional: true
 - name: s2n
-  version: 1.5.0
+  version: 1.5.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.0-h3400bea_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.1-h3400bea_0.conda
   hash:
-    md5: 5f17883266c5312a1fc73583f28ebae5
-    sha256: 594878a49b1c4d657795f80ffbe87f15a16cd2162f28383a5b794d301d6cbc65
+    md5: bf136eb7f8e15fcf8915c1a04b0aec6f
+    sha256: 2717b0fa534aee9aca152ae980731f3d201542d12c19403563aaa07194021041
   category: main
   optional: false
 - name: s3fs
@@ -15489,10 +15498,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    aiohttp: ''
-    python: '>=3.8'
     aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
     fsspec: 2024.5.0
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
     md5: 69f9f792aa777125aa284263067d1e97
@@ -15504,10 +15513,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    aiohttp: ''
-    python: '>=3.8'
     aiobotocore: '>=2.5.4,<3.0.0'
+    aiohttp: ''
     fsspec: 2024.5.0
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3fs-2024.5.0-pyhd8ed1ab_0.conda
   hash:
     md5: 69f9f792aa777125aa284263067d1e97
@@ -15532,8 +15541,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
     md5: 80f00f9033aee2358171207746e09ea0
@@ -15545,8 +15554,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     botocore: '>=1.33.2,<2.0a.0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
   hash:
     md5: 80f00f9033aee2358171207746e09ea0
@@ -15599,65 +15608,66 @@ package:
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.14.1
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
+    libgcc-ng: '>=13'
     libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    libgfortran5: '>=13.3.0'
     liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.19,<3'
+    libstdcxx-ng: '>=13'
+    numpy: '>=1.23.5'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py311h517d4fd_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he1f765f_0.conda
   hash:
-    md5: 481fd009b2d863f526f60ca19cb7880b
-    sha256: 55bb5502a4795b5b271bd3879846665ad9ac7ffeeea418ba6334accd8d5c71f4
+    md5: eb7e2a849cd47483d7e9eeb728c7a8c5
+    sha256: 36fd14d01a746bad1f9bc56045aa4fcfcdfe7b064a6d0c5a415dcdc8c0056983
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.14.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16'
+    libcxx: '>=17'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.19,<3'
+    numpy: '>=1.23.5'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.0-py311hceeca8c_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.14.1-py311h2929bc6_0.conda
   hash:
-    md5: d5884accd1a71796a6f9a59b60f814b3
-    sha256: 1fe291622b76be350589fd806ed51e0915e5d7be678332c7bacef36347bf1480
+    md5: 766c008c3537b86fab76fea7f7de1afc
+    sha256: 6671f59afbecbaabafaa84f607ad035153f6ad1b7baa26682c5edd86f5cfd1f8
   category: main
   optional: false
 - name: scipy
-  version: 1.14.0
+  version: 1.14.1
   manager: conda
   platform: win-64
   dependencies:
     libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.19,<3'
+    numpy: '>=1.23.5'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py311hd4686c6_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hd4686c6_0.conda
   hash:
-    md5: 46e7cf04c2a67603ff58a2d9b8ca128a
-    sha256: 60f67658fe153e37da2bda1847eb8b5142d4ff721308f5bf80e4548fa2425b0f
+    md5: 54c36e5548d5f9aa7b6944a6b5d45983
+    sha256: f91a6d034e7f1560f35bd75d6733b2b1cf3997e78de74c21c671e688bc6c98d0
   category: main
   optional: false
 - name: scmrepo
@@ -15687,17 +15697,17 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    tqdm: ''
-    python: '>=3.8'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    pathspec: '>=0.9.0'
-    gitpython: '>3'
-    fsspec: '>=2024.2.0'
     aiohttp-retry: '>=2.5.0'
     asyncssh: '>=2.13.1,<3'
-    pygit2: '>=1.14.0'
     dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.7-pyhd8ed1ab_0.conda
   hash:
     md5: 9591c3dce0f88054c537a23bbb4e5693
@@ -15709,17 +15719,17 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    tqdm: ''
-    python: '>=3.8'
-    funcy: '>=1.14'
-    pygtrie: '>=2.3.2'
-    pathspec: '>=0.9.0'
-    gitpython: '>3'
-    fsspec: '>=2024.2.0'
     aiohttp-retry: '>=2.5.0'
     asyncssh: '>=2.13.1,<3'
-    pygit2: '>=1.14.0'
     dulwich: '>=0.22.1'
+    fsspec: '>=2024.2.0'
+    funcy: '>=1.14'
+    gitpython: '>3'
+    pathspec: '>=0.9.0'
+    pygit2: '>=1.14.0'
+    pygtrie: '>=2.3.2'
+    python: '>=3.8'
+    tqdm: ''
   url: https://conda.anaconda.org/conda-forge/noarch/scmrepo-3.3.7-pyhd8ed1ab_0.conda
   hash:
     md5: 9591c3dce0f88054c537a23bbb4e5693
@@ -15761,9 +15771,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-    numpy: '>=1.17'
     anyconfig: '>=0.12'
+    numpy: '>=1.17'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/seedbank-0.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 4e16b309563adbb713646c3b948a1151
@@ -15775,9 +15785,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-    numpy: '>=1.17'
     anyconfig: '>=0.12'
+    numpy: '>=1.17'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/seedbank-0.1.3-pyhd8ed1ab_0.conda
   hash:
     md5: 4e16b309563adbb713646c3b948a1151
@@ -15853,8 +15863,8 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    pywin32: ''
     python: '>=3.7'
+    pywin32: ''
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
   hash:
     md5: 5a86a21050ca3831ec7f77fb302f1132
@@ -15862,39 +15872,39 @@ package:
   category: dev
   optional: true
 - name: setuptools
-  version: 72.1.0
+  version: 72.2.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e06d4c26df4f958a8d38696f2c344d15
-    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
+    md5: 1462aa8b243aad09ef5d0841c745eb89
+    sha256: 0252f6570de8ff29d489958fc7826677a518061b1aa5e1828a427eec8a7928a4
   category: main
   optional: false
 - name: setuptools
-  version: 72.1.0
+  version: 72.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e06d4c26df4f958a8d38696f2c344d15
-    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
+    md5: 1462aa8b243aad09ef5d0841c745eb89
+    sha256: 0252f6570de8ff29d489958fc7826677a518061b1aa5e1828a427eec8a7928a4
   category: main
   optional: false
 - name: setuptools
-  version: 72.1.0
+  version: 72.2.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: e06d4c26df4f958a8d38696f2c344d15
-    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
+    md5: 1462aa8b243aad09ef5d0841c745eb89
+    sha256: 0252f6570de8ff29d489958fc7826677a518061b1aa5e1828a427eec8a7928a4
   category: main
   optional: false
 - name: shellingham
@@ -16048,11 +16058,12 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.6.1-h3400bea_1.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.6.1-h1b44611_2.conda
   hash:
-    md5: ac00525f47c9fd0e0456a64caef525a6
-    sha256: 4d841e582fef207a7323351ae267e36870b2dd0aa59d01b482f9ba342af77325
+    md5: b5ffc53a2eb33075b38f3a99f52a4aef
+    sha256: c5f0fe5512ecab151f8c2d2add3c738a932a032a158fcc9af4c656ffc5b46222
   category: main
   optional: false
 - name: sleef
@@ -16061,11 +16072,12 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    llvm-openmp: '>=18.1.8'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.6.1-hf6b88df_1.conda
+    libcxx: '>=17'
+    llvm-openmp: '>=17.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.6.1-h7783ee8_2.conda
   hash:
-    md5: 2e65b2842451a191b49b36f206df87c2
-    sha256: 769e2ffcdd0d04944ca39bd05f58ec28d5cd217bf547b8e60220ac24b5c5652b
+    md5: cc2bfbcf35764050e4b009d245ff1e30
+    sha256: 1094c42668634b5551a48378dd43145091c189cd795ad861edbe5f18f218fec3
   category: main
   optional: false
 - name: smart-open
@@ -16122,8 +16134,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    wrapt: ''
     python: '>=3.6'
+    wrapt: ''
   url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
   hash:
     md5: 2804ae86934b30c2afbd713d1448afe5
@@ -16135,8 +16147,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    wrapt: ''
     python: '>=3.6'
+    wrapt: ''
   url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
   hash:
     md5: 2804ae86934b30c2afbd713d1448afe5
@@ -16402,9 +16414,9 @@ package:
   platform: osx-arm64
   dependencies:
     __unix: ''
-    python: '*'
-    mpmath: '>=0.19'
     gmpy2: '>=2.0.8'
+    mpmath: '>=0.19'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pypyh2585a3b_103.conda
   hash:
     md5: 7327125b427c98b81564f164c4a75d4c
@@ -16416,8 +16428,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     mpmath: '>=0.19'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.13.2-pyh04b8f61_3.conda
   hash:
     md5: e172fca69b6b9617448f4f41f05e06c4
@@ -16512,8 +16524,8 @@ package:
   dependencies:
     __win: ''
     python: '>=3.8'
-    tornado: '>=6.1.0'
     pywinpty: '>=1.1.0'
+    tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
   hash:
     md5: 4abd500577430a942a995fd0d09b76a2
@@ -16911,7 +16923,7 @@ package:
   category: dev
   optional: true
 - name: transformers
-  version: 4.44.0
+  version: 4.44.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -16927,56 +16939,56 @@ package:
     safetensors: '>=0.4.1'
     tokenizers: '>=0.19,<0.20'
     tqdm: '>=4.27'
-  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 4785ae8c9ae74b8745d17e8c05a04470
-    sha256: 2e7d99fd408ede238fd6b71dc6c870fd6497a7d96f8b8abead75cee733f2fda6
+    md5: 00d239b9219b2453736c8b1d816d793a
+    sha256: ff42271f3650525a8c7250618bcf763dd800088eed300baeb0e15c9856131f2a
   category: main
   optional: false
 - name: transformers
-  version: 4.44.0
+  version: 4.44.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
+    datasets: '!=2.5.0'
     filelock: ''
+    huggingface_hub: '>=0.23.0,<1.0'
+    numpy: '>=1.17,<2.0'
+    packaging: '>=20.0'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.0'
     regex: '!=2019.12.17'
-    tqdm: '>=4.27'
-    datasets: '!=2.5.0'
+    requests: ''
     safetensors: '>=0.4.1'
-    numpy: '>=1.17,<2.0'
     tokenizers: '>=0.19,<0.20'
-    huggingface_hub: '>=0.23.0,<1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.0-pyhd8ed1ab_0.conda
+    tqdm: '>=4.27'
+  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 4785ae8c9ae74b8745d17e8c05a04470
-    sha256: 2e7d99fd408ede238fd6b71dc6c870fd6497a7d96f8b8abead75cee733f2fda6
+    md5: 00d239b9219b2453736c8b1d816d793a
+    sha256: ff42271f3650525a8c7250618bcf763dd800088eed300baeb0e15c9856131f2a
   category: main
   optional: false
 - name: transformers
-  version: 4.44.0
+  version: 4.44.2
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
+    datasets: '!=2.5.0'
     filelock: ''
+    huggingface_hub: '>=0.23.0,<1.0'
+    numpy: '>=1.17,<2.0'
+    packaging: '>=20.0'
     python: '>=3.8'
     pyyaml: '>=5.1'
-    packaging: '>=20.0'
     regex: '!=2019.12.17'
-    tqdm: '>=4.27'
-    datasets: '!=2.5.0'
+    requests: ''
     safetensors: '>=0.4.1'
-    numpy: '>=1.17,<2.0'
     tokenizers: '>=0.19,<0.20'
-    huggingface_hub: '>=0.23.0,<1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.0-pyhd8ed1ab_0.conda
+    tqdm: '>=4.27'
+  url: https://conda.anaconda.org/conda-forge/noarch/transformers-4.44.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 4785ae8c9ae74b8745d17e8c05a04470
-    sha256: 2e7d99fd408ede238fd6b71dc6c870fd6497a7d96f8b8abead75cee733f2fda6
+    md5: 00d239b9219b2453736c8b1d816d793a
+    sha256: ff42271f3650525a8c7250618bcf763dd800088eed300baeb0e15c9856131f2a
   category: main
   optional: false
 - name: trove-classifiers
@@ -17016,162 +17028,162 @@ package:
   category: dev
   optional: true
 - name: typer
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    typer-slim-standard: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: f905d31da5631dfb35e0895a7d8446f8
+    sha256: 0662dabe0c77a7ab86db8a3b2dc6af8e0efa542da48423718c9119fe8acac1ba
   category: dev
   optional: true
 - name: typer
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    typer-slim-standard: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: f905d31da5631dfb35e0895a7d8446f8
+    sha256: 0662dabe0c77a7ab86db8a3b2dc6af8e0efa542da48423718c9119fe8acac1ba
   category: dev
   optional: true
 - name: typer
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-    typer-slim-standard: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.3-pyhd8ed1ab_0.conda
+    typer-slim-standard: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 10efd02b22c39c0a46312ef7cb16d237
-    sha256: b8b182303858c512fa04f38a3123c892958f708d2ae90afd35246da7c4829485
+    md5: f905d31da5631dfb35e0895a7d8446f8
+    sha256: 0662dabe0c77a7ab86db8a3b2dc6af8e0efa542da48423718c9119fe8acac1ba
   category: dev
   optional: true
 - name: typer-slim
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: linux-64
   dependencies:
     click: '>=8.0.0'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: c68f47e7b02694f3d0f8eea00b5d9a17
+    sha256: c3042feb1f70b008759a09a7a010e617294dcf43cb111c13ec48546ed3e92b74
   category: dev
   optional: true
 - name: typer-slim
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     click: '>=8.0.0'
+    python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: c68f47e7b02694f3d0f8eea00b5d9a17
+    sha256: c3042feb1f70b008759a09a7a010e617294dcf43cb111c13ec48546ed3e92b74
   category: dev
   optional: true
 - name: typer-slim
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     click: '>=8.0.0'
+    python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-0.12.4-pyhd8ed1ab_0.conda
   hash:
-    md5: cf2c3a89f89644c53cadbfeb124914e9
-    sha256: 01dcb54375c8eae54d13374ed3d5823635401c552340b87e67fdbbb507760596
+    md5: c68f47e7b02694f3d0f8eea00b5d9a17
+    sha256: c3042feb1f70b008759a09a7a010e617294dcf43cb111c13ec48546ed3e92b74
   category: dev
   optional: true
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: linux-64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.4-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 7ad257f55c47dde09e8cce723de7ba23
+    sha256: 14d484828bfb1f080f0fff92205c495f18cfbd8fd23af89cf74989b7ba8d9ad0
   category: dev
   optional: true
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: osx-arm64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.4-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 7ad257f55c47dde09e8cce723de7ba23
+    sha256: 14d484828bfb1f080f0fff92205c495f18cfbd8fd23af89cf74989b7ba8d9ad0
   category: dev
   optional: true
 - name: typer-slim-standard
-  version: 0.12.3
+  version: 0.12.4
   manager: conda
   platform: win-64
   dependencies:
     rich: ''
     shellingham: ''
-    typer-slim: 0.12.3
-  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.3-hd8ed1ab_0.conda
+    typer-slim: 0.12.4
+  url: https://conda.anaconda.org/conda-forge/noarch/typer-slim-standard-0.12.4-hd8ed1ab_0.conda
   hash:
-    md5: 8e56b98837d17e6ace4dc455d905709a
-    sha256: 06e2f8ca7e3f7168a39d3d2cc62ee1e220928e1e5a4370f4ade2566342c4a459
+    md5: 7ad257f55c47dde09e8cce723de7ba23
+    sha256: 14d484828bfb1f080f0fff92205c495f18cfbd8fd23af89cf74989b7ba8d9ad0
   category: dev
   optional: true
 - name: types-python-dateutil
-  version: 2.9.0.20240316
+  version: 2.9.0.20240821
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240821-pyhd8ed1ab_0.conda
   hash:
-    md5: 7831efa91d57475373ee52fb92e8d137
-    sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+    md5: a0637bb6a2428c10448807b9d87f082c
+    sha256: 26b5939438e31ffc9ea5c56aaea5799804186887bd0d8d639d8fad1898f07bdd
   category: dev
   optional: true
 - name: types-python-dateutil
-  version: 2.9.0.20240316
+  version: 2.9.0.20240821
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240821-pyhd8ed1ab_0.conda
   hash:
-    md5: 7831efa91d57475373ee52fb92e8d137
-    sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+    md5: a0637bb6a2428c10448807b9d87f082c
+    sha256: 26b5939438e31ffc9ea5c56aaea5799804186887bd0d8d639d8fad1898f07bdd
   category: dev
   optional: true
 - name: types-python-dateutil
-  version: 2.9.0.20240316
+  version: 2.9.0.20240821
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240821-pyhd8ed1ab_0.conda
   hash:
-    md5: 7831efa91d57475373ee52fb92e8d137
-    sha256: 6630bbc43dfb72339fadafc521db56c9d17af72bfce459af195eecb01163de20
+    md5: a0637bb6a2428c10448807b9d87f082c
+    sha256: 26b5939438e31ffc9ea5c56aaea5799804186887bd0d8d639d8fad1898f07bdd
   category: dev
   optional: true
 - name: typing-extensions
@@ -17429,9 +17441,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -17443,9 +17455,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   hash:
     md5: 6bb37c314b3cc1515dcf086ffe01c46e
@@ -17492,44 +17504,44 @@ package:
   category: dev
   optional: true
 - name: uv
-  version: 0.2.36
+  version: 0.3.2
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.2.36-he0f44a0_0.conda
+    libgcc-ng: '>=13'
+    libstdcxx-ng: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.3.2-h0f3a69f_0.conda
   hash:
-    md5: fa2c54710e6cafa0e337c6b58a198d58
-    sha256: 075cbc45c237695703dc1217738d9e67f2931b6327c198c22e95c42b687b8736
+    md5: 9ad5fe4b2f7a684ba8d244f0a86c2d13
+    sha256: d0f0c59da38d3966040277305da8a50ffb71872a1bbca7236dd506bc8dce365b
   category: dev
   optional: true
 - name: uv
-  version: 0.2.36
+  version: 0.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.2.36-hc069d6b_0.conda
+    libcxx: '>=17'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.3.2-hd3a8144_0.conda
   hash:
-    md5: 7e98047ef21bb3299c58fc4469eee7f8
-    sha256: 45699770d57b1453a82812e9dbd2c0d2674c3226f678b3a565e88157e600cc7a
+    md5: fa0c9be6642af748b075614d723a3df8
+    sha256: 76de45dfa03275acbb6f09a46e7533497cc160cb2e39446b92d42f8afe84eca6
   category: dev
   optional: true
 - name: uv
-  version: 0.2.36
+  version: 0.3.2
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.2.36-ha08ef0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/uv-0.3.2-ha08ef0e_0.conda
   hash:
-    md5: 49b3dc18b625391853c0348327b4c5b2
-    sha256: 36a52d9d26fe174e6a6c468b325d1c162a7890ec7f2da73d3a229c1fdfd813f7
+    md5: a2d73d936a389190ce5ee230342d262e
+    sha256: b7ba9109f82d4e8208a168c26f869ffa4fd995e3ba865f2957f1ebf304c4e696
   category: dev
   optional: true
 - name: vc
@@ -17612,10 +17624,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     distlib: <1,>=0.3.7
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
     md5: 284008712816c64c85bf2b7fa9f3b264
@@ -17627,10 +17639,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     distlib: <1,>=0.3.7
     filelock: <4,>=3.12.2
     platformdirs: <5,>=3.9.1
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
   hash:
     md5: 284008712816c64c85bf2b7fa9f3b264
@@ -17642,11 +17654,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 0993e524b9b6afdd5d963f7bbb7df29a
-    sha256: 55654fa3014552ed98cdac00642d7059078a8673e5b3f220914b5be89aafeb24
+    md5: 431b457267ff0efd4242f66b32f2fe99
+    sha256: 00433a475e17af57a17f7ae71297e5ee407d927f125a4c1c8fef59e2f10f5102
   category: dev
   optional: true
 - name: voluptuous
@@ -17654,11 +17666,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 0993e524b9b6afdd5d963f7bbb7df29a
-    sha256: 55654fa3014552ed98cdac00642d7059078a8673e5b3f220914b5be89aafeb24
+    md5: 431b457267ff0efd4242f66b32f2fe99
+    sha256: 00433a475e17af57a17f7ae71297e5ee407d927f125a4c1c8fef59e2f10f5102
   category: dev
   optional: true
 - name: voluptuous
@@ -17666,11 +17678,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/voluptuous-0.15.2-pyhd8ed1ab_1.conda
   hash:
-    md5: 0993e524b9b6afdd5d963f7bbb7df29a
-    sha256: 55654fa3014552ed98cdac00642d7059078a8673e5b3f220914b5be89aafeb24
+    md5: 431b457267ff0efd4242f66b32f2fe99
+    sha256: 00433a475e17af57a17f7ae71297e5ee407d927f125a4c1c8fef59e2f10f5102
   category: dev
   optional: true
 - name: vs2015_runtime
@@ -18406,8 +18418,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=2'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
@@ -18419,8 +18431,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=2'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-3.0.post1-pyhd8ed1ab_0.conda
   hash:
     md5: c5de65315ad9643b7fb67e985fbb54a9
@@ -18649,13 +18661,13 @@ package:
   platform: linux-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   hash:
-    sha256: ef167d47d2e686e95ccb3f599ef685ab09181867
+    sha256: f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -18663,13 +18675,13 @@ package:
   platform: osx-arm64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   hash:
-    sha256: ef167d47d2e686e95ccb3f599ef685ab09181867
+    sha256: f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   optional: false
 - name: poprox-concepts
   version: 0.0.1
@@ -18677,13 +18689,13 @@ package:
   platform: win-64
   dependencies:
     pydantic: '>=2.7.1,<2.8.0'
-  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+  url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   hash:
-    sha256: ef167d47d2e686e95ccb3f599ef685ab09181867
+    sha256: f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   category: main
   source:
     type: url
-    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@ef167d47d2e686e95ccb3f599ef685ab09181867
+    url: git+https://github.com/CCRI-POPROX/poprox-concepts.git@f337da0f5c24af44eb982d7c39fe81e9bc1d5017
   optional: false
 - name: progress-api
   version: 0.1.0a9

--- a/src/poprox_recommender/components/embedders/article.py
+++ b/src/poprox_recommender/components/embedders/article.py
@@ -78,7 +78,7 @@ class NRMSArticleEmbedder(Component):
                 [
                     th.tensor(
                         self.tokenizer.encode(
-                            article.title, padding="max_length", max_length=TITLE_LENGTH_LIMIT, truncation=True
+                            article.headline, padding="max_length", max_length=TITLE_LENGTH_LIMIT, truncation=True
                         ),
                         dtype=th.int32,
                     ).to(self.device)

--- a/src/poprox_recommender/data/mind.py
+++ b/src/poprox_recommender/data/mind.py
@@ -123,9 +123,8 @@ class MindData:
         article = Article(
             article_id=uuid,
             url=f"urn:uuid:{uuid}",
-            title=str(self.news_df.loc[id, "title"]),
+            headline=str(self.news_df.loc[id, "title"]),
         )
-        article.content = article.title
         return article
 
 

--- a/src/poprox_recommender/evaluation/evaluate.py
+++ b/src/poprox_recommender/evaluation/evaluate.py
@@ -44,7 +44,7 @@ class UserRecs(NamedTuple):
 def convert_df_to_article_set(rec_df):
     articles = []
     for _, row in rec_df.iterrows():
-        articles.append(Article(article_id=row["item"], title=""))
+        articles.append(Article(article_id=row["item"], headline=""))
     return ArticleSet(articles=articles)
 
 

--- a/tests/components/test_topic_filter.py
+++ b/tests/components/test_topic_filter.py
@@ -23,22 +23,22 @@ def test_select_by_topic_filters_articles():
     articles = [
         Article(
             article_id=uuid4(),
-            title="Something about TV",
+            headline="Something about TV",
             mentions=[Mention(source="AP", relevance=50.0, entity=entertainment)],
         ),
         Article(
             article_id=uuid4(),
-            title="Something about the US",
+            headline="Something about the US",
             mentions=[Mention(source="AP", relevance=50.0, entity=us_news)],
         ),
         Article(
             article_id=uuid4(),
-            title="Something about politics",
+            headline="Something about politics",
             mentions=[Mention(source="AP", relevance=50.0, entity=politics)],
         ),
         Article(
             article_id=uuid4(),
-            title="Something about books",
+            headline="Something about books",
             mentions=[Mention(source="AP", relevance=50.0, entity=entertainment)],
         ),
     ]

--- a/tests/request_data/basic-request.json
+++ b/tests/request_data/basic-request.json
@@ -2,16 +2,16 @@
   "past_articles": [
     {
       "article_id": "e7605f12-a37a-4326-bf3c-3f9b72d0738d",
-      "title": "title 1",
-      "content": "content 1",
+      "headline": "headline 1",
+      "subhead": "subhead 1",
       "url": "url 1"
     }
   ],
   "todays_articles": [
     {
       "article_id": "7e5e0f12-d563-4a60-b90a-1737839389ff",
-      "title": "title 2",
-      "content": "content 2",
+      "headline": "headline 2",
+      "subhead": "subhead 2",
       "url": "url 2"
     }
   ],

--- a/tests/request_data/medium_request.json
+++ b/tests/request_data/medium_request.json
@@ -2,8 +2,8 @@
   "todays_articles": [
     {
       "article_id": "3966df9d-07fd-45bd-9417-e5d5b13c28ce",
-      "title": "US job openings fall to 8.1 million, lowest since 2021, but remain at historically high levels",
-      "content": "U.S. job openings fell in April to the lowest level since 2021",
+      "headline": "US job openings fall to 8.1 million, lowest since 2021, but remain at historically high levels",
+      "subhead": "U.S. job openings fell in April to the lowest level since 2021",
       "url": "https://apnews.com/article/job-openings-unemployment-economy-inflation-interest-rates-81dae65f447ae75165b9eed8278cd424",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -172,8 +172,8 @@
     },
     {
       "article_id": "469e1b02-4d72-42d8-a520-a40a85c79610",
-      "title": "How Trump's deny-everything strategy could hurt him at sentencing",
-      "content": "Donald Trump has had plenty to say since his hush money trial conviction last week",
+      "headline": "How Trump's deny-everything strategy could hurt him at sentencing",
+      "subhead": "Donald Trump has had plenty to say since his hush money trial conviction last week",
       "url": "https://apnews.com/article/trump-hush-money-stormy-daniels-sentencing-66dbfa66613aaae29a3959e619b7593c",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -299,8 +299,8 @@
     },
     {
       "article_id": "e906956c-ede0-4a43-972c-a61f48fc1e76",
-      "title": "Idris Elba helps uncover the WWII soldiers of color who never got their due",
-      "content": "More than 8 million people of color served with the Allies but little is known of their sacrifices",
+      "headline": "Idris Elba helps uncover the WWII soldiers of color who never got their due",
+      "subhead": "More than 8 million people of color served with the Allies but little is known of their sacrifices",
       "url": "https://apnews.com/article/erased-idris-elba-ww2-soldiers-5b8163286bfdd17d4ee7dff9c9df744c",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -472,8 +472,8 @@
     },
     {
       "article_id": "28ed3e1e-be65-4e3b-b676-c2157f866e11",
-      "title": "CEO pay is rising, widening the gap between top executives and workers. What to know, by the numbers",
-      "content": "The typical compensation for CEOs of S&P 500 companies keeps climber higher \u2014 and outpacing the wages of average workers today",
+      "headline": "CEO pay is rising, widening the gap between top executives and workers. What to know, by the numbers",
+      "subhead": "The typical compensation for CEOs of S&P 500 companies keeps climber higher \u2014 and outpacing the wages of average workers today",
       "url": "https://apnews.com/article/ceo-pay-packages-2023-numbers-acf14f0a4dc4f8e64aabaa1f0e4632ef",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -645,8 +645,8 @@
     },
     {
       "article_id": "cbc30136-7fdc-4627-a4e0-66294fea6066",
-      "title": "Taraji P. Henson will host the 2024 BET Awards. Here's what to know about the show",
-      "content": "The 2024 BET Awards are fast approaching",
+      "headline": "Taraji P. Henson will host the 2024 BET Awards. Here's what to know about the show",
+      "subhead": "The 2024 BET Awards are fast approaching",
       "url": "https://apnews.com/article/bet-awards-2024-what-to-know-e7aabec1241bd72911c390baf2ad5ca4",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -796,8 +796,8 @@
     },
     {
       "article_id": "4a5d577f-b4b9-46b8-aae8-9233f7228669",
-      "title": "Mired in disappointing season, Atlanta United fires coach Gonzalo Pineda",
-      "content": "Atlanta United has fired coach Gonzalo Pineda, less than 24 hours after another loss dropped the team farther from playoff contention in Major League Soccer",
+      "headline": "Mired in disappointing season, Atlanta United fires coach Gonzalo Pineda",
+      "subhead": "Atlanta United has fired coach Gonzalo Pineda, less than 24 hours after another loss dropped the team farther from playoff contention in Major League Soccer",
       "url": "https://apnews.com/article/atlanta-united-mls-coach-pineda-fired-b75d4dc5bb437342014fecfe15b077f4",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -922,8 +922,8 @@
     },
     {
       "article_id": "327b6e77-7276-4663-99c7-f15e603b003a",
-      "title": "A Black medic wounded on D-Day saved dozens of lives. He's finally being posthumously honored",
-      "content": "Waverly Woodson Jr., a medic who was part of the only Black combat unit to take part in the D-Day invasion of France, is being posthumously awarded the Distinguished Service Cross",
+      "headline": "A Black medic wounded on D-Day saved dozens of lives. He's finally being posthumously honored",
+      "subhead": "Waverly Woodson Jr., a medic who was part of the only Black combat unit to take part in the D-Day invasion of France, is being posthumously awarded the Distinguished Service Cross",
       "url": "https://apnews.com/article/dday-black-medic-woodson-distinguished-cross-14062c686b897fe6c40a3734f28b871a",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -1143,8 +1143,8 @@
     },
     {
       "article_id": "ea52aa04-5522-433e-88bb-195ce47f1611",
-      "title": "Mother of airman killed by Florida deputy says his firing, alone, won't cut it",
-      "content": "The mother of an airman who was shot and killed by a Florida sheriff\u2019s deputy says the deputy\u2019s firing was not justice for her son\u2019s killing",
+      "headline": "Mother of airman killed by Florida deputy says his firing, alone, won't cut it",
+      "subhead": "The mother of an airman who was shot and killed by a Florida sheriff\u2019s deputy says the deputy\u2019s firing was not justice for her son\u2019s killing",
       "url": "https://apnews.com/article/roger-fortson-florida-deputy-fired-charges-89c843dba31845df1c82415238179615",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -1270,8 +1270,8 @@
     },
     {
       "article_id": "fb51572d-6a10-463c-a31d-875fd409e4ea",
-      "title": "Rapper Sean Kingston booked into Florida jail, where he and mother are charged with $1M in fraud",
-      "content": "Rapper and singer Sean Kingston is back in South Florida, where he and his mother are charged with committing more than a million dollars worth of fraud",
+      "headline": "Rapper Sean Kingston booked into Florida jail, where he and mother are charged with $1M in fraud",
+      "subhead": "Rapper and singer Sean Kingston is back in South Florida, where he and his mother are charged with committing more than a million dollars worth of fraud",
       "url": "https://apnews.com/article/sean-kingston-arrest-jail-florida-cf7eb4dd744fdeb15bf1a452f466b534",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -1466,8 +1466,8 @@
     },
     {
       "article_id": "946444f3-f21f-43c7-a6c1-684cb0ba02fb",
-      "title": "Atlanta water woes extend into fourth day as city finally cuts off leak gushing into streets",
-      "content": "For at least some residents, Atlanta\u2019s water problems aren't over",
+      "headline": "Atlanta water woes extend into fourth day as city finally cuts off leak gushing into streets",
+      "subhead": "For at least some residents, Atlanta\u2019s water problems aren't over",
       "url": "https://apnews.com/article/atlanta-water-outage-woes-andre-dickens-c02d45a4c3e2b02a413189f9d417e55e",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -1569,8 +1569,8 @@
     },
     {
       "article_id": "ab4fcd39-00b2-443a-8c48-4ebc5742a9cc",
-      "title": "Larry Allen, a Hall of Fame offensive lineman for the Dallas Cowboys, dies suddenly at 52",
-      "content": "Larry Allen, one of the most dominant offensive linemen in the NFL during a 12-year career spent mostly with the Dallas Cowboys, has died",
+      "headline": "Larry Allen, a Hall of Fame offensive lineman for the Dallas Cowboys, dies suddenly at 52",
+      "subhead": "Larry Allen, one of the most dominant offensive linemen in the NFL during a 12-year career spent mostly with the Dallas Cowboys, has died",
       "url": "https://apnews.com/article/larry-allen-dead-cowboys-3f87778f6777b4de2b82106801808e38",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": [
@@ -1651,168 +1651,168 @@
   "past_articles": [
     {
       "article_id": "50551b08-1f74-4b3f-8183-96ac57b0ed6d",
-      "title": "A foreign armed force to fight gangs makes many in Haiti celebrate, while others worry",
-      "content": "Foreigners with guns are met with hostility in most countries in the world. But the departure of armed soldiers and police from Haiti in 2017 after nearly two decades on the streets helped criminals seize control of much of the country.",
+      "headline": "A foreign armed force to fight gangs makes many in Haiti celebrate, while others worry",
+      "subhead": "Foreigners with guns are met with hostility in most countries in the world. But the departure of armed soldiers and police from Haiti in 2017 after nearly two decades on the streets helped criminals seize control of much of the country.",
       "url": "https://apnews.com/article/haiti-un-armed-force-deployment-f1a6e60688502a2e8a13ad8282869e56",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "9faaf1ec-53d0-46c1-9116-7869eebf63e6",
-      "title": "No. 10 Alabama looks to rebound from loss to Texas when Crimson Tide visits rebuilding South Florida",
-      "content": "The daunting challenge South Florida faces hosting 10th-ranked Alabama isn\u2019t lost on Alex Golesh. The first-year coach is rebuilding USF\u2019s once-thriving program and understands Saturday\u2019s nationally televised game against the Crimson Tide offers an opportunity to showcase what he\u2019s trying to accompl",
+      "headline": "No. 10 Alabama looks to rebound from loss to Texas when Crimson Tide visits rebuilding South Florida",
+      "subhead": "The daunting challenge South Florida faces hosting 10th-ranked Alabama isn\u2019t lost on Alex Golesh. The first-year coach is rebuilding USF\u2019s once-thriving program and understands Saturday\u2019s nationally televised game against the Crimson Tide offers an opportunity to showcase what he\u2019s trying to accompl",
       "url": "https://apnews.com/article/alabama-usf-crimson-tide-a0611d3a9b6b5ec169d7a50447737d0e",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "ad5c8152-5d8d-4bb8-980b-1171517f740e",
-      "title": "Pro Picks: Eagles' talent over Chiefs' experience",
-      "content": "The Philadelphia Eagles left their dog masks at home. Back in the Super Bowl five years after winning the first Lombardi Trophy in franchise history, the Eagles took a different path to reach this one.",
+      "headline": "Pro Picks: Eagles' talent over Chiefs' experience",
+      "subhead": "The Philadelphia Eagles left their dog masks at home. Back in the Super Bowl five years after winning the first Lombardi Trophy in franchise history, the Eagles took a different path to reach this one.",
       "url": "https://apnews.com/article/tom-brady-new-england-patriots-kansas-city-chiefs-minnesota-vikings-san-francisco-49ers-228cda4a6c5db4021d6b97db418b25dc",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "6ee05f9c-0f97-406a-a471-f37a2acdbb13",
-      "title": "Vanna White extends her time at the puzzle board on 'Wheel of Fortune' for two additional seasons",
-      "content": "Vanna White will remain with \"Wheel of Fortune'' for two additional seasons. Followig the announcement earlier this year that Pat Sajak would make season 41 of \u201cWheel of Fortune\u201d his last, White's future with the show was uncertain.",
+      "headline": "Vanna White extends her time at the puzzle board on 'Wheel of Fortune' for two additional seasons",
+      "subhead": "Vanna White will remain with \"Wheel of Fortune'' for two additional seasons. Followig the announcement earlier this year that Pat Sajak would make season 41 of \u201cWheel of Fortune\u201d his last, White's future with the show was uncertain.",
       "url": "https://apnews.com/article/vanna-white-wheel-of-fortune-pat-sajak-5603a165f731ae1ce426ba197b64873c",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "8818b13c-c99c-4e6a-88a7-6db36af5e40b",
-      "title": "Capitals' 5-foot 7, 140-pound Matthew Phillips tops the list of season-opening NHL roster surprises",
-      "content": "Matthew Phillips making the Washington Capitals season-opening roster is one of the biggest surprises around the NHL.",
+      "headline": "Capitals' 5-foot 7, 140-pound Matthew Phillips tops the list of season-opening NHL roster surprises",
+      "subhead": "Matthew Phillips making the Washington Capitals season-opening roster is one of the biggest surprises around the NHL.",
       "url": "https://apnews.com/article/matthew-phillips-capitals-bruins-poitras-231c0c1fdf720423617db43dba8b80d4",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "999563d9-b2d0-4ca9-8f6e-793ac5c5ae4a",
-      "title": "Coach Eddie Jones backed by union amid Australia's worst Rugby World Cup campaign",
-      "content": "Rugby Australia has doubled down on backing coach Eddie Jones while the Wallabies are on the brink of missing the Rugby World Cup quarterfinals for the first time.",
+      "headline": "Coach Eddie Jones backed by union amid Australia's worst Rugby World Cup campaign",
+      "subhead": "Rugby Australia has doubled down on backing coach Eddie Jones while the Wallabies are on the brink of missing the Rugby World Cup quarterfinals for the first time.",
       "url": "https://apnews.com/article/australia-jones-rugby-world-cup-d8e4bbc19f0cea8842356b99719fcbda",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "2b9cc70f-2d64-4b34-b26d-6d7bf908524d",
-      "title": "Inflation is slowing, but still high. What you need to know",
-      "content": "After reaching 40-year highs over the summer, price increases in the U.S. are now steadily easing. Consumer inflation slowed to 7.1% in November from a year earlier and to 0.1% from October, the government said Tuesday.",
+      "headline": "Inflation is slowing, but still high. What you need to know",
+      "subhead": "After reaching 40-year highs over the summer, price increases in the U.S. are now steadily easing. Consumer inflation slowed to 7.1% in November from a year earlier and to 0.1% from October, the government said Tuesday.",
       "url": "https://apnews.com/article/inflation-business-149cec9fb85f97f97f5d39e6b6e686d3",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "41475605-f8ae-4a9d-9565-063a55c2e5ad",
-      "title": "Injunction blocking Florida law targeting drag shows applies to all venues, judge says",
-      "content": "A federal judge says that his order blocking a Florida law targeting drag shows doesn\u2019t just apply to the restaurant that brought a lawsuit challenging it but other venues in the state.",
+      "headline": "Injunction blocking Florida law targeting drag shows applies to all venues, judge says",
+      "subhead": "A federal judge says that his order blocking a Florida law targeting drag shows doesn\u2019t just apply to the restaurant that brought a lawsuit challenging it but other venues in the state.",
       "url": "https://apnews.com/article/lgbtq-desantis-florida-drag-shows-89cc68eb3a34ceead38ec00831817eb9",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "9cd74855-f983-4d32-bb6c-3bc14e93f147",
-      "title": "Texans place Stingley on injured list, say Tunsil won't travel to Jacksonville",
-      "content": "The Houston Texans have placed cornerback Derek Stingley Jr. on the injured reserve with a hamstring injury and said Saturday left tackle Laremy Tunsil won\u2019t travel to Jacksonville because of a knee injury.",
+      "headline": "Texans place Stingley on injured list, say Tunsil won't travel to Jacksonville",
+      "subhead": "The Houston Texans have placed cornerback Derek Stingley Jr. on the injured reserve with a hamstring injury and said Saturday left tackle Laremy Tunsil won\u2019t travel to Jacksonville because of a knee injury.",
       "url": "https://apnews.com/article/texans-stingley-tunsil-houston-injured-d935c032468c05236cd5d766b2cea652",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "29328848-7cae-432a-84da-9c9b282be4c6",
-      "title": "Former Texas Rep. Will Hurd suspends long-shot GOP 2024 presidential bid, endorses Nikki Haley",
-      "content": "Former Texas congressman Will Hurd has suspended his Republican presidential bid, abandoning a brief campaign built on criticizing Donald Trump at a time when his party seems even more determined to embrace the former president.",
+      "headline": "Former Texas Rep. Will Hurd suspends long-shot GOP 2024 presidential bid, endorses Nikki Haley",
+      "subhead": "Former Texas congressman Will Hurd has suspended his Republican presidential bid, abandoning a brief campaign built on criticizing Donald Trump at a time when his party seems even more determined to embrace the former president.",
       "url": "https://apnews.com/article/will-hurd-ends-2024-presidential-campaign-c34b3c8d9ef44126e8e36623b1dc3021",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "8a6f5e08-9e4e-4598-be3e-8bde809c7092",
-      "title": "Deep-sea 'hot tubs' help octopus moms hatch their eggs faster",
-      "content": "A new study suggests that deep-sea \u201chot tubs\u201d may help octopus eggs hatch faster. Octopus usually live solitary lives.",
+      "headline": "Deep-sea 'hot tubs' help octopus moms hatch their eggs faster",
+      "subhead": "A new study suggests that deep-sea \u201chot tubs\u201d may help octopus eggs hatch faster. Octopus usually live solitary lives.",
       "url": "https://apnews.com/article/octopus-deepsea-garden-eggs-nest-6ef8d8b464d49bda4cda27b7eda270c9",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "544b7ef2-07ae-45f3-9f32-383380139956",
-      "title": "Seahawks expect to have Jamal Adams and several others back in time to face Bengals",
-      "content": "The Seattle Seahawks expect safety Jamal Adams to be cleared from the concussion protocol in the next couple of days and to play this week against Cincinnati.",
+      "headline": "Seahawks expect to have Jamal Adams and several others back in time to face Bengals",
+      "subhead": "The Seattle Seahawks expect safety Jamal Adams to be cleared from the concussion protocol in the next couple of days and to play this week against Cincinnati.",
       "url": "https://apnews.com/article/seahawks-jamal-adams-concussion-return-4b106add2315c6de1b210b597af8f05b",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "2cb543da-64a3-4640-a18b-dd84ef1e8dd9",
-      "title": "Kansas college reaches settlement in lawsuit alleging discrimination against Black athletes",
-      "content": "A Kansas community college that was accused of discriminating against Black student-athletes has agreed to a settlement. The U.S.",
+      "headline": "Kansas college reaches settlement in lawsuit alleging discrimination against Black athletes",
+      "subhead": "A Kansas community college that was accused of discriminating against Black student-athletes has agreed to a settlement. The U.S.",
       "url": "https://apnews.com/article/kansas-college-black-athletes-8d354add43b95bb90082a09f5a850fe8",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "ea8bd1fd-2fc2-4195-aeef-04f6a4197a28",
-      "title": "Dillon Gabriel throws for 5 TDs as No. 19 Oklahoma rolls past Tulsa 66-17",
-      "content": "Dillon Gabriel threw for 421 yards and five touchdowns, three of them to Nic Anderson, and No. 19 Oklahoma rolled to a 66-17 victory over in-state rival Tulsa.",
+      "headline": "Dillon Gabriel throws for 5 TDs as No. 19 Oklahoma rolls past Tulsa 66-17",
+      "subhead": "Dillon Gabriel threw for 421 yards and five touchdowns, three of them to Nic Anderson, and No. 19 Oklahoma rolled to a 66-17 victory over in-state rival Tulsa.",
       "url": "https://apnews.com/article/oklahoma-tulsa-dillon-gabriel-da24b20a2a19c93f68115613a1e5fb2d",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "98a39396-6705-4705-8307-3a618d4f63f5",
-      "title": "DeSantis' retaliation against Disney hurts Florida, former governors and lawmakers say",
-      "content": "A group of mostly Republican former high-level government officials is calling Gov. Ron DeSantis' takeover of Disney World\u2019s governing district \u201cseverely damaging to the political, social, and economic fabric of the State.\u201d",
+      "headline": "DeSantis' retaliation against Disney hurts Florida, former governors and lawmakers say",
+      "subhead": "A group of mostly Republican former high-level government officials is calling Gov. Ron DeSantis' takeover of Disney World\u2019s governing district \u201cseverely damaging to the political, social, and economic fabric of the State.\u201d",
       "url": "https://apnews.com/article/disney-desantis-feud-lgbtq-74591d962dc30065fe2dd6947bf12d2e",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "e1e93d47-68e0-451e-a3d1-5233a162ebde",
-      "title": "They shared a name \u2014 but not a future. How two kids fought to escape poverty in Baltimore",
-      "content": "Two kids named Antonio grew up together in the streets of east Baltimore surrounded by poverty and gun violence",
+      "headline": "They shared a name \u2014 but not a future. How two kids fought to escape poverty in Baltimore",
+      "subhead": "Two kids named Antonio grew up together in the streets of east Baltimore surrounded by poverty and gun violence",
       "url": "https://apnews.com/article/baltimore-youth-gun-violence-poverty-entrepreneurship-1cb941be0cd302df626f7ba38bb96df6",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "bffa0189-5f00-429f-a191-7ca8fcc29b85",
-      "title": "STAT WATCH: Davis' FBS season-best rushing game for Kentucky pushes him over 3,000 career yards",
-      "content": "Kentucky\u2019s Ray Davis became the fourth active player in the Football Bowl Subdivision to go over 3,000 career rushing yards.",
+      "headline": "STAT WATCH: Davis' FBS season-best rushing game for Kentucky pushes him over 3,000 career yards",
+      "subhead": "Kentucky\u2019s Ray Davis became the fourth active player in the Football Bowl Subdivision to go over 3,000 career rushing yards.",
       "url": "https://apnews.com/article/kentucky-wildcats-ray-davis-3d283a123843410363b577d7f22c8296",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "1410985c-f52a-4b0b-a7ac-2aa046ecdd29",
-      "title": "Hong Kong's top court rules in favor of recognizing same-sex partnerships in a landmark case",
-      "content": "Hong Kong\u2019s top court has ruled the government should provide a framework for recognizing same-sex partnerships in a landmark decision for the city\u2019s LGBTQ+ community.",
+      "headline": "Hong Kong's top court rules in favor of recognizing same-sex partnerships in a landmark case",
+      "subhead": "Hong Kong\u2019s top court has ruled the government should provide a framework for recognizing same-sex partnerships in a landmark decision for the city\u2019s LGBTQ+ community.",
       "url": "https://apnews.com/article/hong-kong-same-sex-marriage-e32da67e8d4b364cb156a2e2ec526850",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "352a67b6-153d-4835-af7c-560ad795f67a",
-      "title": "Movie Review: Horror flick 'Talk to Me' is a hand-some high-five for twin Australian filmmakers",
-      "content": "You\u2019ve got to hand it to the Philippou brothers. They\u2019ve taken the old horror cliche of a severed hand and made something worth, well, applauding, says Associated Press critic Mark Kennedy.",
+      "headline": "Movie Review: Horror flick 'Talk to Me' is a hand-some high-five for twin Australian filmmakers",
+      "subhead": "You\u2019ve got to hand it to the Philippou brothers. They\u2019ve taken the old horror cliche of a severed hand and made something worth, well, applauding, says Associated Press critic Mark Kennedy.",
       "url": "https://apnews.com/article/talk-to-me-movie-review-6e28141ea4a6d2480a504016c2a9ea8d",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "a1bdee8c-2e75-4e50-a75d-ff48d44fe6d3",
-      "title": "Starting next year, child influencers can sue if earnings aren't set aside, says new Illinois law",
-      "content": "Illinois is the first state in the U.S. to ensure child social media influencers are compensated for their work. That's according to Sen.",
+      "headline": "Starting next year, child influencers can sue if earnings aren't set aside, says new Illinois law",
+      "subhead": "Illinois is the first state in the U.S. to ensure child social media influencers are compensated for their work. That's according to Sen.",
       "url": "https://apnews.com/article/tiktok-child-influencer-illinois-social-media-f784b4bc52cb75ad1e0d28785993b1c5",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []
     },
     {
       "article_id": "c4d45ecf-2d86-4419-931a-4bf76bcd0305",
-      "title": "Stock market today: Asian shares mostly higher after US inflation data ease rate hike worries",
-      "content": "Shares are mostly higher in Asia after a highly anticipated report showed inflation accelerated across the U.S. in August, but not by much more than expected.",
+      "headline": "Stock market today: Asian shares mostly higher after US inflation data ease rate hike worries",
+      "subhead": "Shares are mostly higher in Asia after a highly anticipated report showed inflation accelerated across the U.S. in August, but not by much more than expected.",
       "url": "https://apnews.com/article/stock-market-inflation-rates-oil-c6706a055c002e5d858d3591a6d3bddc",
       "published_at": "1970-01-01T00:00:00Z",
       "mentions": []

--- a/tests/request_data/request_body.json.dvc
+++ b/tests/request_data/request_body.json.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: cb04c17746dbe905cce9bcab79f8e7b1
-  size: 5319784
+- md5: a06488190cac05a6302e4ac6713ea7f9
+  size: 5345887
   hash: md5
   path: request_body.json

--- a/tests/test_joiners.py
+++ b/tests/test_joiners.py
@@ -20,7 +20,7 @@ def build_pipeline(total_slots):
 
 total_slots = 10
 inputs = {
-    "candidate": ArticleSet(articles=[Article(article_id=uuid4(), title="title") for _ in range(total_slots)]),
+    "candidate": ArticleSet(articles=[Article(article_id=uuid4(), headline="headline") for _ in range(total_slots)]),
     "profile": InterestProfile(click_history=[], onboarding_topics=[]),
 }
 


### PR DESCRIPTION
These names probably originated with the early articles we scraped directly from AP's website, which were stored with different field names than are commonly used in journalism. Journalists sometimes call these the `hed` and `subhed`/`dek`, so I've adapted those names a bit to be easier for us to use while staying as true to the source domain as I can.

This differentiates the `subhead` (formerly `content`) from the actual text of the article, which we may soon start fetching from AP with additional API calls.

Connected PRs:
* https://github.com/CCRI-POPROX/poprox-concepts/pull/22
* https://github.com/CCRI-POPROX/poprox-storage/pull/40
* https://github.com/CCRI-POPROX/poprox-platform/pull/142
* https://github.com/CCRI-POPROX/poprox-recommender/pull/91