### PR TITLE
Pull model and test data from public S3 repo

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,10 +39,7 @@ jobs:
 
       - name: Fetch model data
         run: |
-          dvc pull -R models
-        env:
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          dvc pull -r public -R models
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,10 +38,7 @@ jobs:
 
       - name: Fetch model data
         run: |
-          dvc pull -R models tests
-        env:
-          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          dvc pull -r public -R models tests
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This pulls the model and test data from the `public` S3 remote, instead of the private one, so that the tests can run without S3 credentials, so long as they only depend on data we have pushed to `public`.