### PR TITLE
Replace fallbacks with lazy nodes and components

### DIFF
--- a/src/poprox_recommender/components/joiners/fill.py
+++ b/src/poprox_recommender/components/joiners/fill.py
@@ -1,11 +1,15 @@
 from poprox_concepts import ArticleSet
 from poprox_recommender.lkpipeline import Component
+from poprox_recommender.lkpipeline.types import Lazy
 
 
 class Fill(Component):
     def __init__(self, num_slots):
         self.num_slots = num_slots
 
-    def __call__(self, candidates1: ArticleSet, candidates2: ArticleSet) -> ArticleSet:
-        articles = candidates1.articles + candidates2.articles
+    def __call__(self, candidates1: ArticleSet, candidates2: Lazy[ArticleSet]) -> ArticleSet:
+        articles = candidates1.articles
+        if len(articles) < self.num_slots:
+            articles = articles + candidates2.get().articles
+
         return ArticleSet(articles=articles[: self.num_slots])

--- a/src/poprox_recommender/default.py
+++ b/src/poprox_recommender/default.py
@@ -139,7 +139,6 @@ def build_pipeline(name, article_embedder, user_embedder, ranker, num_slots):
         o_rank = pipeline.add_component("reranker", ranker, candidate_articles=o_scored, interest_profile=e_user)
 
     # Fallback in case not enough articles came from the ranker
-    # TODO: make this lazy so the sampler only runs if the reranker isn't enough
     o_filtered = pipeline.add_component("topic-filter", topic_filter, candidate=candidates, interest_profile=profile)
     o_sampled = pipeline.add_component("sampler", sampler, candidate=o_filtered, backup=candidates)
     pipeline.add_component("recommender", fill, candidates1=o_rank, candidates2=o_sampled)

--- a/src/poprox_recommender/lkpipeline/__init__.py
+++ b/src/poprox_recommender/lkpipeline/__init__.py
@@ -26,7 +26,7 @@ from .components import (  # type: ignore # noqa: F401
     instantiate_component,
 )
 from .config import PipelineConfig
-from .nodes import ND, ComponentNode, FallbackNode, InputNode, LiteralNode, Node
+from .nodes import ND, ComponentNode, InputNode, LiteralNode, Node
 from .state import PipelineState
 from .types import Lazy, parse_type_string
 
@@ -323,63 +323,6 @@ class Pipeline:
         self._clear_caches()
         return node
 
