### PR TITLE
Remove dependency on ADD --chmod working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 ARG LOG_LEVEL=INFO
+
 # Use Lambda "Provided" base image for the build container
 FROM public.ecr.aws/lambda/provided:al2023 AS build
+ARG PIXI_VERSION=0.31.0
 
 # install necessary system packages
 RUN dnf -y install git-core
 
 # Fetch the pixi executable from GitHub
-ADD --chmod=0755 https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-unknown-linux-musl  /usr/local/bin/pixi
+# see: https://github.com/prefix-dev/pixi-docker/blob/main/Dockerfile
+RUN curl -fsL \
+    "https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/pixi-x86_64-unknown-linux-musl" \
+    -o /usr/local/bin/pixi && chmod +x /usr/local/bin/pixi
 
 # Copy the soure code into the image to install it and create the environment
 # TODO do we want to copy the sdist or wheel instead?


### PR DESCRIPTION
This updates `Dockerfile` to use `curl` instead of `ADD --chmod`, which was causing compatibility problems with Docker updates. Docker removed support in "legacy" `docker build`, so this option only works with the new `docker-buildx`. We'll probably be on that eventually, and many already are, but I'd rather not have our builds break because Docker pulled a rug, and `RUN` should keep working.

I am doing this, copying the logic from [prefix-dev/pixi-docker](https://github.com/prefix-dev/pixi-docker/) instead of using their images, because I don't want to deal with the potential problems of using a Debian-based image to build and a RedHat-based image to deploy (Amazon Linux is derived from Red Hat / CentOS / Fedora).