### PR TITLE
Post (or update) a comment instead of failing when pipeline is out of date

### DIFF
--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -3,6 +3,9 @@ name: Check Data Pipeline
 on:
   pull_request:
 
+permissions:
+  issues: write
+
 jobs:
   check-status:
     name: "Check data pipeline is up-to-date"

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
           /bin/bash scripts/check-dvc-status.sh
 
       - name: Comment on PR
-        if: github.event == 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -7,8 +7,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  statuses: write
-  checks: write
 
 jobs:
   check-status:

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           script: |
             const { postDvcStatus } = require('./scripts/auto-comments.js')
-            await postDvcStatus({octokit, context});
+            await postDvcStatus({github, context});
 
   rerun-subset-recs:
     name: "Rerun MIND subset recommendations"

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -32,7 +32,15 @@ jobs:
 
       - name: Check pipeline status
         run: |
-          exec /bin/bash scripts/check-dvc-status.sh
+          /bin/bash scripts/check-dvc-status.sh
+
+      - name: Comment on PR
+        if: github.event == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { postDvcStatus } = require('./scripts/auto-comments.js')
+            await postDvcStatus();
 
   rerun-subset-recs:
     name: "Rerun MIND subset recommendations"

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           script: |
             const { postDvcStatus } = require('./scripts/auto-comments.js')
-            await postDvcStatus({ octokit, context });
+            await postDvcStatus({octokit, context});
 
   rerun-subset-recs:
     name: "Rerun MIND subset recommendations"

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           script: |
             const { postDvcStatus } = require('./scripts/auto-comments.js')
-            await postDvcStatus();
+            await postDvcStatus({ octokit, context });
 
   rerun-subset-recs:
     name: "Rerun MIND subset recommendations"

--- a/.github/workflows/check-data-pipeline.yml
+++ b/.github/workflows/check-data-pipeline.yml
@@ -4,7 +4,11 @@ on:
   pull_request:
 
 permissions:
+  contents: read
   issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
 
 jobs:
   check-status:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,12 @@
   "[jsonc]": {
     "editor.formatOnSave": true
   },
