### PR TITLE
Rename and reorganize component types

### DIFF
--- a/src/poprox_recommender/lkpipeline/config.py
+++ b/src/poprox_recommender/lkpipeline/config.py
@@ -15,7 +15,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, JsonValue, ValidationError
 from typing_extensions import Any, Optional, Self
 
-from .components import ConfigurableComponent
+from .components import Configurable
 from .nodes import ComponentNode, InputNode
 from .types import type_string
 
@@ -109,7 +109,7 @@ class PipelineComponent(BaseModel):
 
         code = f"{ctype.__module__}:{ctype.__qualname__}"
 
-        config = comp.get_config() if isinstance(comp, ConfigurableComponent) else None
+        config = comp.get_config() if isinstance(comp, Configurable) else None
 
         return cls(
             code=code,

--- a/src/poprox_recommender/lkpipeline/nodes.py
+++ b/src/poprox_recommender/lkpipeline/nodes.py
@@ -11,7 +11,7 @@ from inspect import Signature, signature
 
 from typing_extensions import Generic, TypeVar
 
-from .components import PipelineComponent
+from .components import PipelineFunction
 from .types import TypecheckWarning
 
 # Nodes are (conceptually) immutable data containers, so Node[U] can be assigned
@@ -73,7 +73,7 @@ class LiteralNode(Node[ND], Generic[ND]):
 class ComponentNode(Node[ND], Generic[ND]):
     __match_args__ = ("name", "component", "inputs", "connections")
 
-    component: PipelineComponent[ND]
+    component: PipelineFunction[ND]
     "The component associated with this node"
 
     inputs: dict[str, type | None]
@@ -82,7 +82,7 @@ class ComponentNode(Node[ND], Generic[ND]):
     connections: dict[str, str]
     "The component's input connections."
 
-    def __init__(self, name: str, component: PipelineComponent[ND]):
+    def __init__(self, name: str, component: PipelineFunction[ND]):
         super().__init__(name)
         self.component = component
         self.connections = {}

--- a/src/poprox_recommender/lkpipeline/runner.py
+++ b/src/poprox_recommender/lkpipeline/runner.py
@@ -13,7 +13,7 @@ import logging
 from typing import Any, Literal, TypeAlias
 
 from . import Pipeline, PipelineError
-from .components import PipelineComponent
+from .components import PipelineFunction
 from .nodes import ComponentNode, FallbackNode, InputNode, LiteralNode, Node
 from .types import is_compatible_data
 
@@ -96,7 +96,7 @@ class PipelineRunner:
     def _run_component(
         self,
         name: str,
-        comp: PipelineComponent[Any],
+        comp: PipelineFunction[Any],
         inputs: dict[str, type | None],
         wiring: dict[str, str],
         required: bool,

--- a/tests/lkpipeline/test_component_config.py
+++ b/tests/lkpipeline/test_component_config.py
@@ -7,10 +7,10 @@
 import json
 
 from poprox_recommender.lkpipeline import Pipeline
-from poprox_recommender.lkpipeline.components import AutoConfig
+from poprox_recommender.lkpipeline.components import Component
 
 
-class Prefixer(AutoConfig):
+class Prefixer(Component):
     prefix: str
 
     def __init__(self, prefix: str = "hello"):

--- a/tests/lkpipeline/test_pipeline_clone.py
+++ b/tests/lkpipeline/test_pipeline_clone.py
@@ -7,11 +7,11 @@
 import json
 
 from poprox_recommender.lkpipeline import Pipeline
-from poprox_recommender.lkpipeline.components import AutoConfig
+from poprox_recommender.lkpipeline.components import Component
 from poprox_recommender.lkpipeline.nodes import ComponentNode
 
 
-class Prefixer(AutoConfig):
+class Prefixer(Component):
     prefix: str
 
     def __init__(self, prefix: str = "hello"):

--- a/tests/lkpipeline/test_save_load.py
+++ b/tests/lkpipeline/test_save_load.py
@@ -6,7 +6,7 @@ from pytest import fail, warns
 from typing_extensions import assert_type
 
 from poprox_recommender.lkpipeline import InputNode, Node, Pipeline, PipelineWarning
-from poprox_recommender.lkpipeline.components import AutoConfig
+from poprox_recommender.lkpipeline.components import Component
 from poprox_recommender.lkpipeline.config import PipelineConfig
 from poprox_recommender.lkpipeline.nodes import ComponentNode
 
@@ -14,7 +14,7 @@ _log = logging.getLogger(__name__)
 
 
 # region Test Components
-class Prefixer(AutoConfig):
+class Prefixer(Component):
     prefix: str
 
     def __init__(self, prefix: str = "hello"):


### PR DESCRIPTION
This follows up on #83 to do the component type renaming and logic cleanup around `AutoConfig`, etc.

Tentatively, I renamed the callable type alias to `PipelineFunction`, to communicate that you're either adding a component or a function to the pipeline.