### PR TITLE
Create an `EmbeddingCopier` component

### DIFF
--- a/src/poprox_recommender/components/embedders/article.py
+++ b/src/poprox_recommender/components/embedders/article.py
@@ -112,3 +112,25 @@ class NRMSArticleEmbedder(Component):
         article_set.embeddings = embed_tensor  # type: ignore
 
         return article_set
+
+
+class EmbeddingCopier(Component):
+    @torch_inference
+    def __call__(self, candidate_set: ArticleSet, selected_set: ArticleSet) -> ArticleSet:
+        candidate_article_ids = [article.article_id for article in candidate_set.articles]
+
+        article_embeddings = []
+        for article in selected_set.articles:
+            idx = candidate_article_ids.index(article.article_id)
+            article_embeddings.append(candidate_set.embeddings[idx])
+
+        selected_set.embeddings = th.stack(article_embeddings)
+
+        assert_tensor_size(
+            selected_set.embeddings,
+            len(selected_set.articles),
+            candidate_set.embeddings.shape[1],
+            label="copied article embeddings",
+        )
+
+        return selected_set


### PR DESCRIPTION
This copies embeddings from a candidate set to an selected set of articles, so that embeddings can be used in downstream analysis for metrics like ILD.