### PR TITLE
Address warnings, including attention mask issue that changes the recs

### DIFF
--- a/src/poprox_recommender/components/embedders/article.py
+++ b/src/poprox_recommender/components/embedders/article.py
@@ -53,7 +53,7 @@ class NRMSArticleEmbedder(Component):
         plm_path = model_file_path(config.pretrained_model)
         logger.debug("loading tokenizer from %s", plm_path)
 
-        self.tokenizer = AutoTokenizer.from_pretrained(plm_path, cache_dir="/tmp/")
+        self.tokenizer = AutoTokenizer.from_pretrained(plm_path, cache_dir="/tmp/", clean_up_tokenization_spaces=True)
         self.device = device
         self.embedding_cache = {}
 

--- a/src/poprox_recommender/components/samplers/softmax.py
+++ b/src/poprox_recommender/components/samplers/softmax.py
@@ -8,7 +8,7 @@ class SoftmaxSampler:
         self.num_slots = num_slots
         self.temperature = temperature
 
-    def __call__(self, candidate_articles: ArticleSet):
+    def __call__(self, candidate_articles: ArticleSet) -> ArticleSet:
         if candidate_articles.scores is None:
             scores = np.ones(len(candidate_articles.articles))
         else:

--- a/src/poprox_recommender/model/nrms/news_encoder.py
+++ b/src/poprox_recommender/model/nrms/news_encoder.py
@@ -28,7 +28,7 @@ class NewsEncoder(torch.nn.Module):
     def forward(self, news_input: torch.Tensor) -> torch.Tensor:
         # batch_size, num_words_title, word_embedding_dim
 
-        V = self.plm(news_input).last_hidden_state
+        V = self.plm(news_input, attention_mask=news_input.bool().int()).last_hidden_state
         multihead_attn_output, _ = self.multihead_attention(
             V, V, V
         )  # [batch_size, seq_len, hidden_size] -> [batch_size, seq_len, hidden_size]


### PR DESCRIPTION
This addresses three warnings of varying importance:
* The LK pipeline code warned that `SoftmaxSampler` didn't have an annotated return type
* The HF Tokenizers library warned about a tokenization space clean-up behavior that has been enabled by default but will be disabled in future versions
* The HF Transformers library warned about the absence of an attention mask being passed to DistilBERT, which can (and does!) affect the article embeddings