### PR TITLE
Use Pixi tasks for further automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ Once you have installed the dependencies, there are 3 easy ways to run code in t
     pixi shell -e dev
     ```
 
-> [!NOTE]
-> Tests are also available as a Pixi task: `pixi run -e dev test`.
-
-
 Finally, set up `pre-commit` to make sure that code formatting rules are applied
 as you make changes:
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Once you have installed the dependencies, there are 3 easy ways to run code in t
     pixi shell -e dev
     ```
 
+> [!NOTE]
+>
+> `pixi shell` starts a new, *nested* shell with the Pixi environment active. If
+> you type `exit` in this shell, it will exit the nested shell and return you to
+> you original shell session without the environment active.
+
 Finally, set up `pre-commit` to make sure that code formatting rules are applied
 as you make changes:
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,21 @@ pixi install -e dev
 
 Alternatively, on Linux, you can use `cuda` instead of `dev`.
 
-Once you have installed the dependencies, there are 2 easy ways to run code in the environment:
+Once you have installed the dependencies, there are 3 easy ways to run code in the environment:
 
-1.  Run individual commands with `pixi run`, e.g.:
+1.  Run a defined task, like `test`, with `pixi run`:
+
+    ```console
+    pixi run -e dev test
+    ```
+
+2.  Run individual commands with `pixi run`, e.g.:
 
     ```console
     pixi run -e dev pytest tests
     ```
 
-2.  Run a Pixi shell, which activates the environment and adds the appropriate
+3.  Run a Pixi shell, which activates the environment and adds the appropriate
     Python to your `PATH`:
 
     ```console
@@ -85,17 +91,29 @@ pixi update
 
 ## Local Endpoint Development
 
-Local endpoint development also requires some Node-based tools in addition to the tools above:
+Local endpoint development also requires some Node-based tools in addition to the tools above — this install is
+automated with `npm` and `pixi`:
 
 ```console
-npm install
+pixi run -e dev install-serverless
 ```
 
 To run the API endpoint locally:
 
 ```console
+pixi run -e dev start-serverless
+```
+
+<details>
+<summary>Implementation</sumamry>
+
+Under the hood, those tasks run the following Node commands within the `dev` environment:
+
+```console
+npm ci
 npx serverless offline start --reloadHandler
 ```
+</details>
 
 Once the local server is running, you can send requests to `localhost:3000`. A request with this JSON body:
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -58,6 +58,12 @@ conda-pack = "~=0.8"
 [feature.serverless.dependencies]
 nodejs = "~=22.1"
 
+[feature.serverless.tasks]
+install-serverless = "npm ci"
+start-serverless = { cmd = "npx serverless offline start --reloadHandler", depends-on = [
+  "install-serverless",
+] }
+
 # general development dependencies
 [feature.dev.dependencies]
 hatch = "*"
@@ -86,7 +92,7 @@ pexpect = "~=4.9"
 poprox-recommender = { path = ".", editable = true }
 
 [feature.test.tasks]
-test = "pytest tests"
+test = { cmd = "pytest tests", depends-on = ["install-serverless"] }
 
 # tooling for code validation
 [feature.lint.dependencies]


### PR DESCRIPTION
This PR adds additional `pixi` tasks to automate installing & starting Serverless, and makes the serverless install step a dependency of `test`.  That way we can run the tests, installing Serverless if needed, with one command:

```console
pixi run -e dev test
```

I also update the README to use these, and to reduce the risk of environment-related "where do we actually run npm/npx?" errors encountered when onboarding an external research student recently.