-    def use_first_of(self, name: str, *nodes: Node[T | None]) -> Node[T]:
-        """
-        Create a new node whose value is the first defined (not ``None``) value
-        of the specified nodes.  If a node is an input node and its value is not
-        supplied, it is treated as ``None`` in this case instead of failing the
-        run. This method is used for things like filling in optional pipeline
-        inputs.  For example, if you want the pipeline to take candidate items
-        through an ``items`` input, but look them up from the user's history and
-        the training data if ``items`` is not supplied, you would do:
-
-        .. code:: python
-
-            pipe = Pipeline()
-            # allow candidate items to be optionally specified
-            items = pipe.create_input('items', list[EntityId], None)
-            # find candidates from the training data (optional)
-            lookup_candidates = pipe.add_component(
-                'select-candidates',
-                UnratedTrainingItemsCandidateSelector(),
-                user=history,
-            )
-            # if the client provided items as a pipeline input, use those; otherwise
-            # use the candidate selector we just configured.
-            candidates = pipe.use_first_of('candidates', items, lookup_candidates)
-
-        .. note::
-
-            This method does not distinguish between an input being unspecified and
-            explicitly specified as ``None``.
-
-        .. note::
-
-            This method does *not* implement item-level fallbacks, only
-            fallbacks at the level of entire results.  That is, you can use it
-            to use component A as a fallback for B if B returns ``None``, but it
-            will not use B to fill in missing scores for individual items that A
-            did not score.  A specific itemwise fallback component is needed for
-            such an operation.
-
-        .. note::
-            If one of the fallback elements is a component ``A`` that depends on
-            another component or input ``B``, and ``B`` is missing or returns
-            ``None`` such that ``A`` would usually fail, then ``A`` will be
-            skipped and the fallback will move on to the next node. This works
-            with arbitrarily-deep transitive chains.
-
-        Args:
-            name:
-                The name of the node.
-            nodes:
-                The nodes to try, in order, to satisfy this node.
-        """
-        node = FallbackNode(name, list(nodes))
-        self._nodes[name] = node
-        self._clear_caches()
-        return node
-
     def connect(self, obj: str | Node[Any], **inputs: Node[Any] | str | object):
         """
         Provide additional input connections for a component that has already
@@ -459,8 +402,6 @@ class Pipeline:
                     clone.create_input(name, *types)
                 case LiteralNode(name, value):
                     clone._nodes[name] = LiteralNode(name, value)
-                case FallbackNode(name, alts):
-                    clone.use_first_of(name, *alts)
                 case ComponentNode(name, comp, _inputs, wiring):
                     if isinstance(comp, FunctionType):
                         comp = comp
@@ -535,11 +476,6 @@ class Pipeline:
                     cfg.literals[name] = config.PipelineLiteral.represent(value)
                 case ComponentNode(name):
                     cfg.components[name] = config.PipelineComponent.from_node(node, remapped)
-                case FallbackNode(name, alternatives):
-                    cfg.components[name] = config.PipelineComponent(
-                        code="@use-first-of",
-                        inputs=[remapped.get(n.name, n.name) for n in alternatives],
-                    )
                 case _:  # pragma: nocover
                     raise RuntimeError(f"invalid node {node}")
 
@@ -602,16 +538,7 @@ class Pipeline:
             pipe.add_component(name, obj)
             to_wire.append(comp)
 
-        # pass 3: add meta nodes
-        for name, comp in cfg.components.items():
-            if comp.code == "@use-first-of":
-                if not isinstance(comp.inputs, list):
-                    raise PipelineError("@use-first-of must have input list, not dict")
-                pipe.use_first_of(name, *[pipe.node(n) for n in comp.inputs])
-            elif comp.code.startswith("@"):
-                raise PipelineError(f"unsupported meta-component {comp.code}")
-
-        # pass 4: wiring
+        # pass 3: wiring
         for name, comp in cfg.components.items():
             if isinstance(comp.inputs, dict):
                 inputs = {n: pipe.node(t) for (n, t) in comp.inputs.items()}
@@ -619,11 +546,11 @@ class Pipeline:
             elif not comp.code.startswith("@"):
                 raise PipelineError(f"component {name} inputs must be dict, not list")
 
-        # pass 5: aliases
+        # pass 4: aliases
         for n, t in cfg.aliases.items():
             pipe.alias(n, t)
 
-        # pass 6: defaults
+        # pass 5: defaults
         for n, t in cfg.defaults.items():
             pipe.set_default(n, pipe.node(t))
 

--- a/src/poprox_recommender/lkpipeline/__init__.py
+++ b/src/poprox_recommender/lkpipeline/__init__.py
@@ -28,7 +28,7 @@ from .components import (  # type: ignore # noqa: F401
 from .config import PipelineConfig
 from .nodes import ND, ComponentNode, FallbackNode, InputNode, LiteralNode, Node
 from .state import PipelineState
-from .types import parse_type_string
+from .types import Lazy, parse_type_string
 
 __all__ = [
     "Pipeline",
@@ -38,6 +38,7 @@ __all__ = [
     "PipelineFunction",
     "Configurable",
     "PipelineConfig",
+    "Lazy",
     "Component",
 ]
 

--- a/src/poprox_recommender/lkpipeline/config.py
+++ b/src/poprox_recommender/lkpipeline/config.py
@@ -78,10 +78,6 @@ class PipelineComponent(BaseModel):
     """
     The path to the component's implementation, either a class or a function.
     This is a Python qualified path of the form ``module:name``.
-
-    Special nodes, like :class:`lenskit.pipeline.Pipeline.use_first_of`, are
-    serialized as components whose code is a magic name beginning with ``@``
-    (e.g. ``@use-first-of``).
     """
 
     config: dict[str, object] | None = Field(default=None)

--- a/src/poprox_recommender/lkpipeline/nodes.py
+++ b/src/poprox_recommender/lkpipeline/nodes.py
@@ -45,21 +45,6 @@ class InputNode(Node[ND], Generic[ND]):
     """
 
 
-class FallbackNode(Node[ND], Generic[ND]):
-    """
-    Node for trying several nodes in turn.
-    """
-
-    __match_args__ = ("name", "alternatives")
-
-    alternatives: list[Node[ND | None]]
-    "The nodes that can possibly fulfil this node."
-
-    def __init__(self, name: str, alternatives: list[Node[ND | None]]):
-        super().__init__(name)
-        self.alternatives = alternatives
-
-
 class LiteralNode(Node[ND], Generic[ND]):
     __match_args__ = ("name", "value")
     value: ND

