### PR TITLE
Support pipeline configuration files

### DIFF
--- a/pipelines/_common.toml
+++ b/pipelines/_common.toml
@@ -28,27 +28,33 @@ inputs = { article_set = "candidate" }
 code = "poprox_recommender.components.embedders.article:NRMSArticleEmbedder"
 config = { model_path = "nrms-mind/news_encoder.safetensors" }
 inputs = { article_set = "candidate" }
+meta.group = "history-based ranking"
 
 [components.user-embedder]
 code = "poprox_recommender.components.embedders.user:NRMSUserEmbedder"
 config = { max_clicks_per_user = 50, model_path = "nrms-mind/user_encoder.safetensors" }
 inputs = { clicked_articles = "history-embedder", interest_profile = "profile" }
+meta.group = "history-based ranking"
 
 [components.scorer]
 code = "poprox_recommender.components.scorers.article:ArticleScorer"
 inputs = { candidate_articles = "candidate-embedder", interest_profile = "user-embedder" }
+meta.group = "history-based ranking"
 
 [components.ranker]
 code = "poprox_recommender.components.rankers.topk:TopKRanker"
 config = { num_slots = "$N" }
 inputs = { candidate_articles = "scorer", interest_profile = "user-embedder" }
+meta.group = "history-based ranking"
 
 [components.topic-filter]
 code = "poprox_recommender.components.filters.topic:TopicFilter"
 inputs = { candidate = "candidate", interest_profile = "profile" }
+meta.group = "topic-based ranking"
 
 [components.sampler]
 code = "poprox_recommender.components.samplers.uniform:UniformSampler"
+meta.group = "topic-based ranking"
 
 [components.recommender]
 code = "poprox_recommender.components.joiners.fill:Fill"

--- a/pipelines/_common.toml
+++ b/pipelines/_common.toml
@@ -1,0 +1,56 @@
+# Commmon layout components for POPROX pipelines
+
+[meta]
+name = "NRMS"
+
+# Define convenient aliases for components so we do not need to re-type their
+# full names everywhere.  Inherting configurations can override these to change
+# the component without overwriting it!
+[definitions]
+# the name of the final personalized ranking component
+ranker = "ranker"
+# number of recommendation slots to configure
+N = 10
+
+[inputs.candidate]
+type = "poprox_concepts.domain.article.ArticleSet"
+[inputs.profile]
+type = "poprox_concepts.domain.article.ArticleSet"
+[inputs.clicked]
+type = "poprox_concepts.domain.article.InterestProfile"
+
+[components.candidate-embedder]
+code = "poprox_recommender.components.embedders.article:NRMSArticleEmbedder"
+config = { model_path = "nrms-mind/news_encoder.safetensors" }
+inputs = { article_set = "candidate" }
+
+[components.history-embedder]
+code = "poprox_recommender.components.embedders.article:NRMSArticleEmbedder"
+config = { model_path = "nrms-mind/news_encoder.safetensors" }
+inputs = { article_set = "candidate" }
+
+[components.user-embedder]
+code = "poprox_recommender.components.embedders.user:NRMSUserEmbedder"
+config = { max_clicks_per_user = 50, model_path = "nrms-mind/user_encoder.safetensors" }
+inputs = { clicked_articles = "history-embedder", interest_profile = "profile" }
+
+[components.scorer]
+code = "poprox_recommender.components.scorers.article:ArticleScorer"
+inputs = { candidate_articles = "candidate-embedder", interest_profile = "user-embedder" }
+
+[components.ranker]
+code = "poprox_recommender.components.rankers.topk:TopKRanker"
+config = { num_slots = "$N" }
+inputs = { candidate_articles = "scorer", interest_profile = "user-embedder" }
+
+[components.topic-filter]
+code = "poprox_recommender.components.filters.topic:TopicFilter"
+inputs = { candidate = "candidate", interest_profile = "profile" }
+
+[components.sampler]
+code = "poprox_recommender.components.samplers.uniform:UniformSampler"
+
+[components.recommender]
+code = "poprox_recommender.components.joiners.fill:Fill"
+config = { num_slots = "$N" }
+inputs = { candidates1 = "$ranker", candidates2 = "sampler" }

--- a/pipelines/nrms.toml
+++ b/pipelines/nrms.toml
@@ -1,0 +1,2 @@
+[meta]
+extend = "_common.toml"

--- a/pipelines/softmax.toml
+++ b/pipelines/softmax.toml
@@ -1,0 +1,10 @@
+[meta]
+name = "NRMS+Softmax"
+extend = "_common.toml"
+
+[definitions]
+ranker = "reranker"
+
+[components.reranker]
+code = "poprox_recommender.components.samplers.softmax:SoftmaxSampler"
+inputs = { candidate_articles = "scorer", interest_profile = "user-embedder" }

--- a/pipelines/softmax.toml
+++ b/pipelines/softmax.toml
@@ -8,3 +8,4 @@ ranker = "reranker"
 [components.reranker]
 code = "poprox_recommender.components.samplers.softmax:SoftmaxSampler"
 inputs = { candidate_articles = "scorer", interest_profile = "user-embedder" }
+meta.group = "history-based ranking"


### PR DESCRIPTION
This PR is to work on adding pipeline configuration file support.

In its current form, all it does is add draft configuration file definitions of 2 of our pipelines, to see if we are happy with what they might look like in configuration file form. I've built this around a minimal reuse concept, that supports variable/parameter interpolation and lightweight `extends` mechanism to facilitate reuse. The intended resolution process is:

1. Load and parse the pipeline from TOML into Python data structures.
2. If `meta.extends` is defined, load and parse that TOML file, and do a deep merge of the two parsed pipelines. (This happens recursively, if the referenced pipeline also has `meta.extends`. That allows this pipeline def to override any elements of the parent configuration. Since unused inputs are silently ignored, this should mostly work without defining any key-specific merge strategies, so long as we aren't redefining inputs. Future work can add more nuanced merging if needed.)
3. Walk the data structure, looking for variable references ($...) in any string values. Interpolate them using the variables defined in `definitions` or provided by the code loading the configuration file. This is to allow things like parameterizing the number of recommendation slots in the pipeline configuration (like the current configuration code).
4. Validate the resulting object as a `PipelineConfig`.
5. Construct a pipeline from the validated `PipelineConfig`.

I thought briefly about using Jinja templates instead of rolling our own lightweight extension and variable mechanism. That would also work, and the VS Code Jinja package has support for syntax-highlighting TOML with embedded Jinja, and then we would just inherit Jinja's templating and extension capabilities, but I'm not sure the result would actually be easier to understand. Feedback on this point, or on any elements of what the config files might look like, very welcome!