### PR TITLE
Update LensKit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = { file = "LICENSE.md" }
 dynamic = ["version"]
 dependencies = [
-  "lenskit==2025.0.0a4",
+  "lenskit==2025.1.1b12",
   "nltk>=3.8,<4",
   "numpy>=1.26,<2",
   "torch~=2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1366,6 +1366,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8c/4f2f0784d08a383b5de3d3b1d65a6f204cc5dc487621c91c550388d756af/humanize-4.12.1.tar.gz", hash = "sha256:1338ba97415c96556758a6e2f65977ed406dddf4620d4c6db9bbdfd07f0f1232", size = 80827 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/30/5ef5994b090398f9284d2662f56853e5183ae2cb5d8e3db67e4f4cfea407/humanize-4.12.1-py3-none-any.whl", hash = "sha256:86014ca5c52675dffa1d404491952f1f5bf03b07c175a51891a343daebf01fea", size = 127409 },
+]
+
+[[package]]
 name = "hydra-core"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1977,12 +1986,15 @@ wheels = [
 
 [[package]]
 name = "lenskit"
-version = "2025.0.0a4"
+version = "2025.1.1b12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
+    { name = "humanize" },
     { name = "more-itertools" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "prettytable" },
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyzmq" },
@@ -1994,10 +2006,11 @@ dependencies = [
     { name = "torch", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-18-poprox-recommender-cpu' and extra == 'extra-18-poprox-recommender-cuda') or (extra != 'extra-18-poprox-recommender-cpu' and extra != 'extra-18-poprox-recommender-cuda')" },
     { name = "torch", version = "2.6.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-18-poprox-recommender-cpu') or (extra == 'extra-18-poprox-recommender-cpu' and extra == 'extra-18-poprox-recommender-cuda')" },
     { name = "torch", version = "2.6.0+cu124", source = { registry = "https://download.pytorch.org/whl/cu124" }, marker = "extra == 'extra-18-poprox-recommender-cuda'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/31/b8520bc9c89a9d2f8eaa5bde9bf0ca007c96c60c666f731459991ca6e892/lenskit-2025.0.0a4.tar.gz", hash = "sha256:9d428d80c10cbbfda3090b2de549f520d0c718e655e71536a7956a80b3cb94df", size = 112550 }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/d8/19b6d1022cd2d71ee1fe8547109cfe551278888da8e4d9c03ede52cc2956/lenskit-2025.1.1b12.tar.gz", hash = "sha256:cf4f212a8009362c85c0a8c4e44f6b0b0f2cfe318a417798aed1068aebc3bbb8", size = 147727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/3c/368f894d876d492be27b2784063424abdad23e72617f9c81bc6aa860f307/lenskit-2025.0.0a4-py3-none-any.whl", hash = "sha256:8b8ef0559759405a8b3d6d91125d5f6db2286573d94fc622a5525caaba93936a", size = 166718 },
+    { url = "https://files.pythonhosted.org/packages/2b/f3/fe0a89a466847fac40459eca0cb7e21ebcd8e2f8ced9787a45a2662c5553/lenskit-2025.1.1b12-py3-none-any.whl", hash = "sha256:f9dc1f991ae870eb9a8c1488959c73a02c954acaa8fab6b06ca21aa52e75cc3e", size = 211413 },
 ]
 
 [[package]]
@@ -2885,7 +2898,7 @@ requires-dist = [
     { name = "awslambdaric", marker = "extra == 'deploy'", specifier = "~=2.2" },
     { name = "docopt", marker = "extra == 'eval'", specifier = ">=0.6" },
     { name = "ipyparallel", specifier = "~=8.0" },
-    { name = "lenskit", specifier = "==2025.0.0a4" },
+    { name = "lenskit", specifier = "==2025.1.1b12" },
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "numpy", specifier = ">=1.26,<2" },
     { name = "pandas", marker = "extra == 'eval'", specifier = "~=2.0" },
@@ -2963,6 +2976,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/10/97ee2fa54dff1e9da9badbc5e35d0bbaef0776271ea5907eccf64140f72f/pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af", size = 177815 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f", size = 204643 },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/95/78080e58efbdde46cda8d4498737bf9687839ed4a9744b068cc730a073ed/prettytable-3.15.1.tar.gz", hash = "sha256:f0edb38060cb9161b2417939bfd5cd9877da73388fb19d1e8bf7987e8558896e", size = 65907 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/37/f687efd8760c183787ff16a61ec9e3515355178271f33fd7c14bf42e338c/prettytable-3.15.1-py3-none-any.whl", hash = "sha256:1bb0da7437e904ec879d2998aded19abc722719aa3d384a7faa44dcbe4aeb2e9", size = 33781 },
 ]
 
 [[package]]


### PR DESCRIPTION
This updates LensKit to a newer beta, and makes sure everything still works.

**Note:** this changes the default RBP patience parameter from 0.5 to 0.85.