### PR TITLE
Fix tests to work without model data

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,13 +67,6 @@ jobs:
           environments: test
           activate-environment: true
 
-      - name: Fetch model data
-        run: |
-          dvc pull -R models tests
-        env:
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-
       - name: Run tests
         run: |
           python -m pytest -v

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,8 @@ jobs:
         with:
           pixi-version: v0.29.0
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # just reuse cache from previous run of other test action
+          cache-write: false
           environments: test
           activate-environment: true
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,3 +70,5 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest -v
+        env:
+          POPROX_CI_WITHOUT_DATA: 1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,13 +6,8 @@ on:
       - main
   pull_request:
 
-# override default shell for mamba activation
-defaults:
-  run:
-    shell: bash -el {0}
-
 jobs:
-  run-tests:
+  full-tests:
     name: Run the PyTest tests
     runs-on: ubuntu-latest
 
@@ -40,6 +35,36 @@ jobs:
         with:
           path: .dvc/cache
           key: test-dvc-cache-${{ hashFiles('models/**.dvc') }}
+
+      - name: Fetch model data
+        run: |
+          dvc pull -R models tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+
+      - name: Run tests
+        run: |
+          python -m pytest -v
+
+  nodata-tests:
+    name: Run the PyTest tests without model data
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install environment
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.29.0
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          environments: test
+          activate-environment: true
 
       - name: Fetch model data
         run: |

--- a/src/poprox_recommender/config.py
+++ b/src/poprox_recommender/config.py
@@ -45,3 +45,11 @@ def available_cpu_parallelism(max: int | None = None) -> int:
         n_cpus = max
 
     return n_cpus
+
+
+def allow_data_test_failures() -> bool:
+    "Whether to allow tests to fail because the DVC-managed data is missing."
+    if "CI" in os.environ:
+        return "POPROX_CI_WITHOUT_DATA" in os.environ
+
+    return True

--- a/tests/components/test_softmax_sampler.py
+++ b/tests/components/test_softmax_sampler.py
@@ -1,5 +1,7 @@
 import logging
 
+from pytest import skip
+
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest
 from poprox_recommender.paths import project_root
@@ -15,17 +17,21 @@ def test_request_with_softmax_sampler():
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
-    base_outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-    )
-    sampled_outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-        pipeline_params={"pipeline": "softmax"},
-    )
+    try:
+        base_outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+        )
+        sampled_outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+            pipeline_params={"pipeline": "softmax"},
+        )
+    except FileNotFoundError:
+        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
+        skip("model data not available")
 
     # do we get recommendations?
     softmax_recs = sampled_outputs.default.articles

--- a/tests/components/test_softmax_sampler.py
+++ b/tests/components/test_softmax_sampler.py
@@ -1,37 +1,35 @@
 import logging
 
-from pytest import skip
+from pytest import mark, skip
 
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
-from poprox_recommender.recommenders import select_articles
+from poprox_recommender.recommenders import PipelineLoadError, select_articles
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+@mark.xfail(condition=allow_data_test_failures(), raises=PipelineLoadError, reason="data not pulled")
 def test_request_with_softmax_sampler():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "medium_request.json"
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
-    try:
-        base_outputs = select_articles(
-            ArticleSet(articles=req.todays_articles),
-            ArticleSet(articles=req.past_articles),
-            req.interest_profile,
-        )
-        sampled_outputs = select_articles(
-            ArticleSet(articles=req.todays_articles),
-            ArticleSet(articles=req.past_articles),
-            req.interest_profile,
-            pipeline_params={"pipeline": "softmax"},
-        )
-    except FileNotFoundError:
-        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
-        skip("model data not available")
+    base_outputs = select_articles(
+        ArticleSet(articles=req.todays_articles),
+        ArticleSet(articles=req.past_articles),
+        req.interest_profile,
+    )
+    sampled_outputs = select_articles(
+        ArticleSet(articles=req.todays_articles),
+        ArticleSet(articles=req.past_articles),
+        req.interest_profile,
+        pipeline_params={"pipeline": "softmax"},
+    )
 
     # do we get recommendations?
     softmax_recs = sampled_outputs.default.articles

--- a/tests/components/test_softmax_sampler.py
+++ b/tests/components/test_softmax_sampler.py
@@ -16,6 +16,8 @@ logger.setLevel(logging.DEBUG)
 def test_request_with_softmax_sampler():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "medium_request.json"
+    if allow_data_test_failures() and not req_f.exists():
+        skip("request file does not exist")
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 

--- a/tests/components/test_topic_calibration.py
+++ b/tests/components/test_topic_calibration.py
@@ -4,6 +4,8 @@ Test the topic calibration logic.
 
 import logging
 
+from pytest import skip
+
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest
 from poprox_recommender.paths import project_root
@@ -19,17 +21,21 @@ def test_request_with_topic_calibrator():
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
-    base_outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-    )
-    topic_calibrated_outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-        pipeline_params={"pipeline": "topic-cali"},
-    )
+    try:
+        base_outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+        )
+        topic_calibrated_outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+            pipeline_params={"pipeline": "topic-cali"},
+        )
+    except FileNotFoundError:
+        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
+        skip("model data not available")
 
     # do we get recommendations?
     tco_recs = topic_calibrated_outputs.default.articles