--- a/src/poprox_recommender/lkpipeline/runner.py
+++ b/src/poprox_recommender/lkpipeline/runner.py
@@ -161,7 +161,7 @@ class DeferredRun(Generic[T]):
     required: bool
     data_type: type | None
 
-    def get(self):
+    def get(self) -> T:
         val = self.runner.run(self.node, required=self.required)
 
         if self.data_type is not None and not is_compatible_data(val, self.data_type):

--- a/src/poprox_recommender/lkpipeline/runner.py
+++ b/src/poprox_recommender/lkpipeline/runner.py
@@ -10,14 +10,16 @@ Pipeline runner logic.
 
 # pyright: strict
 import logging
-from typing import Any, Literal, TypeAlias
+from dataclasses import dataclass
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, get_args, get_origin
 
 from . import Pipeline, PipelineError
 from .components import PipelineFunction
 from .nodes import ComponentNode, FallbackNode, InputNode, LiteralNode, Node
-from .types import is_compatible_data
+from .types import Lazy, is_compatible_data
 
 _log = logging.getLogger(__name__)
+T = TypeVar("T")
 State: TypeAlias = Literal["pending", "in-progress", "finished", "failed"]
 
 
@@ -104,11 +106,18 @@ class PipelineRunner:
         in_data = {}
         _log.debug("processing inputs for component %s", name)
         for iname, itype in inputs.items():
+            # look up the input wiring for this parameter input
             src = wiring.get(iname, None)
             if src is not None:
                 snode = self.pipe.node(src)
             else:
                 snode = self.pipe.get_default(iname)
+
+            # check if this is a lazy node
+            lazy = False
+            if itype is not None and get_origin(itype) == Lazy:
+                lazy = True
+                (itype,) = get_args(itype)
 
             if snode is None:
                 ival = None
@@ -117,13 +126,18 @@ class PipelineRunner:
                     ireq = not is_compatible_data(None, itype)
                 else:
                     ireq = False
-                ival = self.run(snode, required=ireq)
 
-            # bail out if we're trying to satisfy a non-required dependency
-            if ival is None and itype and not is_compatible_data(None, itype) and not required:
+                if lazy:
+                    ival = DeferredRun(self, iname, name, snode, required=ireq, data_type=itype)
+                else:
+                    ival = self.run(snode, required=ireq)
+
+            # bail out if we're failing to satisfy a dependency but it is not required
+            if ival is None and itype and not lazy and not is_compatible_data(None, itype) and not required:
                 return None
 
