### PR TITLE
Add retargetable test fixtures and test Docker instead of Serverless Local

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -10,4 +10,3 @@ pre-commit install-hooks
 
 # install the development environment
 pixi install -e dev
-pixi run -e dev install-serverless

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,7 +54,10 @@ jobs:
 
       - name: Submit test request
         run: |
-          python ./tests/integration/test-docker-lambda.py
+          python -m pytest -v tests/integration
+        env:
+          POPROX_TEST_TARGET: docker
+          POPROX_TEST_PORT: 9000
 
       - name: Dump Docker logs
         if: always()

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,11 +38,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .dvc/cache
-          key: docker-dvc-cache-${{ hashFiles('models/**.dvc') }}
+          key: docker-dvc-cache-${{ hashFiles('models/**.dvc', 'tests/**.dvc') }}
 
       - name: Fetch model data
         run: |
-          dvc pull -vr public -R models
+          dvc pull -vr public -R models tests
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,7 @@ jobs:
           pixi-version: latest
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-          environments: data
+          environments: test
           activate-environment: true
 
       - name: Show DVC config
@@ -52,7 +52,7 @@ jobs:
         run: |
           docker run -d -p 9000:8080 --name=poprox-recommender poprox-recommender:ci
 
-      - name: Submit test request
+      - name: Run integration tests
         run: |
           python -m pytest -v tests/integration
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,6 @@ jobs:
           environments: test
           activate-environment: true
 
-      - name: Install Node dependencies
-        run: |
-          npm ci
-
       - name: Cache model data
         uses: actions/cache@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
         "serverless": "^3.39.0"
       },
       "devDependencies": {
-        "serverless-offline": "^13.5.0",
         "serverless-python-requirements": "^6.1.0"
       }
     },
