### PR TITLE
Fix test xfail logic

### DIFF
--- a/tests/components/test_softmax_sampler.py
+++ b/tests/components/test_softmax_sampler.py
@@ -1,6 +1,6 @@
 import logging
 
-from pytest import mark, skip
+from pytest import skip, xfail
 
 from poprox_concepts import ArticleSet
 from poprox_concepts.api.recommendations import RecommendationRequest
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-@mark.xfail(condition=allow_data_test_failures(), raises=PipelineLoadError, reason="data not pulled")
 def test_request_with_softmax_sampler():
     test_dir = project_root() / "tests"
     req_f = test_dir / "request_data" / "medium_request.json"
@@ -21,17 +20,23 @@ def test_request_with_softmax_sampler():
 
     req = RecommendationRequest.model_validate_json(req_f.read_text())
 
-    base_outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-    )
-    sampled_outputs = select_articles(
-        ArticleSet(articles=req.todays_articles),
-        ArticleSet(articles=req.past_articles),
-        req.interest_profile,
-        pipeline_params={"pipeline": "softmax"},
-    )
+    try:
+        base_outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+        )
+        sampled_outputs = select_articles(
+            ArticleSet(articles=req.todays_articles),
+            ArticleSet(articles=req.past_articles),
+            req.interest_profile,
+            pipeline_params={"pipeline": "softmax"},
+        )
+    except PipelineLoadError as e:
+        if allow_data_test_failures():
+            xfail("data not pulled")
+        else:
+            raise e
 
     # do we get recommendations?
     softmax_recs = sampled_outputs.default.articles


### PR DESCRIPTION
The `mark.xfail` marker did not do what I thought it would do — if `condition` was true, it didn't even try to run the test, when I wanted it to only allow the failure to be expected if the condition was true.

This PR replaces `mark.xfail` with exception-catching and imperative `xfail`, so that it does try to run the tests in all cases.