-            if itype and not is_compatible_data(ival, itype):
+            # check the data type before passing
+            if itype and not lazy and not is_compatible_data(ival, itype):
                 if ival is None:
                     raise TypeError(f"no data available for required input ❬{iname}❭ on component ❬{name}❭")
                 raise TypeError(
@@ -144,3 +158,27 @@ class PipelineRunner:
 
         # got this far, no alternatives
         raise RuntimeError(f"no alternative for {name} returned data")
+
+
+@dataclass(eq=False)
+class DeferredRun(Generic[T]):
+    """
+    Implementation of :class:`Lazy` for deferred runs in a pipeline runner.
+    """
+
+    runner: PipelineRunner
+    iname: str
+    cname: str
+    node: Node[T]
+    required: bool
+    data_type: type | None
+
+    def get(self):
+        val = self.runner.run(self.node, required=self.required)
+
+        if self.data_type is not None and not is_compatible_data(val, self.data_type):
+            raise TypeError(
+                f"input ❬{self.iname}❭ on component ❬{self.cname}❭ has invalid type {type(val)} (expected {self.data_type})"  # noqa: E501
+            )
+
+        return val

--- a/src/poprox_recommender/lkpipeline/runner.py
+++ b/src/poprox_recommender/lkpipeline/runner.py
@@ -15,7 +15,7 @@ from typing import Any, Generic, Literal, TypeAlias, TypeVar, get_args, get_orig
 
 from . import Pipeline, PipelineError
 from .components import PipelineFunction
-from .nodes import ComponentNode, FallbackNode, InputNode, LiteralNode, Node
+from .nodes import ComponentNode, InputNode, LiteralNode, Node
 from .types import Lazy, is_compatible_data
 
 _log = logging.getLogger(__name__)
@@ -80,8 +80,6 @@ class PipelineRunner:
                 self._inject_input(name, types, required)
             case ComponentNode(name, comp, inputs, wiring):
                 self._run_component(name, comp, inputs, wiring, required)
-            case FallbackNode(name, alts):
-                self._run_fallback(name, alts)
             case _:  # pragma: nocover
                 raise PipelineError(f"invalid node {node}")
 
@@ -148,16 +146,6 @@ class PipelineRunner:
 
         _log.debug("running component %s", name)
         self.state[name] = comp(**in_data)
-
-    def _run_fallback(self, name: str, alternatives: list[Node[Any]]) -> None:
-        for alt in alternatives:
-            val = self.run(alt, required=False)
-            if val is not None:
-                self.state[name] = val
-                return
-
-        # got this far, no alternatives
-        raise RuntimeError(f"no alternative for {name} returned data")
 
 
 @dataclass(eq=False)

--- a/src/poprox_recommender/lkpipeline/types.py
+++ b/src/poprox_recommender/lkpipeline/types.py
@@ -11,15 +11,39 @@ import re
 import warnings
 from importlib import import_module
 from types import GenericAlias, NoneType
-from typing import Union, _GenericAlias, get_args, get_origin  # type: ignore
+from typing import Generic, Protocol, TypeVar, Union, _GenericAlias, get_args, get_origin  # type: ignore
 
 import numpy as np
+
+T = TypeVar("T", covariant=True)
 
 
 class TypecheckWarning(UserWarning):
     "Warnings about type-checking logic."
 
     pass
+
+
+class Lazy(Protocol, Generic[T]):
+    """
+    Type for accepting lazy inputs from the pipeline runner.  If your function
+    may or may not need one of its inputs, declare the type with this to only
+    run it as needed:
+
+    .. code:: python
+
+        def my_component(input: str, backup: Lazy[str]) -> str:
+            if input == 'invalid':
+                return backup.get()
+            else:
+                return input
+    """
+
+    def get(self) -> T:
+        """
+        Get the value behind this lazy instance.
+        """
+        ...
 
 
 def is_compatible_type(typ: type, *targets: type) -> bool:

--- a/tests/lkpipeline/test_lazy.py
+++ b/tests/lkpipeline/test_lazy.py
@@ -1,0 +1,141 @@
+# pyright: strict
+from pytest import fail, raises
+
+from poprox_recommender.lkpipeline import Lazy, Pipeline
+
+
+def fallback(first: int | None, second: Lazy[int]) -> int:
+    if first is not None:
+        return first
+    else:
+        return second.get()
+
+
+def test_lazy_input():
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int:
+        return -x
+
+    def double(x: int) -> int:
+        return x * 2
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=a)
+    fb = pipe.add_component("fill-operand", fallback, first=b, second=nn)
+    na = pipe.add_component("add", add, x=nd, y=fb)
+
+    # 3 * 2 + -3 = 3
+    assert pipe.run(na, a=3) == 3
+
+
+def test_lazy_only_run_if_needed():
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int:
+        fail("fallback component run when not needed")
+
+    def double(x: int) -> int:
+        return x * 2
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=a)
+    fb = pipe.add_component("fill-operand", fallback, first=b, second=nn)
+    na = pipe.add_component("add", add, x=nd, y=fb)
+
+    assert pipe.run(na, a=3, b=8) == 14
+
+
+def test_lazy_fail_with_missing_options():
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int | None:
+        return None
+
+    def double(x: int) -> int:
+        return x * 2
+
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=a)
+    fb = pipe.add_component("fill-operand", fallback, first=b, second=nn)
+    na = pipe.add_component("add", add, x=nd, y=fb)
+
+    with raises(RuntimeError, match="no alternative"):
+        pipe.run(na, a=3)
+
+
+def test_lazy_transitive():
+    "test that a fallback works if a dependency's dependency fails"
+    pipe = Pipeline()
+    ia = pipe.create_input("a", int)
+    ib = pipe.create_input("b", int)
+
+    def double(x: int) -> int:
+        return 2 * x
+
+    # two components, each with a different input
+    c1 = pipe.add_component("double-a", double, x=ia)
+    c2 = pipe.add_component("double-b", double, x=ib)
+    # use the first that succeeds
+    c = pipe.add_component("fill-operand", fallback, first=c1, second=c2)
+
+    # omitting the first input should result in the second component
+    assert pipe.run(c, b=17) == 34
+
+
+def test_lazy_transitive_deeper():
+    "deeper transitive fallback test"
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int:
+        return -x
+
+    def double(x: int) -> int:
+        return x * 2
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=nd)
+    nr = pipe.add_component("fill-operand", fallback, first=nn, second=b)
+
+    assert pipe.run(nr, b=8) == 8
+
+
+def test_lazy_transitive_nodefail():
+    "deeper transitive fallback test"
+    pipe = Pipeline()
+    a = pipe.create_input("a", int)
+    b = pipe.create_input("b", int)
+
+    def negative(x: int) -> int | None:
+        # make this return None in some cases to trigger failure
+        if x >= 0:
+            return -x
+        else:
+            return None
+
+    def double(x: int) -> int:
+        return x * 2
+
+    nd = pipe.add_component("double", double, x=a)
+    nn = pipe.add_component("negate", negative, x=nd)
+    nr = pipe.use_first_of("fill-operand", nn, b)
+
+    assert pipe.run(nr, a=2, b=8) == -4
+    assert pipe.run(nr, a=-7, b=8) == 8