@@ -7973,337 +7972,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@hapi/accept": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.3.tgz",
-      "integrity": "sha512-p72f9k56EuF0n3MwlBNThyVE5PXX40g+aQh+C/xbKrfzahM2Oispv3AXmOIU51t3j77zay1qrX7IIziZXspMlw==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/ammo": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.1.tgz",
-      "integrity": "sha512-pmL+nPod4g58kXrMcsGLp05O2jF4P2Q3GiL8qYV7nKYEh3cGf+rV4P5Jyi2Uq0agGhVU63GtaSAfBEZOlrJn9w==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/b64": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.1.tgz",
-      "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/boom": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
-      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/bounce": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.1.tgz",
-      "integrity": "sha512-G+/Pp9c1Ha4FDP+3Sy/Xwg2O4Ahaw3lIZFSX+BL4uWi64CmiETuZPxhKDUD4xBMOUZbBlzvO8HjiK8ePnhBadA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/bourne": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-      "dev": true
-    },
-    "node_modules/@hapi/call": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.1.tgz",
-      "integrity": "sha512-uPojQRqEL1GRZR4xXPqcLMujQGaEpyVPRyBlD8Pp5rqgIwLhtveF9PkixiKru2THXvuN8mUrLeet5fqxKAAMGg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/catbox": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.1.tgz",
-      "integrity": "sha512-hDqYB1J+R0HtZg4iPH3LEnldoaBsar6bYp0EonBmNQ9t5CO+1CqgCul2ZtFveW1ReA5SQuze9GPSU7/aecERhw==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/podium": "^5.0.0",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "node_modules/@hapi/catbox-memory": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.1.tgz",
-      "integrity": "sha512-sVb+/ZxbZIvaMtJfAbdyY+QJUQg9oKTwamXpEg/5xnfG5WbJLTjvEn4kIGKz9pN3ENNbIL/bIdctmHmqi/AdGA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.0"
-      }
-    },
-    "node_modules/@hapi/cryptiles": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.1.tgz",
-      "integrity": "sha512-9GM9ECEHfR8lk5ASOKG4+4ZsEzFqLfhiryIJ2ISePVB92OHLp/yne4m+zn7z9dgvM98TLpiFebjDFQ0UHcqxXQ==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
-      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
-      "dev": true
-    },
-    "node_modules/@hapi/h2o2": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.4.tgz",
-      "integrity": "sha512-dvD8+Y/Okc0fh0blqaYCLIrcy0+1LqIhMr7hjk8elLQZ9mkw2hKFB9dFKuRfWf+1nvHpGlW+PwccqkdebynQbg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/validate": "^2.0.1",
-        "@hapi/wreck": "^18.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/hapi": {
-      "version": "21.3.9",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.9.tgz",
-      "integrity": "sha512-AT5m+Rb8iSOFG3zWaiEuTJazf4HDYl5UpRpyxMJ3yR+g8tOEmqDv6FmXrLHShdvDOStAAepHGnr1G7egkFSRdw==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/accept": "^6.0.1",
-        "@hapi/ammo": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bounce": "^3.0.1",
-        "@hapi/call": "^9.0.1",
-        "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.1",
-        "@hapi/heavy": "^8.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/mimos": "^7.0.1",
-        "@hapi/podium": "^5.0.1",
-        "@hapi/shot": "^6.0.1",
-        "@hapi/somever": "^4.1.1",
-        "@hapi/statehood": "^8.1.1",
-        "@hapi/subtext": "^8.1.0",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/topo": "^6.0.1",
-        "@hapi/validate": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      }
-    },
-    "node_modules/@hapi/heavy": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.1.tgz",
-      "integrity": "sha512-gBD/NANosNCOp6RsYTsjo2vhr5eYA3BEuogk6cxY0QdhllkkTaJFYtTXv46xd6qhBVMbMMqcSdtqey+UQU3//w==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ==",
-      "dev": true
-    },
-    "node_modules/@hapi/iron": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.1.tgz",
-      "integrity": "sha512-tEZnrOujKpS6jLKliyWBl3A9PaE+ppuL/+gkbyPPDb/l2KSKQyH4lhMkVb+sBhwN+qaxxlig01JRqB8dk/mPxQ==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/b64": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/mimos": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.1.tgz",
-      "integrity": "sha512-b79V+BrG0gJ9zcRx1VGcCI6r6GEzzZUgiGEJVoq5gwzuB2Ig9Cax8dUuBauQCFKvl2YWSWyOc8mZ8HDaJOtkew==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2",
-        "mime-db": "^1.52.0"
-      }
-    },
-    "node_modules/@hapi/nigel": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.1.tgz",
-      "integrity": "sha512-uv3dtYuB4IsNaha+tigWmN8mQw/O9Qzl5U26Gm4ZcJVtDdB1AVJOwX3X5wOX+A07qzpEZnOMBAm8jjSqGsU6Nw==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/vise": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/pez": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.1.0.tgz",
-      "integrity": "sha512-+FE3sFPYuXCpuVeHQ/Qag1b45clR2o54QoonE/gKHv9gukxQ8oJJZPR7o3/ydDTK6racnCJXxOyT1T93FCJMIg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/b64": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/content": "^6.0.0",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/nigel": "^5.0.1"
-      }
-    },
-    "node_modules/@hapi/podium": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.1.tgz",
-      "integrity": "sha512-eznFTw6rdBhAijXFIlBOMJJd+lXTvqbrBIS4Iu80r2KTVIo4g+7fLy4NKp/8+UnSt5Ox6mJtAlKBU/Sf5080TQ==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "node_modules/@hapi/shot": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.1.tgz",
-      "integrity": "sha512-s5ynMKZXYoDd3dqPw5YTvOR/vjHvMTxc388+0qL0jZZP1+uwXuUD32o9DuuuLsmTlyXCWi02BJl1pBpwRuUrNA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "node_modules/@hapi/somever": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.1.tgz",
-      "integrity": "sha512-lt3QQiDDOVRatS0ionFDNrDIv4eXz58IibQaZQDOg4DqqdNme8oa0iPWcE0+hkq/KTeBCPtEOjDOBKBKwDumVg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/bounce": "^3.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/statehood": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.1.1.tgz",
-      "integrity": "sha512-YbK7PSVUA59NArAW5Np0tKRoIZ5VNYUicOk7uJmWZF6XyH5gGL+k62w77SIJb0AoAJ0QdGQMCQ/WOGL1S3Ydow==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bounce": "^3.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/iron": "^7.0.1",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "node_modules/@hapi/subtext": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.1.0.tgz",
-      "integrity": "sha512-PyaN4oSMtqPjjVxLny1k0iYg4+fwGusIhaom9B2StinBclHs7v46mIW706Y+Wo21lcgulGyXbQrmT/w4dus6ww==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/content": "^6.0.0",
-        "@hapi/file": "^3.0.0",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/pez": "^6.1.0",
-        "@hapi/wreck": "^18.0.1"
-      }
-    },
-    "node_modules/@hapi/teamwork": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
-      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/topo": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/validate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
-      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/topo": "^6.0.1"
-      }
-    },
-    "node_modules/@hapi/vise": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.1.tgz",
-      "integrity": "sha512-XZYWzzRtINQLedPYlIkSkUr7m5Ddwlu99V9elh8CSygXstfv3UnWIXT0QD+wmR0VAG34d2Vx3olqcEhRRoTu9A==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -9600,15 +9268,6 @@
         }
       }
     },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -9765,15 +9424,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-unflat-js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
-      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.18.0"
       }
     },
     "node_modules/array-union": {
@@ -9968,131 +9618,6 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
-    "node_modules/boxen": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
-      "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
-      "dev": true,
-      "dependencies": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^7.0.1",
-        "chalk": "^5.2.0",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^5.1.2",
-        "type-fest": "^2.13.0",
-        "widest-line": "^4.0.1",
-        "wrap-ansi": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
-    },
-    "node_modules/boxen/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/boxen/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10232,18 +9757,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -10330,18 +9843,6 @@
       ],
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-color": {
@@ -10573,18 +10074,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-      "dev": true,
-      "dependencies": {
-        "luxon": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -10998,12 +10487,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/desm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.1.tgz",
-      "integrity": "sha512-vgTAOosB1aHrmzjGnzFCbjvXbk8QAOC/36JxJhcBkeAuUy8QwRFxAWBHemiDpUB3cbrBruFUdzpUS21aocvaWg==",
-      "dev": true
-    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -11051,12 +10534,6 @@
         "d": "1",
         "es5-ext": "~0.10.46"
       }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -11318,151 +10795,6 @@
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/execa/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/execa/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/execa/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/execa/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/ext": {
@@ -12161,15 +11493,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12420,39 +11743,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -12673,39 +11963,12 @@
         "ws": "*"
       }
     },
