### PR TITLE
Update pre-commit and copier template with secret scanning

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 733113b
+_commit: 48a6656
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: a040681
+_commit: 2fd3bf2
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: c4194d6
+_commit: 733113b
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 48a6656
+_commit: a040681
 _src_path: https://github.com/CCRI-POPROX/poprox-repo-template
 package_name: poprox_recommender
 project_descr: POPROX recommender implementation and infrastructure.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,14 +39,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
         name: format Python source
-  - repo: local
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.10.0-1
     hooks:
-      # shfmt support, adapted from https://github.com/mvdan/sh/issues/818
-      - id: format-shell-scripts
-        name: format shell scripts
-        language: golang
-        require_serial: true
-        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.8.0]
-        entry: shfmt
-        args: ["-l", "-w", "-i", "4"]
-        types: [shell]
+      - id: shfmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,10 @@ repos:
       - id: yamlfmt
         name: format yaml files
         exclude: (cloudformation|conda-lock.*)\.yml
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.7.1
@@ -37,14 +41,6 @@ repos:
         name: format Python source
   - repo: local
     hooks:
-      - id: format-toml-files
-        name: format toml files
-        entry: taplo
-        args: ["format"]
-        files: \.toml$
-        language: node
-        additional_dependencies:
-          - "@taplo/cli"
       # shfmt support, adapted from https://github.com/mvdan/sh/issues/818
       - id: format-shell-scripts
         name: format shell scripts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,10 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.0
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/google/yamlfmt
     rev: v0.12.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         exclude: conda-lock.*\.yml|pixi\.lock
@@ -19,14 +19,14 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/google/yamlfmt
-    rev: v0.12.1
+    rev: v0.13.0
     hooks:
       - id: yamlfmt
         name: format yaml files
         exclude: (cloudformation|conda-lock.*)\.yml
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.8
+    rev: v0.7.1
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.0
+    rev: v8.21.1
     hooks:
       - id: gitleaks
   - repo: https://github.com/google/yamlfmt

--- a/scripts/upload-shared-data.sh
+++ b/scripts/upload-shared-data.sh
@@ -6,7 +6,7 @@ repo="UNKNOWN"
 file_attr_pattern=""
 upload=yes
 
-while [[ -n "$1" ]]; do
+while [[ -n $1 ]]; do
     case "$1" in
     --shared)
         file_attr_pattern='poprox-sharing: (shared|public)$'
@@ -33,7 +33,7 @@ while [[ -n "$1" ]]; do
     esac
 done
 
-if [[ -z "$file_attr_pattern" ]]; then
+if [[ -z $file_attr_pattern ]]; then
     echo "no target specified" >&2
     exit 2
 fi
@@ -47,7 +47,7 @@ files=($(dvc list --dvc-only -R . |
     sed -e 's/:.*$//'))
 
 echo "found ${#files[@]} files to share"
-if [[ $upload = yes ]]; then
+if [[ $upload == yes ]]; then
     set -x
     dvc push -r $repo "${files[@]}"
 fi


### PR DESCRIPTION
This adds [gitleaks][] to the Copier template and imports those changes here, updates our other pre-commit hook versions, and replaces our `local` hooks with externally-maintained hooks that have emerged since last setup.

This will reduce the risk of accidentally committing secrets to the repository.

[gitleaks]: https://github.com/gitleaks/gitleaks