--- a/tests/lkpipeline/test_lazy.py
+++ b/tests/lkpipeline/test_lazy.py
@@ -135,7 +135,7 @@ def test_lazy_transitive_nodefail():
 
     nd = pipe.add_component("double", double, x=a)
     nn = pipe.add_component("negate", negative, x=nd)
-    nr = pipe.use_first_of("fill-operand", nn, b)
+    nr = pipe.add_component("fill-operand", fallback, first=nn, second=b)
 
     assert pipe.run(nr, a=2, b=8) == -4
     assert pipe.run(nr, a=-7, b=8) == 8

--- a/tests/lkpipeline/test_lazy.py
+++ b/tests/lkpipeline/test_lazy.py
@@ -75,7 +75,7 @@ def test_lazy_fail_with_missing_options():
     fb = pipe.add_component("fill-operand", fallback, first=b, second=nn)
     na = pipe.add_component("add", add, x=nd, y=fb)
 
-    with raises(RuntimeError, match="no alternative"):
+    with raises(TypeError):
         pipe.run(na, a=3)
 
 

--- a/tests/lkpipeline/test_pipeline.py
+++ b/tests/lkpipeline/test_pipeline.py
@@ -8,7 +8,7 @@
 from uuid import UUID
 
 import numpy as np
-from pytest import fail, raises, warns
+from pytest import raises, warns
 from typing_extensions import assert_type
 
 from poprox_recommender.lkpipeline import InputNode, Node, Pipeline, PipelineError
@@ -448,136 +448,6 @@ def test_fail_missing_input():
 
     # missing inputs only matter if they are required
     assert pipe.run(nd, a=3) == 6