-    "node_modules/java-invoke-local": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/java-invoke-local/-/java-invoke-local-0.0.6.tgz",
-      "integrity": "sha512-gZmQKe1QrfkkMjCn8Qv9cpyJFyogTYqkP5WCobX5RNaHsJzIV/6NvAnlnouOcwKr29QrxLGDGcqYuJ+ae98s1A==",
-      "dev": true,
-      "bin": {
-        "java-invoke-local": "lib/cli.js"
-      }
-    },
     "node_modules/jmespath": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/jose": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.3.0.tgz",
-      "integrity": "sha512-IChe9AtAE79ru084ow8jzkN2lNrG3Ntfiv65Cvj9uOCE2m5LNsdHG+9EbxWxAoWRF9TgDOqLN5jm08++owDVRg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/js-yaml": {
@@ -12852,28 +12115,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonpath-plus": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-8.1.0.tgz",
-      "integrity": "sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==",
-      "dev": true,
-      "bin": {
-        "jsonpath": "bin/jsonpath-cli.js",
-        "jsonpath-plus": "bin/jsonpath-cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jszip": {
@@ -13082,12 +12323,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/long-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
-      "dev": true
-    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -13102,15 +12337,6 @@
       "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
       "dependencies": {
         "es5-ext": "~0.10.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -13141,12 +12367,6 @@
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
       }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -13345,20 +12565,6 @@
         }
       }
     },
-    "node_modules/node-schedule": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
-      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
-      "dev": true,
-      "dependencies": {
-        "cron-parser": "^4.2.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -13393,33 +12599,6 @@
       },
       "engines": {
         "node": ">=12.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -13594,46 +12773,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/p-memoize": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
-      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0",
-        "type-fest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
-      }
-    },
-    "node_modules/p-memoize/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-memoize/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -14263,106 +13402,6 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/serverless-offline": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.5.0.tgz",
-      "integrity": "sha512-t+xyBTjYBtkyywrP3UnhNFFxQ03QflIn/20ImW3BnkSYr/5Sl6yX6coHoYx7X5QoVaOeHIAROs+WID0WR/IKyQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-lambda": "^3.509.0",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/h2o2": "^10.0.4",
-        "@hapi/hapi": "^21.3.3",
-        "@serverless/utils": "^6.15.0",
-        "array-unflat-js": "^0.1.3",
-        "boxen": "^7.1.1",
-        "chalk": "^5.3.0",
-        "desm": "^1.3.1",
-        "execa": "^8.0.1",
-        "fs-extra": "^11.2.0",
-        "is-wsl": "^3.1.0",
-        "java-invoke-local": "0.0.6",
-        "jose": "^5.2.1",
-        "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^8.0.0",
-        "jsonschema": "^1.4.1",
-        "jszip": "^3.10.1",
-        "luxon": "^3.4.4",
-        "node-schedule": "^2.1.1",
-        "p-memoize": "^7.1.1",
-        "velocityjs": "^2.0.6",
-        "ws": "^8.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "serverless": "^3.2.0"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dev": true,
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serverless-offline/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/serverless-python-requirements": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-6.1.0.tgz",
@@ -14552,12 +13591,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sorted-array-functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
-      "dev": true
-    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -14681,18 +13714,6 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dependencies": {
         "is-natural-number": "^4.0.1"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-outer": {
@@ -15160,21 +14181,6 @@
         "builtins": "^1.0.3"
       }
     },
-    "node_modules/velocityjs": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.6.tgz",
-      "integrity": "sha512-QMYLeYLBX6eqekCin3OPmDAHapaUx3foNFE264ml1/yxRZ8TUUlI1+u6rtN4E8tKNqwzpRPeNgJtjLbgRNK4fw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.3"
-      },
-      "bin": {
-        "velocity": "bin/velocity"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -15245,71 +14251,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/widest-line": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/widest-line/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/widest-line/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
-    },
-    "node_modules/widest-line/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi": {
@@ -22075,322 +21016,6 @@
         }
       }
     },
