### PR TITLE
Deleted locality_code from the topics.py

### DIFF
--- a/src/poprox_recommender/topics.py
+++ b/src/poprox_recommender/topics.py
@@ -22,17 +22,8 @@ def extract_locality_topics(article: Article) -> set[str]:
     return article_topics.intersection(locality_topics)
 
 
-def extract_locality_codes(article: Article) -> set[str]:
-    if "raw_data" in article and "subject" in article.raw_data:
-        article_codes = set([sub.code for sub in article.raw_data.subject if sub.code and len(sub.code) == 1])
-        locality_codes = ["a", "i", "w"]
-        return article_codes.intersection(locality_codes)
-    return []
-
-
 def extract_locality(article: Article) -> list[str]:
     topics = extract_general_topics(article)
-    codes = extract_locality_codes(article)
 
     us_criteria = ("U.S. news" in topics) or ("a" in codes)
     world_criteria = ("World news" in topics) or ("i" in codes)


### PR DESCRIPTION
In the code, We just tested the difference of using subject and subject_code and noticed that there isn't a huge difference with just comparing the data with subject and subject_codes. This modified code only is using locality topics to identify and categorize the news location. 