### PR TITLE
Add a CloudFormation template and CF deploy script

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -1,0 +1,22 @@
+Resources:
+  PoproxRecommenderDeploymentIAMGroup:
+    UpdateReplacePolicy: Retain
+    Type: AWS::IAM::Group
+    DeletionPolicy: Retain
+    Properties:
+      GroupName: poprox-recommender-deployment
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
+        - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+  PoproxRecommenderDeploymentIAMUser:
+    UpdateReplacePolicy: Retain
+    Type: AWS::IAM::User
+    DeletionPolicy: Retain
+    Properties:
+      Path: /
+      UserName: PoproxRecommenderDeploymentIamUser
+      Groups:
+        - !Ref PoproxRecommenderDeploymentIAMGroup

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -1,10 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Deployment and execution resources for the POPROX recommender
+
+Parameters:
+  env:
+    Type: String
+    Default: "prod"
+    AllowedValues:
+      - "prod"
+      - "dev"
+      - "test"
+
 Resources:
   PoproxRecommenderDeploymentIAMGroup:
-    UpdateReplacePolicy: Retain
     Type: AWS::IAM::Group
-    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Delete
     Properties:
-      GroupName: poprox-recommender-deployment
+      GroupName: !Sub "poprox-recommender-deployment-${env}"
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
@@ -12,11 +25,50 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
         - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
   PoproxRecommenderDeploymentIAMUser:
-    UpdateReplacePolicy: Retain
     Type: AWS::IAM::User
-    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Delete
     Properties:
       Path: /
-      UserName: PoproxRecommenderDeploymentIamUser
+      UserName: !Sub "PoproxRecommenderDeploymentIamUser-${env}"
       Groups:
         - !Ref PoproxRecommenderDeploymentIAMGroup
+
+  IamRoleLambdaExecution:
+    Type: AWS::IAM::Role
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Delete
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub "poprox-recommender-${env}-lambda"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:CreateLogGroup
+                  - logs:TagResource
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/poprox-recommender-${env}*:*
+              - Effect: Allow
+                Action:
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/poprox-recommender-${env}*:*:*
+      Path: /
+      RoleName: !Join
+        - '-'
+        - - poprox-recommender
+          - !Ref AWS::Region
+          - lambdaRole
+          - !Sub "${env}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,8 +16,18 @@ region=${region:-us-east-1}
 echo "ENV: $env"
 echo "Region: $region"
 
-# Download model artifacts
-dvc pull -R models
+# Check if a script name was provided as a command line argument
+if [ -z "$1" ]; then
+    echo "Error: Not sure whether to run cloudformation or serverless"
+    exit 1
+fi
 
-# Build container and deploy functions
-npx serverless deploy --stage "${env}" --region "${region}"
+if [ "$1" == "cf" ]; then
+    aws cloudformation deploy --template-file cloudformation.yml --stack-name poprox-research-recommender-"${env}" --region "${region}" --capabilities CAPABILITY_NAMED_IAM
+elif [ "$1" == "sls" ]; then
+    # Download model artifacts
+    dvc pull -R models
+
+    # Build container and deploy functions
+    npx serverless deploy --stage "${env}" --region "${region}"
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,6 +16,8 @@ region=${region:-us-east-1}
 echo "ENV: $env"
 echo "Region: $region"
 
+shift $((OPTIND - 1))
+
 # Check if a script name was provided as a command line argument
 if [ -z "$1" ]; then
     echo "Error: Not sure whether to run cloudformation or serverless"
@@ -23,7 +25,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ "$1" == "cf" ]; then
-    aws cloudformation deploy --template-file cloudformation.yml --stack-name poprox-research-recommender-"${env}" --region "${region}" --capabilities CAPABILITY_NAMED_IAM
+    aws cloudformation deploy --template-file cloudformation.yml --stack-name poprox-research-recommender-"${env}" --parameter-overrides env="${env}" --region "${region}" --capabilities CAPABILITY_NAMED_IAM
 elif [ "$1" == "sls" ]; then
     # Download model artifacts
     dvc pull -R models

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,7 +14,7 @@ provider:
   architecture: x86_64
 
   iam:
-    role: !Sub arn:aws:iam::${AWS::AccountId}:role/poprox-recommender-${AWS::Region}-lambdaRole-${opt:stage}
+    role: arn:aws:iam::${AWS::AccountId}:role/poprox-recommender-${AWS::Region}-lambdaRole-${opt:stage}
 
   ecr:
     # In this section you can define images that will be built locally and uploaded to ECR

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,13 +14,7 @@ provider:
   architecture: x86_64
 
   iam:
-    role:
-      # Add statements to the IAM role to give permissions to Lambda functions
-      statements:
-        - Effect: Allow
-          Action:
-            - "logs:*"
-          Resource: "*"
+    role: !Sub arn:aws:iam::${AWS::AccountId}:role/poprox-recommender-${AWS::Region}-lambdaRole-${opt:stage}
 
   ecr:
     # In this section you can define images that will be built locally and uploaded to ECR

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,7 +14,7 @@ provider:
   architecture: x86_64
 
   iam:
-    role: arn:aws:iam::${AWS::AccountId}:role/poprox-recommender-${AWS::Region}-lambdaRole-${opt:stage}
+    role: arn:aws:iam::${aws:accountId}:role/poprox-test-recommender-${aws:region}-lambdaRole-${opt:stage}
 
   ecr:
     # In this section you can define images that will be built locally and uploaded to ECR

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,7 +14,7 @@ provider:
   architecture: x86_64
 
   iam:
-    role: arn:aws:iam::${aws:accountId}:role/poprox-test-recommender-${aws:region}-lambdaRole-${opt:stage}
+    role: arn:aws:iam::${aws:accountId}:role/poprox-recommender-${aws:region}-lambdaRole-${opt:stage}
 
   ecr:
     # In this section you can define images that will be built locally and uploaded to ECR


### PR DESCRIPTION
This sets up the IAM group and user required to deploy the recommender to an outside AWS account. I opted to keep the group (rather than collapse those permissions onto the user) in order to smooth the path for setting up additional users with the same permissions if desired.