-    "@hapi/accept": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.3.tgz",
-      "integrity": "sha512-p72f9k56EuF0n3MwlBNThyVE5PXX40g+aQh+C/xbKrfzahM2Oispv3AXmOIU51t3j77zay1qrX7IIziZXspMlw==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/ammo": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.1.tgz",
-      "integrity": "sha512-pmL+nPod4g58kXrMcsGLp05O2jF4P2Q3GiL8qYV7nKYEh3cGf+rV4P5Jyi2Uq0agGhVU63GtaSAfBEZOlrJn9w==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/b64": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.1.tgz",
-      "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/boom": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
-      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/bounce": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.1.tgz",
-      "integrity": "sha512-G+/Pp9c1Ha4FDP+3Sy/Xwg2O4Ahaw3lIZFSX+BL4uWi64CmiETuZPxhKDUD4xBMOUZbBlzvO8HjiK8ePnhBadA==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/bourne": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
-      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
-      "dev": true
-    },
-    "@hapi/call": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.1.tgz",
-      "integrity": "sha512-uPojQRqEL1GRZR4xXPqcLMujQGaEpyVPRyBlD8Pp5rqgIwLhtveF9PkixiKru2THXvuN8mUrLeet5fqxKAAMGg==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/catbox": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.1.tgz",
-      "integrity": "sha512-hDqYB1J+R0HtZg4iPH3LEnldoaBsar6bYp0EonBmNQ9t5CO+1CqgCul2ZtFveW1ReA5SQuze9GPSU7/aecERhw==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/podium": "^5.0.0",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "@hapi/catbox-memory": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.1.tgz",
-      "integrity": "sha512-sVb+/ZxbZIvaMtJfAbdyY+QJUQg9oKTwamXpEg/5xnfG5WbJLTjvEn4kIGKz9pN3ENNbIL/bIdctmHmqi/AdGA==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/content": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.0"
-      }
-    },
-    "@hapi/cryptiles": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.1.tgz",
-      "integrity": "sha512-9GM9ECEHfR8lk5ASOKG4+4ZsEzFqLfhiryIJ2ISePVB92OHLp/yne4m+zn7z9dgvM98TLpiFebjDFQ0UHcqxXQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1"
-      }
-    },
-    "@hapi/file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
-      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
-      "dev": true
-    },
-    "@hapi/h2o2": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/h2o2/-/h2o2-10.0.4.tgz",
-      "integrity": "sha512-dvD8+Y/Okc0fh0blqaYCLIrcy0+1LqIhMr7hjk8elLQZ9mkw2hKFB9dFKuRfWf+1nvHpGlW+PwccqkdebynQbg==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/validate": "^2.0.1",
-        "@hapi/wreck": "^18.0.1"
-      }
-    },
-    "@hapi/hapi": {
-      "version": "21.3.9",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.9.tgz",
-      "integrity": "sha512-AT5m+Rb8iSOFG3zWaiEuTJazf4HDYl5UpRpyxMJ3yR+g8tOEmqDv6FmXrLHShdvDOStAAepHGnr1G7egkFSRdw==",
-      "dev": true,
-      "requires": {
-        "@hapi/accept": "^6.0.1",
-        "@hapi/ammo": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bounce": "^3.0.1",
-        "@hapi/call": "^9.0.1",
-        "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.1",
-        "@hapi/heavy": "^8.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/mimos": "^7.0.1",
-        "@hapi/podium": "^5.0.1",
-        "@hapi/shot": "^6.0.1",
-        "@hapi/somever": "^4.1.1",
-        "@hapi/statehood": "^8.1.1",
-        "@hapi/subtext": "^8.1.0",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/topo": "^6.0.1",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "@hapi/heavy": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.1.tgz",
-      "integrity": "sha512-gBD/NANosNCOp6RsYTsjo2vhr5eYA3BEuogk6cxY0QdhllkkTaJFYtTXv46xd6qhBVMbMMqcSdtqey+UQU3//w==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ==",
-      "dev": true
-    },
-    "@hapi/iron": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.1.tgz",
-      "integrity": "sha512-tEZnrOujKpS6jLKliyWBl3A9PaE+ppuL/+gkbyPPDb/l2KSKQyH4lhMkVb+sBhwN+qaxxlig01JRqB8dk/mPxQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/b64": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/mimos": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.1.tgz",
-      "integrity": "sha512-b79V+BrG0gJ9zcRx1VGcCI6r6GEzzZUgiGEJVoq5gwzuB2Ig9Cax8dUuBauQCFKvl2YWSWyOc8mZ8HDaJOtkew==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2",
-        "mime-db": "^1.52.0"
-      }
-    },
-    "@hapi/nigel": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.1.tgz",
-      "integrity": "sha512-uv3dtYuB4IsNaha+tigWmN8mQw/O9Qzl5U26Gm4ZcJVtDdB1AVJOwX3X5wOX+A07qzpEZnOMBAm8jjSqGsU6Nw==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/vise": "^5.0.1"
-      }
-    },
-    "@hapi/pez": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.1.0.tgz",
-      "integrity": "sha512-+FE3sFPYuXCpuVeHQ/Qag1b45clR2o54QoonE/gKHv9gukxQ8oJJZPR7o3/ydDTK6racnCJXxOyT1T93FCJMIg==",
-      "dev": true,
-      "requires": {
-        "@hapi/b64": "^6.0.1",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/content": "^6.0.0",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/nigel": "^5.0.1"
-      }
-    },
-    "@hapi/podium": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.1.tgz",
-      "integrity": "sha512-eznFTw6rdBhAijXFIlBOMJJd+lXTvqbrBIS4Iu80r2KTVIo4g+7fLy4NKp/8+UnSt5Ox6mJtAlKBU/Sf5080TQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/teamwork": "^6.0.0",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "@hapi/shot": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.1.tgz",
-      "integrity": "sha512-s5ynMKZXYoDd3dqPw5YTvOR/vjHvMTxc388+0qL0jZZP1+uwXuUD32o9DuuuLsmTlyXCWi02BJl1pBpwRuUrNA==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "@hapi/somever": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.1.tgz",
-      "integrity": "sha512-lt3QQiDDOVRatS0ionFDNrDIv4eXz58IibQaZQDOg4DqqdNme8oa0iPWcE0+hkq/KTeBCPtEOjDOBKBKwDumVg==",
-      "dev": true,
-      "requires": {
-        "@hapi/bounce": "^3.0.1",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/statehood": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.1.1.tgz",
-      "integrity": "sha512-YbK7PSVUA59NArAW5Np0tKRoIZ5VNYUicOk7uJmWZF6XyH5gGL+k62w77SIJb0AoAJ0QdGQMCQ/WOGL1S3Ydow==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bounce": "^3.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/cryptiles": "^6.0.1",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/iron": "^7.0.1",
-        "@hapi/validate": "^2.0.1"
-      }
-    },
-    "@hapi/subtext": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.1.0.tgz",
-      "integrity": "sha512-PyaN4oSMtqPjjVxLny1k0iYg4+fwGusIhaom9B2StinBclHs7v46mIW706Y+Wo21lcgulGyXbQrmT/w4dus6ww==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/content": "^6.0.0",
-        "@hapi/file": "^3.0.0",
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/pez": "^6.1.0",
-        "@hapi/wreck": "^18.0.1"
-      }
-    },
-    "@hapi/teamwork": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
-      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
-      "dev": true
-    },
-    "@hapi/topo": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/validate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
-      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2",
-        "@hapi/topo": "^6.0.1"
-      }
-    },
-    "@hapi/vise": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.1.tgz",
-      "integrity": "sha512-XZYWzzRtINQLedPYlIkSkUr7m5Ddwlu99V9elh8CSygXstfv3UnWIXT0QD+wmR0VAG34d2Vx3olqcEhRRoTu9A==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
-      "dev": true,
-      "requires": {
-        "@hapi/boom": "^10.0.1",
-        "@hapi/bourne": "^3.0.0",
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
     "@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -23444,15 +22069,6 @@
         "ajv": "^8.0.0"
       }
     },