+  "[javascript]": {
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true
+  },
   "[toml]": {
     "editor.formatOnSave": true
   },

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -18,7 +18,11 @@ async function postDvcStatus({ github, context }) {
         if (c.body.match(/Creator:\s+check-dvc-status/)) {
             await github.graphql(`
                 mutation MinimizeComment {
-                    minimizeComment(input: {subjectId:"${c.node_id}",classifier:OUTDATED}) {}
+                    minimizeComment(input: {subjectId:"${c.node_id}",classifier:OUTDATED}) {
+                        minimizedComment {
+                            id
+                        }
+                    }
                 }
             `);
         }

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -20,7 +20,7 @@ async function postDvcStatus({ github, context }) {
                 mutation MinimizeComment {
                     minimizeComment(input: {subjectId:"${c.node_id}",classifier:OUTDATED}) {
                         minimizedComment {
-                            id
+                            minimizedReason
                         }
                     }
                 }

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -1,10 +1,10 @@
 const fs = require("fs/promises");
 
-async function postDvcStatus({ octokit, context }) {
+async function postDvcStatus({ github, context }) {
     let body = await fs.readFile("dvc-status.log", { encoding: "utf-8" });
     console.log("posting issue comment");
 
-    let comments = octokit.rest.issues.listComments({
+    let comments = github.rest.issues.listComments({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: context.issue.number,
@@ -17,14 +17,14 @@ async function postDvcStatus({ octokit, context }) {
         }
     }
     if (comment_id) {
-        octokit.rest.issues.updateComment({
+        github.rest.issues.updateComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id,
             body,
         });
     } else {
-        octokit.rest.issues.createComment({
+        github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -1,0 +1,37 @@
+const fs = require("fs/promises");
+
+async function postDvcStatus() {
+    let body = await fs.readFile("dvc-status.log", { encoding: "utf-8" });
+
+    let comments = octokit.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+    });
+    let comment_id = null;
+    for (let c of comments) {
+        if (c.body.match(/Creator:\s+check-dvc-status/)) {
+            comment_id = c.id;
+            break;
+        }
+    }
+    if (comment_id) {
+        octokit.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id,
+            body,
+        });
+    } else {
+        octokit.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body,
+        });
+    }
+}
+
+module.exports = {
+    postDvcStatus,
+};

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -4,7 +4,7 @@ async function postDvcStatus({ github, context }) {
     let body = await fs.readFile("dvc-status.log", { encoding: "utf-8" });
     console.log("posting issue comment");
 
-    let comments = github.rest.issues.listComments({
+    let comments = await github.rest.issues.listComments({
         owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: context.issue.number,
@@ -17,14 +17,14 @@ async function postDvcStatus({ github, context }) {
         }
     }
     if (comment_id) {
-        github.rest.issues.updateComment({
+        await github.rest.issues.updateComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             comment_id,
             body,
         });
     } else {
-        github.rest.issues.createComment({
+        await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -1,6 +1,6 @@
 const fs = require("fs/promises");
 
-async function postDvcStatus() {
+async function postDvcStatus({ octokit, context }) {
     let body = await fs.readFile("dvc-status.log", { encoding: "utf-8" });
 
     let comments = octokit.rest.issues.listComments({

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -2,6 +2,7 @@ const fs = require("fs/promises");
 
 async function postDvcStatus({ octokit, context }) {
     let body = await fs.readFile("dvc-status.log", { encoding: "utf-8" });
+    console.log("posting issue comment");
 
     let comments = octokit.rest.issues.listComments({
         owner: context.repo.owner,

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -9,9 +9,11 @@ async function postDvcStatus({ github, context }) {
         repo: context.repo.repo,
         issue_number: context.issue.number,
     });
-    console.log(comments);
+    if (comments.status != 200) {
+        throw new Error(`HTTP error fetching comments (${comments.status})`);
+    }
     let comment_id = null;
-    for (let c of comments) {
+    for (let c of comments.data) {
         if (c.body.match(/Creator:\s+check-dvc-status/)) {
             comment_id = c.id;
             break;

--- a/scripts/auto-comments.js
+++ b/scripts/auto-comments.js
@@ -9,6 +9,7 @@ async function postDvcStatus({ github, context }) {
         repo: context.repo.repo,
         issue_number: context.issue.number,
     });
+    console.log(comments);
     let comment_id = null;
     for (let c of comments) {
         if (c.body.match(/Creator:\s+check-dvc-status/)) {

--- a/scripts/check-dvc-status.sh
+++ b/scripts/check-dvc-status.sh
@@ -37,7 +37,7 @@ EOF
 
 dvc status --no-updates | tee -a $report_file
 echo -e '```\n' >>$report_file
-echo -e 'Creator: check-dvc-status'
+echo -e 'Creator: check-dvc-status' >>$report_file
 
 # emit GitHub error messages attached to each individual stage
 jq -r 'keys | .[] | sub(":"; " ")' <$status_file | (while read file stage; do

--- a/scripts/check-dvc-status.sh
+++ b/scripts/check-dvc-status.sh
@@ -1,19 +1,43 @@
 #!/bin/bash
 set -eo pipefail
 
+report_file=dvc-status.log
 status_file=$(mktemp --tmpdir poprox-dvc-status.XXXXXXXX)
 trap 'rm $status_file' INT TERM EXIT
 
 dvc status --no-updates --json >$status_file
 
 n_changed=$(jq length <$status_file)
-echo "$n_changed stages have changed"
+echo "changed=$n_changed" >>"$GITHUB_OUTPUT"
+
 if [[ $n_changed -eq 0 ]]; then
     echo "::notice::DVC pipeline is up-to-date"
+    cat >$report_file <<EOF
+✅ The DVC pipeline is up-to-date.
+
+Creator: check-dvc-status
+EOF
     exit 0
-else
-    dvc status --no-updates
 fi
+
+# Prepare a report for the out-of-date information.
+echo "::notice::$n_changed stages are out-of-date"
+cat >$report_file <<EOF
+🚨 The DVC pipeline is out-of-date. 🚨
+
+This is not a hard error, but the DVC-controlled outputs in this PR, such as
+evaluation metrics, are not current with respect to their code and data inputs.
+
+If the MIND eval CI job also fails, then the pipeline is not only out-of-date but
+cannot be rerun to produce current outputs.
+
+\`\`\`console
+$ dvc status
+EOF
+
+dvc status --no-updates | tee -a $report_file
+echo -e '```\n' >>$report_file
+echo -e 'Creator: check-dvc-status'
 
 # emit GitHub error messages attached to each individual stage
 jq -r 'keys | .[] | sub(":"; " ")' <$status_file | (while read file stage; do
@@ -25,4 +49,3 @@ jq -r 'keys | .[] | sub(":"; " ")' <$status_file | (while read file stage; do
 done)
 
 echo "::error::$n_changed stages are out-of-date"
-exit 1

--- a/scripts/check-dvc-status.sh
+++ b/scripts/check-dvc-status.sh
@@ -13,7 +13,7 @@ echo "changed=$n_changed" >>"$GITHUB_OUTPUT"
 if [[ $n_changed -eq 0 ]]; then
     echo "::notice::DVC pipeline is up-to-date"
     cat >$report_file <<EOF
-✅ The DVC pipeline is up-to-date.
+### ✅ The DVC pipeline is up-to-date.
 
 Good news! The DVC pipeline outputs are up-to-date with respect to their code and data inputs in this PR.
 
@@ -25,7 +25,7 @@ fi
 # Prepare a report for the out-of-date information.
 echo "::notice::$n_changed stages are out-of-date"
 cat >$report_file <<EOF
-🚨 The DVC pipeline is out-of-date. 🚨
+### 🚨 The DVC pipeline is out-of-date. 🚨
 
 This is not a hard error, but the DVC-controlled outputs in this PR, such as evaluation metrics, are not current with respect to their code and data inputs.
 

--- a/scripts/check-dvc-status.sh
+++ b/scripts/check-dvc-status.sh
@@ -15,6 +15,8 @@ if [[ $n_changed -eq 0 ]]; then
     cat >$report_file <<EOF
 ✅ The DVC pipeline is up-to-date.
 
+Good news! The DVC pipeline outputs are up-to-date with respect to their code and data inputs in this PR.
+
 Creator: check-dvc-status
 EOF
     exit 0
@@ -25,11 +27,9 @@ echo "::notice::$n_changed stages are out-of-date"
 cat >$report_file <<EOF
 🚨 The DVC pipeline is out-of-date. 🚨
 
-This is not a hard error, but the DVC-controlled outputs in this PR, such as
-evaluation metrics, are not current with respect to their code and data inputs.
+This is not a hard error, but the DVC-controlled outputs in this PR, such as evaluation metrics, are not current with respect to their code and data inputs.
 
-If the MIND eval CI job also fails, then the pipeline is not only out-of-date but
-cannot be rerun to produce current outputs.
+If the MIND eval CI job also fails, then the pipeline is not only out-of-date but cannot be rerun to produce current outputs.
 
 \`\`\`console
 $ dvc status


### PR DESCRIPTION
This modifies the “is the pipeline up-to-date?” logic to post a comment back to the PR instead of failing the build.

The job minimizes all prior status comments as "outdated" to reduce PR clutter.