### PR TITLE
Add `/warmup` route returning protocol version and available pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Use Lambda "Provided" base image for build
 FROM public.ecr.aws/lambda/provided:al2023 AS build
 
+RUN dnf install -y git
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 # Copy the soure code into the image to install it and create the environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
   "transformers>=4.41,<5",
   "rich ~=13.9",
   "ipyparallel ~=8.0",
-  # we reference the zip file, so install doesn't need git
-  "poprox-concepts @ https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/heads/main.zip",
+  "poprox-concepts @ git+https://github.com/CCRI-POPROX/poprox-concepts.git",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "rich ~=13.9",
   "ipyparallel ~=8.0",
   # we reference the zip file, so install doesn't need git
-  "poprox-concepts @ https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/tags/v0.1.0.zip",
+  "poprox-concepts @ https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/heads/main.zip",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2924,12 +2924,12 @@ wheels = [
 
 [[package]]
 name = "poprox-concepts"
-version = "0.1.0"
-source = { url = "https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/tags/v0.1.0.zip" }
+version = "0.0.1"
+source = { url = "https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/heads/main.zip" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { hash = "sha256:5802efb2d99b598f5b607fb77e6fb58fc00deef6709eb1e6541bd71e1eeaf6fc" }
+sdist = { hash = "sha256:e54d99bf714894c7b4105e1cbb20fb4c2767b86008e3ef1f4f3e284b1f93f152" }
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = "~=2.7.1" }]
@@ -3033,7 +3033,7 @@ requires-dist = [
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "numpy", specifier = ">=1.26,<2" },
     { name = "pandas", marker = "extra == 'eval'", specifier = "~=2.0" },
-    { name = "poprox-concepts", url = "https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/tags/v0.1.0.zip" },
+    { name = "poprox-concepts", url = "https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/heads/main.zip" },
     { name = "rich", specifier = "~=13.9" },
     { name = "safetensors", specifier = ">=0.4,<1" },
     { name = "smart-open", specifier = "==7.*" },

--- a/uv.lock
+++ b/uv.lock
@@ -2925,14 +2925,10 @@ wheels = [
 [[package]]
 name = "poprox-concepts"
 version = "0.0.1"
-source = { url = "https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/heads/main.zip" }
+source = { git = "https://github.com/CCRI-POPROX/poprox-concepts.git#e6377a38be8aef7899c80d6ac38fc21bceeaba46" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { hash = "sha256:e54d99bf714894c7b4105e1cbb20fb4c2767b86008e3ef1f4f3e284b1f93f152" }
-
-[package.metadata]
-requires-dist = [{ name = "pydantic", specifier = "~=2.7.1" }]
 
 [[package]]
 name = "poprox-recommender"
@@ -3033,7 +3029,7 @@ requires-dist = [
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "numpy", specifier = ">=1.26,<2" },
     { name = "pandas", marker = "extra == 'eval'", specifier = "~=2.0" },
-    { name = "poprox-concepts", url = "https://github.com/CCRI-POPROX/poprox-concepts/archive/refs/heads/main.zip" },
+    { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git" },
     { name = "rich", specifier = "~=13.9" },
     { name = "safetensors", specifier = ">=0.4,<1" },
     { name = "smart-open", specifier = "==7.*" },


### PR DESCRIPTION
This route accomplishes several things:
* Get recommendation pipelines and models loaded into memory in at least one Lambda instance before we send recommendation requests
* Tell the platform what version of the request/response format this endpoint supports
* Provide the list of available recommenders back to the platform, which allows us to throw better exceptions on the platform side before we ask for a recommender that doesn't exist in the endpoint

It's a bit tricky to test with the current version of the test service, which (reasonably) assumed only one route per endpoint.