-    "ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.1.0"
-      }
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -23577,12 +22193,6 @@
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
       }
-    },
-    "array-unflat-js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/array-unflat-js/-/array-unflat-js-0.1.3.tgz",
-      "integrity": "sha512-8pljkLj4vfz2i7Tf3yB31tRrszjP8/kwIyABGfcZ1GcHlvdUB0Sbx0WzQkOPMqUBxa/bu4+/NAyHEpDtZJzlJw==",
-      "dev": true
     },
     "array-union": {
       "version": "2.1.0",
@@ -23717,85 +22327,6 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
-    "boxen": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
-      "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^3.0.1",
-        "camelcase": "^7.0.1",
-        "chalk": "^5.2.0",
-        "cli-boxes": "^3.0.0",
-        "string-width": "^5.1.2",
-        "type-fest": "^2.13.0",
-        "widest-line": "^4.0.1",
-        "wrap-ansi": "^8.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-          "dev": true,
-          "requires": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
-          }
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -23903,12 +22434,6 @@
         "set-function-length": "^1.2.1"
       }
     },
-    "camelcase": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-      "dev": true
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -23969,12 +22494,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
-    },
-    "cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "dev": true
     },
     "cli-color": {
       "version": "2.0.4",
@@ -24147,15 +22666,6 @@
       "requires": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
-      }
-    },
-    "cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-      "dev": true,
-      "requires": {
-        "luxon": "^3.2.1"
       }
     },
     "cross-spawn": {
@@ -24474,12 +22984,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
-    "desm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/desm/-/desm-1.3.1.tgz",
-      "integrity": "sha512-vgTAOosB1aHrmzjGnzFCbjvXbk8QAOC/36JxJhcBkeAuUy8QwRFxAWBHemiDpUB3cbrBruFUdzpUS21aocvaWg==",
-      "dev": true
-    },
     "dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -24515,12 +23019,6 @@
         "d": "1",
         "es5-ext": "~0.10.46"
       }
-    },
-    "eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -24730,99 +23228,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
-    },
-    "execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "get-stream": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
     },
     "ext": {
       "version": "1.7.0",
@@ -25306,12 +23711,6 @@
         "debug": "4"
       }
     },
-    "human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -25481,23 +23880,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "requires": {
-        "is-docker": "^3.0.0"
-      },
-      "dependencies": {
-        "is-docker": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-          "dev": true
-        }
-      }
-    },
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -25640,28 +24022,10 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "requires": {}
     },
-    "java-invoke-local": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/java-invoke-local/-/java-invoke-local-0.0.6.tgz",
-      "integrity": "sha512-gZmQKe1QrfkkMjCn8Qv9cpyJFyogTYqkP5WCobX5RNaHsJzIV/6NvAnlnouOcwKr29QrxLGDGcqYuJ+ae98s1A==",
-      "dev": true
-    },
     "jmespath": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