--- a/tests/components/test_topic_calibration.py
+++ b/tests/components/test_topic_calibration.py
@@ -4,38 +4,36 @@ Test the topic calibration logic.
 
 import logging
 
-from pytest import skip
+from pytest import mark, skip
 
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
-from poprox_recommender.recommenders import select_articles
+from poprox_recommender.recommenders import PipelineLoadError, select_articles
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+@mark.xfail(condition=allow_data_test_failures(), raises=PipelineLoadError, reason="data not pulled")
 def test_request_with_topic_calibrator():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "medium_request.json"
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
-    try:
-        base_outputs = select_articles(
-            ArticleSet(articles=req.todays_articles),
-            ArticleSet(articles=req.past_articles),
-            req.interest_profile,
-        )
-        topic_calibrated_outputs = select_articles(
-            ArticleSet(articles=req.todays_articles),
-            ArticleSet(articles=req.past_articles),
-            req.interest_profile,
-            pipeline_params={"pipeline": "topic-cali"},
-        )
-    except FileNotFoundError:
-        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
-        skip("model data not available")
+    base_outputs = select_articles(
+        ArticleSet(articles=req.todays_articles),
+        ArticleSet(articles=req.past_articles),
+        req.interest_profile,
+    )
+    topic_calibrated_outputs = select_articles(
+        ArticleSet(articles=req.todays_articles),
+        ArticleSet(articles=req.past_articles),
+        req.interest_profile,
+        pipeline_params={"pipeline": "topic-cali"},
+    )
 
     # do we get recommendations?
     tco_recs = topic_calibrated_outputs.default.articles

--- a/tests/components/test_topic_calibration.py
+++ b/tests/components/test_topic_calibration.py
@@ -20,6 +20,8 @@ logger.setLevel(logging.DEBUG)
 def test_request_with_topic_calibrator():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "medium_request.json"
+    if allow_data_test_failures() and not req_f.exists():
+        skip("request file does not exist")
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 

--- a/tests/integration/test_serverless_offline.py
+++ b/tests/integration/test_serverless_offline.py
@@ -20,7 +20,7 @@ try:
     PIPELINES = recommendation_pipelines().keys()
 except Exception as e:
     warnings.warn("failed to load models, did you run `dvc pull`?")
-    if "CI" not in os.environ:
+    if "CI" not in os.environ or "POPROX_CI_WITHOUT_DATA" in os.environ:
         skip("recommendation pipelines unavailable", allow_module_level=True)
     else:
         raise e

--- a/tests/integration/test_serverless_offline.py
+++ b/tests/integration/test_serverless_offline.py
@@ -12,6 +12,7 @@ import requests
 from pexpect import EOF, spawn
 from pytest import fail, fixture, mark, skip
 
+from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
 from poprox_recommender.recommenders import recommendation_pipelines
 
@@ -20,7 +21,7 @@ try:
     PIPELINES = recommendation_pipelines().keys()
 except Exception as e:
     warnings.warn("failed to load models, did you run `dvc pull`?")
-    if "CI" not in os.environ or "POPROX_CI_WITHOUT_DATA" in os.environ:
+    if allow_data_test_failures():
         skip("recommendation pipelines unavailable", allow_module_level=True)
     else:
         raise e

--- a/tests/integration/test_serverless_offline.py
+++ b/tests/integration/test_serverless_offline.py
@@ -5,6 +5,7 @@ Test the POPROX endpoint running under Serverless Offline.
 import logging
 import os
 import sys
+import warnings
 from threading import Condition, Lock, Thread
 
 import requests
@@ -18,8 +19,9 @@ logger = logging.getLogger(__name__)
 try:
     PIPELINES = recommendation_pipelines().keys()
 except Exception as e:
+    warnings.warn("failed to load models, did you run `dvc pull`?")
     if "CI" not in os.environ:
-        skip("recommendation pipelines unavailable")
+        skip("recommendation pipelines unavailable", allow_module_level=True)
     else:
         raise e
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -4,6 +4,8 @@ Test the POPROX API through direct call.
 
 import logging
 
+from pytest import skip
+
 from poprox_concepts import ArticleSet, Click
 from poprox_concepts.api.recommendations import RecommendationRequest
 from poprox_recommender.paths import project_root
@@ -18,11 +20,15 @@ def test_direct_basic_request():
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
     logger.info("generating recommendations")
-    outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-    )
+    try:
+        outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+        )
+    except FileNotFoundError:
+        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
+        skip("model data not available")
     # do we get recommendations?
     assert len(outputs.default.articles) > 0
 
@@ -36,10 +42,14 @@ def test_direct_basic_request_without_clicks():
 
     profile = req.interest_profile
     profile.click_history = []
-    outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-    )
+    try:
+        outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+        )
+    except FileNotFoundError:
+        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
+        skip("model data not available")
     # do we get recommendations?
     assert len(outputs.default.articles) > 0

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -4,35 +4,35 @@ Test the POPROX API through direct call.
 
 import logging
 
