### PR TITLE
Add support for compressed request bodies using `gzip`

### DIFF
--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -25,6 +25,10 @@ def generate_recs(event, context):
 
     logger.info(f"Headers: {headers}")
 
+    # base64 encoding is applied to our requests by the AWS stack
+    # and compression is applied in our code, which means that
+    # we have to base64 decode first and decompress second
+    # (contrary to the usual expectation)
     body = base64.b64decode(body) if is_encoded else body
     body = gzip.decompress(body) if is_compressed else body
     logger.info(f"Decoded body: {body}")

--- a/src/poprox_recommender/handler.py
+++ b/src/poprox_recommender/handler.py
@@ -1,4 +1,5 @@
 import base64
+import gzip
 import logging
 import os
 
@@ -15,11 +16,17 @@ logger = logging.getLogger(__name__)
 def generate_recs(event, context):
     logger.info(f"Received event: {event}")
 
-    body = event.get("body", {})
-    is_encoded = event.get("isBase64Encoded", False)
     pipeline_params = event.get("queryStringParameters", {})
+    body = event.get("body", {})
+    headers = event.get("headers", {})
+
+    is_encoded = event.get("isBase64Encoded", False)
+    is_compressed = headers.get("Content-Encoding") == "gzip"
+
+    logger.info(f"Headers: {headers}")
 
     body = base64.b64decode(body) if is_encoded else body
+    body = gzip.decompress(body) if is_compressed else body
     logger.info(f"Decoded body: {body}")
 
     req = RecommendationRequest.model_validate_json(body)

--- a/src/poprox_recommender/testing.py
+++ b/src/poprox_recommender/testing.py
@@ -5,6 +5,8 @@ This lives in the main package so it can be easily imported from any of the
 tests, regardless of their subdirectories.
 """
 
+import base64
+import gzip
 import json
 import logging
 import os
@@ -41,18 +43,32 @@ class InProcessTestService:
     Test service that directly runs the request handler in-process.
     """
 
-    def request(self, req: RecommendationRequest | str, pipeline: str) -> RecommendationResponse:
+    def request(
+        self, req: RecommendationRequest | str, pipeline: str, compress: bool = False
+    ) -> RecommendationResponse:
         # defer to here so we don't always import the handler
         from poprox_recommender.handler import generate_recs
 
         if not isinstance(req, str):
             req = req.model_dump_json()
 
-        event = {
-            "body": req,
-            "queryStringParameters": {"pipeline": pipeline},
-            "isBase64Encoded": False,
-        }
+        req_txt = json.dumps(json.loads(req))
+
+        if compress:
+            event = {
+                "headers": {"Content-Encoding": "gzip", "Content-Type": "application/json"},
+                "queryStringParameters": {"pipeline": pipeline},
+                "body": base64.encodebytes(gzip.compress(req_txt.encode())).decode("ascii"),
+                "isBase64Encoded": True,
+            }
+        else:
+            event = {
+                "headers": {},
+                "queryStringParameters": {"pipeline": pipeline},
+                "body": req_txt,
+                "isBase64Encoded": False,
+            }
+
         res = generate_recs(event, {})
         return RecommendationResponse.model_validate_json(res["body"])
 
@@ -67,15 +83,29 @@ class DockerTestService:
     def __init__(self, url: str):
         self.url = url
 
-    def request(self, req: RecommendationRequest | str, pipeline: str) -> RecommendationResponse:
+    def request(
+        self, req: RecommendationRequest | str, pipeline: str, compress: bool = False
+    ) -> RecommendationResponse:
         if not isinstance(req, str):
             req = req.model_dump_json()
 
-        event = {
-            "body": json.dumps(json.loads(req)),
-            "queryStringParameters": {"pipeline": pipeline},
-            "isBase64Encoded": False,
-        }
+        req_txt = json.dumps(json.loads(req))
+
+        if compress:
+            event = {
+                "headers": {"Content-Encoding": "gzip", "Content-Type": "application/json"},
+                "queryStringParameters": {"pipeline": pipeline},
+                "body": base64.encodebytes(gzip.compress(req_txt.encode())).decode("ascii"),
+                "isBase64Encoded": True,
+            }
+        else:
+            event = {
+                "headers": {},
+                "queryStringParameters": {"pipeline": pipeline},
+                "body": req_txt,
+                "isBase64Encoded": False,
+            }
+
         result = requests.post(self.url, json=event)
         res_data = result.json()
         if result.status_code != 200:

--- a/tests/integration/test_compression.py
+++ b/tests/integration/test_compression.py
@@ -1,0 +1,25 @@
+import logging
+
+from pytest import skip
+
+from poprox_recommender.config import allow_data_test_failures
+from poprox_recommender.paths import project_root
+from poprox_recommender.testing import auto_service as service  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+def test_compressed_request(service):  # noqa: F811
+    try:
+        test_dir = project_root() / "tests"
+        req_f = test_dir / "request_data" / "request_body.json"
+        req_body = req_f.read_text()
+
+        logger.info("sending request")
+        response = service.request(req_body, "nrms", compress=True)
+        logger.info("response: %s", response.model_dump_json(indent=2))
+    except FileNotFoundError as e:
+        if allow_data_test_failures():
+            skip("recommendation request data", allow_module_level=True)
+        else:
+            raise e


### PR DESCRIPTION
We're hitting the upper end of the allowed request size and adding multiple image records per article is pushing us over. I think there are two issues that lead there:
* Our request serialization may not be excluding the raw image metadata attribute/column correctly
* The requests are already large but should be very compressible

This PR attempts to address the second one by checking the `Content-Type` header and decoding/decompressing the request body if the header is set to `application/json+gzip+base64`.