### PR TITLE
Use case-insensitive `Headers` implementation from `httpx`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 license = { file = "LICENSE.md" }
 dynamic = ["version"]
 dependencies = [
+  "httpx~=0.28.1",
   "lenskit==2025.1.1rc1",
   "nltk>=3.8,<4",
   "numpy>=1.26,<2",
@@ -37,12 +38,8 @@ deploy = [
   "awslambdaric ~=2.2",
 ]
 # declare extras for Torch install
-cpu = [
-  "torch~=2.2",
-]
-cuda = [
-  "torch~=2.2",
-]
+cpu = ["torch~=2.2"]
+cuda = ["torch~=2.2"]
 
 [project.urls]
 Homepage = "https://docs.poprox.ai"
@@ -50,16 +47,8 @@ GitHub = "https://github.com/CCRI-POPROX/poprox-recommender"
 
 ## dependencies for various task sets
 [dependency-groups]
-lint = [
-  "pre-commit ~=3.7",
-  "ruff >=0.4",
-  "pyright ~=1.1",
-]
-test = [
-  "requests >=2.31,<3",
-  "coverage >=6.5",
-  "pytest >=8",
-]
+lint = ["pre-commit ~=3.7", "ruff >=0.4", "pyright ~=1.1"]
+test = ["requests >=2.31,<3", "coverage >=6.5", "pytest >=8"]
 dev = [
   "hatch ~=1.13",
   "ipython >=8",
@@ -86,12 +75,7 @@ data = [
 
 ## UV index setup for PyTorch
 [tool.uv]
-conflicts = [
-  [
-    { extra = "cpu" },
-    { extra = "cuda" },
-  ],
-]
+conflicts = [[{ extra = "cpu" }, { extra = "cuda" }]]
 
 [tool.uv.sources]
 torch = [


### PR DESCRIPTION
It seems that API Gateway lower-cases all the headers in between the platform and the recommender, but out of an abundance of caution let's just make the headers case-insensitive. We already have `httpx` as a transitive dependency, so this doesn't really add any additional heft to the container.