-from pytest import skip
+from pytest import mark, skip
 
 from poprox_concepts import ArticleSet, Click
 from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
-from poprox_recommender.recommenders import select_articles
+from poprox_recommender.recommenders import PipelineLoadError, select_articles
 
 logger = logging.getLogger(__name__)
 
 
+@mark.xfail(condition=allow_data_test_failures(), raises=PipelineLoadError, reason="data not pulled")
 def test_direct_basic_request():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "basic-request.json"
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
     logger.info("generating recommendations")
-    try:
-        outputs = select_articles(
-            ArticleSet(articles=req.todays_articles),
-            ArticleSet(articles=req.past_articles),
-            req.interest_profile,
-        )
-    except FileNotFoundError:
-        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
-        skip("model data not available")
+    outputs = select_articles(
+        ArticleSet(articles=req.todays_articles),
+        ArticleSet(articles=req.past_articles),
+        req.interest_profile,
+    )
+
     # do we get recommendations?
     assert len(outputs.default.articles) > 0
 
 
+@mark.xfail(condition=allow_data_test_failures(), raises=PipelineLoadError, reason="data not pulled")
 def test_direct_basic_request_without_clicks():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "basic-request.json"
@@ -42,14 +42,11 @@ def test_direct_basic_request_without_clicks():
 
     profile = req.interest_profile
     profile.click_history = []
-    try:
-        outputs = select_articles(
-            ArticleSet(articles=req.todays_articles),
-            ArticleSet(articles=req.past_articles),
-            req.interest_profile,
-        )
-    except FileNotFoundError:
-        # FIXME: when we have configuration files, separate "cannot load" from "cannot run"
-        skip("model data not available")
+    outputs = select_articles(
+        ArticleSet(articles=req.todays_articles),
+        ArticleSet(articles=req.past_articles),
+        req.interest_profile,
+    )
+
     # do we get recommendations?
     assert len(outputs.default.articles) > 0

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -6,7 +6,7 @@ import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from pytest import mark, skip
+from pytest import mark, xfail
 
 from poprox_recommender.paths import model_file_path, project_root
 
@@ -31,7 +31,7 @@ def test_module_file_path_project_root():
         root = project_root()
         if not (root / "models" / "model.safetensors").exists():
             warnings.warn("model source file not available")
-            skip("model data not available")
+            xfail("model data not available")
 
         mfile = model_file_path("model.safetensors")
 
@@ -54,7 +54,7 @@ def test_module_file_path_env_dir():
             model_src = root / "models" / "model.safetensors"
             if not model_src.exists():
                 warnings.warn("model source file not available")
-                skip("model data not available")
+                xfail("model data not available")
 
             shutil.copy(model_src, td_path / "model.safetensors")
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,10 +2,11 @@ import logging
 import os
 import platform
 import shutil
+import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from pytest import mark
+from pytest import mark, skip
 
 from poprox_recommender.paths import model_file_path, project_root
 
@@ -28,6 +29,10 @@ def test_module_file_path_project_root():
         if old:
             del os.environ["POPROX_MODELS"]
         root = project_root()
+        if not (root / "models" / "model.safetensors").exists():
+            warnings.warn("model source file not available")
+            skip("model data not available")
+
         mfile = model_file_path("model.safetensors")
 
         assert mfile == root / "models" / "model.safetensors"
@@ -46,7 +51,12 @@ def test_module_file_path_env_dir():
             root = project_root()
 
             logger.info("copying model file")
-            shutil.copy(root / "models" / "model.safetensors", td_path / "model.safetensors")
+            model_src = root / "models" / "model.safetensors"
+            if not model_src.exists():
+                warnings.warn("model source file not available")
+                skip("model data not available")
+
+            shutil.copy(model_src, td_path / "model.safetensors")
 
             mfile = model_file_path("model.safetensors")
 

--- a/tests/test_topic_classification.py
+++ b/tests/test_topic_classification.py
@@ -2,7 +2,10 @@ import json
 import logging
 import random
 
+from pytest import skip
+
 from poprox_concepts import Article, ArticleSet, Click
+from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
 from poprox_recommender.topics import GENERAL_TOPICS, extract_general_topics, match_news_topics_to_general
 
@@ -12,6 +15,8 @@ logger = logging.getLogger(__name__)
 def load_test_articles():
     test_dir = project_root() / "tests"
     event_path = test_dir / "request_data" / "request_body.json"
+    if allow_data_test_failures() and not event_path.exists():
+        skip("request file does not exist")
 
     with open(event_path, "r") as j:
         req_body = json.loads(j.read())


### PR DESCRIPTION
This PR fixes our testing situation without model data.

- [x] Fix `skip` invocation to correctly skip Serverless tests when pipelines are unavailable
- [x] Emit a warning when pipelines are unavailable
- [x] Add CI task to run tests without model data (or NPM dependencies), to ensure the suite still runs and data-dependent tests are appropriately skipped
- [x] Add `PipelineLoadError` to distinguish between problems loading the pipeline and problems running it.
- [x] Add function to determine if tests should be allowed to succeed if the loadable data is missing. 
- [x] Fix everything the CI task breaks