### PR TITLE
Small Docker tweaks and cleanups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ data/
 dist/
 outputs/
 models/news-category-classifier-distilbert/
+.pixi/
 .dvc/
 .git/
 node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 data/
 dist/
+outputs/
 models/news-category-classifier-distilbert/
 .dvc/
 .git/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,16 +40,9 @@ jobs:
           path: .dvc/cache
           key: deploy-dvc-cache-${{ hashFiles('models/**.dvc') }}
 
-      - name: Fetch model data
-        run: |
-          dvc pull -R models
-        env:
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-
       - name: Deploy to Serverless
         run: |
-          npx serverless deploy --stage "$STAGE" --region "$REGION"
+          ./deploy.sh -e "$STAGE" -r "REGION"
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pixi install -e pkg
 # Download the punkt NLTK data
 RUN pixi run -e production python -m nltk.downloader -d build/nltk_data punkt
 # Install poprox-recommender
-RUN pixi run -e production pip install --no-deps .
+RUN pixi run -e production pip install --no-deps --root-user-action .
 # Pack up the environment for migration to runtime
 RUN ./.pixi/envs/pkg/bin/conda-pack -p .pixi/envs/production -d /opt/poprox -o build/production-env.tar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG LOG_LEVEL=INFO
-
 # Use Lambda "Provided" base image for the build container
 FROM public.ecr.aws/lambda/provided:al2023 AS build
 ARG PIXI_VERSION=0.35.0
@@ -34,6 +32,7 @@ RUN ./.pixi/envs/pkg/bin/conda-pack -p .pixi/envs/production -d /opt/poprox -o b
 # Use Lambda "Provided" base image for the deployment container
 # We installed Python ourselves
 FROM public.ecr.aws/lambda/provided:al2023
+ARG LOG_LEVEL=INFO
 
 # Unpack the packaged environment from build container into runtime contianer
 # GNU tar chokes on conda-pack's output, so we use bsdtar

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pixi install -e pkg
 # Download the punkt NLTK data
 RUN pixi run -e production python -m nltk.downloader -d build/nltk_data punkt
 # Install poprox-recommender
-RUN pixi run -e production pip install --no-deps --root-user-action .
+RUN pixi run -e production pip install --no-deps --root-user-action=ignore .
 # Pack up the environment for migration to runtime
 RUN ./.pixi/envs/pkg/bin/conda-pack -p .pixi/envs/production -d /opt/poprox -o build/production-env.tar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG LOG_LEVEL=INFO
 
 # Use Lambda "Provided" base image for the build container
 FROM public.ecr.aws/lambda/provided:al2023 AS build
-ARG PIXI_VERSION=0.31.0
+ARG PIXI_VERSION=0.35.0
 
 # install necessary system packages
 RUN dnf -y install git-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ FROM public.ecr.aws/lambda/provided:al2023
 
 # Unpack the packaged environment from build container into runtime contianer
 # GNU tar chokes on conda-pack's output, so we use bsdtar
-RUN dnf install -y bsdtar
+RUN dnf install -y bsdtar && dnf clean -y all
 RUN mkdir /opt/poprox
 RUN --mount=type=bind,from=build,source=/src/poprox-recommender/build,target=/tmp/poprox-build \
     bsdtar -C /opt/poprox -xf /tmp/poprox-build/production-env.tar

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,7 +17,7 @@ echo "ENV: $env"
 echo "Region: $region"
 
 # Download model artifacts
-dvc pull
+dvc pull -R models
 
 # Build container and deploy functions
-serverless deploy --stage "${env}" --region "${region}"
+npx serverless deploy --stage "${env}" --region "${region}"

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,6 +28,7 @@ provider:
     images:
       poprox-recommender:
         path: "./"
+        platform: linux/amd64
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
Several relatively small improvements to our Docker config:

- configure Serverless to build for `linux/amd64` explicitly
- update deploy.sh to run serverless properly with npx, and only pull necessary DVC data
- bump Pixi version in docker images
- clean up docker image a bit, removing DNF caches (saves 60MB in final image)
- add `outputs/` and `.pixi/` to `.dockerignore`, speeding up Docker build startup a lot