-    "jose": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.3.0.tgz",
-      "integrity": "sha512-IChe9AtAE79ru084ow8jzkN2lNrG3Ntfiv65Cvj9uOCE2m5LNsdHG+9EbxWxAoWRF9TgDOqLN5jm08++owDVRg==",
-      "dev": true
-    },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
-      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -25783,18 +24147,6 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
-    },
-    "jsonpath-plus": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-8.1.0.tgz",
-      "integrity": "sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==",
-      "dev": true
-    },
-    "jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "dev": true
     },
     "jszip": {
       "version": "3.10.1",
@@ -25988,12 +24340,6 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
-    "long-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
-      "dev": true
-    },
     "lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -26006,12 +24352,6 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
-    },
-    "luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "dev": true
     },
     "make-dir": {
       "version": "4.0.0",
@@ -26035,12 +24375,6 @@
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
       }
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -26182,17 +24516,6 @@
         "whatwg-url": "^5.0.0"
       }
     },
-    "node-schedule": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
-      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
-      "dev": true,
-      "requires": {
-        "cron-parser": "^4.2.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -26215,23 +24538,6 @@
         "semver": "^7.3.5",
         "type": "^2.6.0",
         "validate-npm-package-name": "^3.0.0"
-      }
-    },
-    "npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "requires": {
-        "path-key": "^4.0.0"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        }
       }
     },
     "object-assign": {
@@ -26346,30 +24652,6 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
-      }
-    },
-    "p-memoize": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
-      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^4.0.0",
-        "type-fest": "^3.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-          "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-          "dev": true
-        }
       }
     },
     "p-timeout": {
@@ -26804,72 +25086,6 @@
         "yaml-ast-parser": "0.0.43"
       }
     },
-    "serverless-offline": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/serverless-offline/-/serverless-offline-13.5.0.tgz",
-      "integrity": "sha512-t+xyBTjYBtkyywrP3UnhNFFxQ03QflIn/20ImW3BnkSYr/5Sl6yX6coHoYx7X5QoVaOeHIAROs+WID0WR/IKyQ==",
-      "dev": true,
-      "requires": {
-        "@aws-sdk/client-lambda": "^3.509.0",
-        "@hapi/boom": "^10.0.1",
-        "@hapi/h2o2": "^10.0.4",
-        "@hapi/hapi": "^21.3.3",
-        "@serverless/utils": "^6.15.0",
-        "array-unflat-js": "^0.1.3",
-        "boxen": "^7.1.1",
-        "chalk": "^5.3.0",
-        "desm": "^1.3.1",
-        "execa": "^8.0.1",
-        "fs-extra": "^11.2.0",
-        "is-wsl": "^3.1.0",
-        "java-invoke-local": "0.0.6",
-        "jose": "^5.2.1",
-        "js-string-escape": "^1.0.1",
-        "jsonpath-plus": "^8.0.0",
-        "jsonschema": "^1.4.1",
-        "jszip": "^3.10.1",
-        "luxon": "^3.4.4",
-        "node-schedule": "^2.1.1",
-        "p-memoize": "^7.1.1",
-        "velocityjs": "^2.0.6",
-        "ws": "^8.16.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "is-wsl": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-          "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-          "dev": true,
-          "requires": {
-            "is-inside-container": "^1.0.0"
-          }
-        },
-        "ws": {
-          "version": "8.18.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
     "serverless-python-requirements": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/serverless-python-requirements/-/serverless-python-requirements-6.1.0.tgz",
@@ -27011,12 +25227,6 @@
         "sort-keys": "^1.0.0"
       }
     },
-    "sorted-array-functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
-      "dev": true
-    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -27117,12 +25327,6 @@
       "requires": {
         "is-natural-number": "^4.0.1"
       }
-    },
-    "strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true
     },
     "strip-outer": {
       "version": "1.0.1",
@@ -27465,15 +25669,6 @@
         "builtins": "^1.0.3"
       }
     },