-
-
-def test_fallback_input():
-    pipe = Pipeline()
-    a = pipe.create_input("a", int)
-    b = pipe.create_input("b", int)
-
-    def negative(x: int) -> int:
-        return -x
-
-    def double(x: int) -> int:
-        return x * 2
-
-    def add(x: int, y: int) -> int:
-        return x + y
-
-    nd = pipe.add_component("double", double, x=a)
-    nn = pipe.add_component("negate", negative, x=a)
-    fb = pipe.use_first_of("fill-operand", b, nn)
-    na = pipe.add_component("add", add, x=nd, y=fb)
-
-    # 3 * 2 + -3 = 3
-    assert pipe.run(na, a=3) == 3
-
-
-def test_fallback_only_run_if_needed():
-    pipe = Pipeline()
-    a = pipe.create_input("a", int)
-    b = pipe.create_input("b", int)
-
-    def negative(x: int) -> int:
-        fail("fallback component run when not needed")
-
-    def double(x: int) -> int:
-        return x * 2
-
-    def add(x: int, y: int) -> int:
-        return x + y
-
-    nd = pipe.add_component("double", double, x=a)
-    nn = pipe.add_component("negate", negative, x=a)
-    fb = pipe.use_first_of("fill-operand", b, nn)
-    na = pipe.add_component("add", add, x=nd, y=fb)
-
-    assert pipe.run(na, a=3, b=8) == 14
-
-
-def test_fallback_fail_with_missing_options():
-    pipe = Pipeline()
-    a = pipe.create_input("a", int)
-    b = pipe.create_input("b", int)
-
-    def negative(x: int) -> int | None:
-        return None
-
-    def double(x: int) -> int:
-        return x * 2
-
-    def add(x: int, y: int) -> int:
-        return x + y
-
-    nd = pipe.add_component("double", double, x=a)
-    nn = pipe.add_component("negate", negative, x=a)
-    fb = pipe.use_first_of("fill-operand", b, nn)
-    na = pipe.add_component("add", add, x=nd, y=fb)
-
-    with raises(RuntimeError, match="no alternative"):
-        pipe.run(na, a=3)
-
-
-def test_fallback_transitive():
-    "test that a fallback works if a dependency's dependency fails"
-    pipe = Pipeline()
-    ia = pipe.create_input("a", int)
-    ib = pipe.create_input("b", int)
-
-    def double(x: int) -> int:
-        return 2 * x
-
-    # two components, each with a different input
-    c1 = pipe.add_component("double-a", double, x=ia)
-    c2 = pipe.add_component("double-b", double, x=ib)
-    # use the first that succeeds
-    c = pipe.use_first_of("result", c1, c2)
-
-    # omitting the first input should result in the second component
-    assert pipe.run(c, b=17) == 34
-
-
-def test_fallback_transitive_deeper():
-    "deeper transitive fallback test"
-    pipe = Pipeline()
-    a = pipe.create_input("a", int)
-    b = pipe.create_input("b", int)
-
-    def negative(x: int) -> int:
-        return -x
-
-    def double(x: int) -> int:
-        return x * 2
-
-    nd = pipe.add_component("double", double, x=a)
-    nn = pipe.add_component("negate", negative, x=nd)
-    nr = pipe.use_first_of("fill-operand", nn, b)
-
-    assert pipe.run(nr, b=8) == 8
-
-
-def test_fallback_transitive_nodefail():
-    "deeper transitive fallback test"
-    pipe = Pipeline()
-    a = pipe.create_input("a", int)
-    b = pipe.create_input("b", int)
-
-    def negative(x: int) -> int | None:
-        # make this return None in some cases to trigger failure
-        if x >= 0:
-            return -x
-        else:
-            return None
-
-    def double(x: int) -> int:
-        return x * 2
-
-    nd = pipe.add_component("double", double, x=a)
-    nn = pipe.add_component("negate", negative, x=nd)
-    nr = pipe.use_first_of("fill-operand", nn, b)
-
-    assert pipe.run(nr, a=2, b=8) == -4
-    assert pipe.run(nr, a=-7, b=8) == 8
 
 
 def test_pipeline_component_default():

--- a/tests/lkpipeline/test_save_load.py
+++ b/tests/lkpipeline/test_save_load.py
@@ -183,27 +183,6 @@ def test_hashes_different():
     assert p1.config_hash() != p2.config_hash()
 
 
-def test_save_with_fallback():
-    pipe = Pipeline()
-    a = pipe.create_input("a", int)
-    b = pipe.create_input("b", int)
-
-    nd = pipe.add_component("double", double, x=a)
-    nn = pipe.add_component("negate", negative, x=a)
-    fb = pipe.use_first_of("fill-operand", b, nn)
-    pipe.add_component("add", add, x=nd, y=fb)
-
-    cfg = pipe.get_config()
-    json = cfg.model_dump_json(exclude_none=True)
-    print(json)
-    c2 = PipelineConfig.model_validate_json(json)
-
-    p2 = Pipeline.from_config(c2)
-
-    # 3 * 2 + -3 = 3
-    assert p2.run("fill-operand", "add", a=3) == (-3, 3)
-
-
 def test_hash_validate():
     pipe = Pipeline()
     msg = pipe.create_input("msg", str)


### PR DESCRIPTION
This addresses a question early in discussion on fallbacks where @karlhigley suggested that a fallback should be a component. The way I see to do that without excessive recomputation is through lazy node inputs.

This introduces the following changes:

1.  Add a `Lazy` type so that a component can take a `Lazy[T]` instead of `T`, and the pipeline will key off that type declaration to defer computation of that input until it is requested.
2. Reimplement the fallback tests to use lazy nodes.
3. Update the runner to defer computation of lazy inputs.
4. Update the `Fill` POPROX component to take its second input lazily, and only request it if the first set of recommendations is too short.
5. Update the combiner tests to use the new pipeline.
6. Yeet the `use_first_of` method, `FallbackNode`, and related obsolete logic.

The result is a reduction in the number of concepts in the pipeline — rather than components, and edges, and other weird things like fallbacks, we just have components and edges (and literals).

It builds on #92, and will be easier to review once that is merged.