-    "velocityjs": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.6.tgz",
-      "integrity": "sha512-QMYLeYLBX6eqekCin3OPmDAHapaUx3foNFE264ml1/yxRZ8TUUlI1+u6rtN4E8tKNqwzpRPeNgJtjLbgRNK4fw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.3"
-      }
-    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -27532,49 +25727,6 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.2"
-      }
-    },
-    "widest-line": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
-      "dev": true,
-      "requires": {
-        "string-width": "^5.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-          "dev": true,
-          "requires": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "serverless-offline": "^13.5.0",
     "serverless-python-requirements": "^6.1.0"
   },
   "dependencies": {

--- a/pixi.lock
+++ b/pixi.lock
@@ -11641,7 +11641,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.1-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py311h5592be9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
@@ -11655,7 +11654,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.1.0-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-h2466b09_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -111,7 +111,6 @@ poprox-recommender = { path = ".", editable = true }
 requests = ">=2.31,<3"
 coverage = ">=6.5"
 pytest = ">=8"
-pexpect = "~=4.9"
 
 [feature.test.pypi-dependencies]
 poprox-recommender = { path = ".", editable = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -53,13 +53,12 @@ awslambdaric = "~=2.2"
 hatch = "*"
 conda-pack = "~=0.8"
 
-# dependencies for working with serverless
+# dependencies for working with serverless (for deploy)
 [feature.serverless.dependencies]
 nodejs = "~=22.1"
 
 [feature.serverless.tasks]
 install-serverless = "npm ci"
-start-serverless = { cmd = "npx serverless offline start --reloadHandler", depends-on = ["install-serverless"] }
 
 # general development dependencies
 [feature.dev.dependencies]

--- a/serverless/offline.functions.yaml
+++ b/serverless/offline.functions.yaml
@@ -1,8 +1,0 @@
-functions:
-  generateRecommendations:
-    handler: poprox_recommender.handler.generate_recs
-    memorySize: 4096
-    events:
-      - httpApi:
-          path: /
-          method: post

--- a/src/poprox_recommender/testing.py
+++ b/src/poprox_recommender/testing.py
@@ -32,7 +32,7 @@ class InProcessTestService:
     Test service that directly runs the request handler in-process.
     """
 
-    def request(self, req: RecommendationRequest | str) -> RecommendationResponse:
+    def request(self, req: RecommendationRequest | str, pipeline: str) -> RecommendationResponse:
         # defer to here so we don't always import the handler
         from poprox_recommender.handler import generate_recs
 
@@ -41,7 +41,7 @@ class InProcessTestService:
 
         event = {
             "body": req,
-            "queryStringParameters": {"pipeline": "nrms"},
+            "queryStringParameters": {"pipeline": pipeline},
             "isBase64Encoded": False,
         }
         res = generate_recs(event, {})

--- a/src/poprox_recommender/testing.py
+++ b/src/poprox_recommender/testing.py
@@ -1,0 +1,53 @@
+"""
+Support code for testing the poprox-recommender components and service.
+
+This lives in the main package so it can be easily imported from any of the
+tests, regardless of their subdirectories.
+"""
+
+from collections.abc import Generator
+from typing import Protocol
+
+from pytest import fixture
+
+from poprox_concepts.api.recommendations import RecommendationRequest, RecommendationResponse
+
+
+class TestService(Protocol):
+    """
+    Interface for test services bridges that accept requests and return
+    responses. It abstracts direct local runs, Docker, and AWS Lambda test
+    endpoints.
+    """
+
+    def request(self, req: RecommendationRequest) -> RecommendationResponse:
+        """
+        Request recommendations from the recommender.
+        """
+        raise NotImplementedError()
+
+
+class InProcessTestService:
+    """
+    Test service that directly runs the request handler in-process.
+    """
+
+    def request(self, req: RecommendationRequest | str) -> RecommendationResponse:
+        # defer to here so we don't always import the handler
+        from poprox_recommender.handler import generate_recs
+
+        if not isinstance(req, str):
+            req = req.model_dump_json()
+
+        event = {
+            "body": req,
+            "queryStringParameters": {"pipeline": "nrms"},
+            "isBase64Encoded": False,
+        }
+        res = generate_recs(event, {})
+        return RecommendationResponse.model_validate_json(res["body"])
+
+
+@fixture
+def local_service() -> Generator[InProcessTestService, None, None]:
+    yield InProcessTestService()

--- a/src/poprox_recommender/testing.py
+++ b/src/poprox_recommender/testing.py
@@ -5,12 +5,20 @@ This lives in the main package so it can be easily imported from any of the
 tests, regardless of their subdirectories.
 """
 
+import json
+import logging
+import subprocess as sp
 from collections.abc import Generator
+from signal import SIGINT
+from time import sleep
 from typing import Protocol
 
+import requests
 from pytest import fixture
 
 from poprox_concepts.api.recommendations import RecommendationRequest, RecommendationResponse
+
+logger = logging.getLogger(__name__)
 
 
 class TestService(Protocol):
@@ -20,7 +28,7 @@ class TestService(Protocol):
     endpoints.
     """
 
-    def request(self, req: RecommendationRequest) -> RecommendationResponse:
+    def request(self, req: RecommendationRequest | str, pipeline: str) -> RecommendationResponse:
         """
         Request recommendations from the recommender.
         """
@@ -48,6 +56,57 @@ class InProcessTestService:
         return RecommendationResponse.model_validate_json(res["body"])
 
 
+class DockerTestService:
+    """
+    Test service that directly runs the request handler in-process.
+    """
+
+    url: str
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def request(self, req: RecommendationRequest | str, pipeline: str) -> RecommendationResponse:
+        if not isinstance(req, str):
+            req = req.model_dump_json()
+
+        event = {
+            "body": json.dumps(json.loads(req)),
+            "queryStringParameters": {"pipeline": pipeline},
+            "isBase64Encoded": False,
+        }
+        result = requests.post(self.url, json=event)
+        res_data = result.json()
+        if result.status_code != 200:
+            logger.error("Lambda function failed with type %s", res_data["errorType"])
+            logger.info("Lambda error message: %s", res_data["errorMessage"])
+            if res_data["stackTrace"]:
+                logger.info("Stack trace:%s", [f"\n  {i}: {t}" for (i, t) in enumerate(res_data["stackTrace"], 1)])
+            raise AssertionError("lambda function failed")
+
+        if res_data["statusCode"] != 200:
+            logger.error("HTTP succeeded but lambda failed with code %s", res_data["statusCode"])
+            logger.info("result: %s", json.dumps(res_data, indent=2))
+            raise AssertionError("lambda request failed")
+
+        return RecommendationResponse.model_validate_json(res_data["body"])
+
+
 @fixture
-def local_service() -> Generator[InProcessTestService, None, None]:
+def local_service() -> Generator[TestService, None, None]:
     yield InProcessTestService()
+
+
+@fixture(scope="session")
+def docker_service() -> Generator[TestService, None, None]:
+    logger.info("building docker container")
+    sp.check_call(["docker-buildx", "build", "-t", "poprox-recommender:test", "."])
+    logger.info("starting docker container")
+    proc = sp.Popen(["docker", "run", "--rm", "-p", "18080:8080", "poprox-recommender:test"])
+    sleep(1)
+    try:
+        yield DockerTestService("http://localhost:18080/2015-03-31/functions/function/invocations")
+    finally:
+        logger.info("stopping docker container")
+        proc.send_signal(SIGINT)
+        proc.wait()

--- a/tests/integration/test_all_pipelines.py
+++ b/tests/integration/test_all_pipelines.py
@@ -3,12 +3,9 @@ Test the POPROX endpoint running under Serverless Offline.
 """
 
 import logging
-import os
-import sys
 import warnings
-from threading import Condition, Lock, Thread
 
-from pytest import fail, fixture, mark, skip
+from pytest import mark, skip
 
 from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root

--- a/tests/integration/test_all_pipelines.py
+++ b/tests/integration/test_all_pipelines.py
@@ -14,7 +14,7 @@ from pytest import fail, fixture, mark, skip
 from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
 from poprox_recommender.recommenders import recommendation_pipelines
-from poprox_recommender.testing import local_service as service  # noqa: F401
+from poprox_recommender.testing import docker_service as service  # noqa: F401
 
 logger = logging.getLogger(__name__)
 try:
@@ -67,7 +67,6 @@ class ServerlessBackground(Thread):
         self.proc.expect(EOF)
 
 
-@mark.serverless
 @mark.parametrize("pipeline", PIPELINES)
 def test_basic_request(service, pipeline):  # noqa: F811
     test_dir = project_root() / "tests"

--- a/tests/integration/test_all_pipelines.py
+++ b/tests/integration/test_all_pipelines.py
@@ -8,7 +8,6 @@ import sys
 import warnings
 from threading import Condition, Lock, Thread
 
-from pexpect import EOF, spawn
 from pytest import fail, fixture, mark, skip
 
 from poprox_recommender.config import allow_data_test_failures
@@ -25,46 +24,6 @@ except Exception as e:
         skip("recommendation pipelines unavailable", allow_module_level=True)
     else:
         raise e
-
-
-@fixture(scope="module")
-def sl_listener():
-    """
-    Fixture that starts and stops serverless offline to test endpoint responses.
-    """
-
-    local = os.environ.get("POPROX_LOCAL_LAMBDA", None)
-    if local:
-        yield
-        return
-
-    thread = ServerlessBackground()
-    thread.start()
-    try:
-        with thread.lock:
-            if thread.ready.wait(15):
-                logger.info("ready for tests")
-                yield
-            else:
-                fail("serverless timed out")
-    finally:
-        thread.proc.sendintr()
-
-
-class ServerlessBackground(Thread):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.lock = Lock()
-        self.ready = Condition(self.lock)
-
-    def run(self):
-        logger.info("starting serverless")
-        self.proc = spawn("npx serverless offline start", logfile=sys.stdout.buffer)
-        self.proc.expect(r"Server ready:")
-        logger.info("server ready")
-        with self.lock:
-            self.ready.notify_all()
-        self.proc.expect(EOF)
 
 
 @mark.parametrize("pipeline", PIPELINES)

--- a/tests/integration/test_all_pipelines.py
+++ b/tests/integration/test_all_pipelines.py
@@ -14,7 +14,7 @@ from pytest import fail, fixture, mark, skip
 from poprox_recommender.config import allow_data_test_failures
 from poprox_recommender.paths import project_root
 from poprox_recommender.recommenders import recommendation_pipelines
-from poprox_recommender.testing import docker_service as service  # noqa: F401
+from poprox_recommender.testing import auto_service as service  # noqa: F401
 
 logger = logging.getLogger(__name__)
 try:


### PR DESCRIPTION
This makes the test suites configurable in terms of their targets to test.

- The various `_service` fixtures will make a POPROX service available to a test case.
- The `auto_service` fixture looks at the `POPROX_TEST_TARGET` environment variable to see which fixture to load. Supported values are `local` (run handlers directly), `docker-auto` (build and run a docker container), and `docker` (connect to already-running Docker container). Eventually it will be able to be a URL to connect to a deployed Lambda endpoint.
- Use the tests instead of the separate test script to test the docker container. This now tests all pipelines after building the container.
- Remove `serverless-offline` and its bits.