### PR TITLE
Fix default recommender pipeline when pipeline=None

### DIFF
--- a/src/poprox_recommender/recommenders/__init__.py
+++ b/src/poprox_recommender/recommenders/__init__.py
@@ -5,8 +5,14 @@ from lenskit.pipeline import PipelineState
 
 from poprox_concepts import CandidateSet, InterestProfile
 
-from .configurations import DEFAULT_PIPELINE
-from .load import PipelineLoadError, discover_pipelines, get_pipeline, get_pipeline_builder, load_all_pipelines
+from .load import (
+    PipelineLoadError,
+    default_pipeline,
+    discover_pipelines,
+    get_pipeline,
+    get_pipeline_builder,
+    load_all_pipelines,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +41,7 @@ def select_articles(
         name = pipeline_params["pipeline"]
 
     if name is None:
-        name = DEFAULT_PIPELINE
+        name = default_pipeline()
 
     pipeline = get_pipeline(name)
 

--- a/src/poprox_recommender/recommenders/__init__.py
+++ b/src/poprox_recommender/recommenders/__init__.py
@@ -5,6 +5,7 @@ from lenskit.pipeline import PipelineState
 
 from poprox_concepts import CandidateSet, InterestProfile
 
+from .configurations import DEFAULT_PIPELINE
 from .load import PipelineLoadError, discover_pipelines, get_pipeline, get_pipeline_builder, load_all_pipelines
 
 logger = logging.getLogger(__name__)
@@ -29,10 +30,12 @@ def select_articles(
     Select articles with default recommender configuration.  It returns a
     pipeline state whose ``default`` is the final list of recommendations.
     """
+    name = None
     if pipeline_params and "pipeline" in pipeline_params:
         name = pipeline_params["pipeline"]
-    else:
-        name = "nrms"
+
+    if name is None:
+        name = DEFAULT_PIPELINE
 
     pipeline = get_pipeline(name)
 

--- a/src/poprox_recommender/recommenders/configurations/__init__.py
+++ b/src/poprox_recommender/recommenders/configurations/__init__.py
@@ -4,3 +4,7 @@ recommender service.
 """
 
 DEFAULT_PIPELINE = "nrms"
+"""
+The default recommender pipeline. Can be overridden by the
+:envvar:`POPROX_DEFAULT_PIPELINE` environment variable.
+"""

--- a/src/poprox_recommender/recommenders/configurations/__init__.py
+++ b/src/poprox_recommender/recommenders/configurations/__init__.py
@@ -2,3 +2,5 @@
 Module definitions for the different recommender pipelines defined in the POPROX
 recommender service.
 """
+
+DEFAULT_PIPELINE = "nrms"

--- a/src/poprox_recommender/recommenders/load.py
+++ b/src/poprox_recommender/recommenders/load.py
@@ -47,7 +47,13 @@ def default_pipeline() -> str:
     is set; otherwise, it returns
     :attr:`poprox_recommender.recommenders.configurations.DEFAULT_PIPELINE`.
     """
-    return os.environ.get("POPROX_DEFAULT_PIPELINE", DEFAULT_PIPELINE)
+    pipe = os.environ.get("POPROX_DEFAULT_PIPELINE")
+
+    # if env var is missing *or* is empty, use built-in default.
+    if pipe is None or not pipe.strip():
+        pipe = DEFAULT_PIPELINE
+
+    return pipe
 
 
 def get_pipeline_builder(name: str, device: str | None = None, num_slots: int = 10) -> PipelineBuilder:

--- a/src/poprox_recommender/recommenders/load.py
+++ b/src/poprox_recommender/recommenders/load.py
@@ -3,6 +3,7 @@ Functions and logic for loading recommender pipeline configurations.
 """
 
 # pyright: basic
+import os
 from importlib import import_module
 from importlib.metadata import version
 from pathlib import Path
@@ -11,6 +12,8 @@ from lenskit.pipeline import Pipeline, PipelineBuilder, PipelineCache
 from structlog.stdlib import get_logger
 
 from poprox_recommender.config import default_device
+
+from .configurations import DEFAULT_PIPELINE
 
 logger = get_logger(__name__)
 
@@ -34,6 +37,17 @@ def discover_pipelines() -> list[str]:
     names = [p.stem for p in cfg_dir.glob("*.py") if not p.name.startswith("_")]
     logger.debug("scanned pipeline configurations", path=str(cfg_dir), count=len(names))
     return names
+
+
+def default_pipeline() -> str:
+    """
+    Get the configured default pipeline.
+
+    This uses the :envvar:`POPROX_DEFAULT_PIPELINE` environment variable, if it
+    is set; otherwise, it returns
+    :attr:`poprox_recommender.recommenders.configurations.DEFAULT_PIPELINE`.
+    """
+    return os.environ.get("POPROX_DEFAULT_PIPELINE", DEFAULT_PIPELINE)
 
 
 def get_pipeline_builder(name: str, device: str | None = None, num_slots: int = 10) -> PipelineBuilder:

--- a/src/poprox_recommender/recommenders/load.py
+++ b/src/poprox_recommender/recommenders/load.py
@@ -40,6 +40,9 @@ def get_pipeline_builder(name: str, device: str | None = None, num_slots: int = 
     """
     Get a pipeline builder by name.
     """
+    if name is None:
+        raise ValueError("must specify pipeline name")
+
     if device is None:
         device = default_device()
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -35,7 +35,7 @@ def test_direct_basic_request():
         )
     except PipelineLoadError as e:
         if allow_data_test_failures():
-            xfail("data not pulled")
+            xfail("models not pulled")
         else:
             raise e
 
@@ -50,7 +50,7 @@ def test_direct_basic_request_without_clicks():
         req = RecommendationRequestV2.model_validate_json(req_f.read_text())
     except FileNotFoundError as e:
         if allow_data_test_failures():
-            xfail("data not pulled")
+            xfail("models not pulled")
         else:
             raise e
 
@@ -67,6 +67,33 @@ def test_direct_basic_request_without_clicks():
     except PipelineLoadError as e:
         if allow_data_test_failures():
             xfail("data not pulled")
+        else:
+            raise e
+
+    # do we get recommendations?
+    assert len(outputs.default.articles) > 0
+
+
+def test_direct_basic_request_explicit_none():
+    test_dir = project_root() / "tests"
+    req_f = test_dir / "request_data" / "basic-request.json"
+    try:
+        req = RecommendationRequestV2.model_validate_json(req_f.read_text())
+    except FileNotFoundError as e:
+        if allow_data_test_failures():
+            xfail("data not pulled")
+        else:
+            raise e
+
+    logger.info("generating recommendations")
+    try:
+        outputs = select_articles(
+            req.candidates, req.interacted, req.interest_profile, pipeline_params={"pipeline": None}
+        )
+    except PipelineLoadError as e:
+        if allow_data_test_failures():
+            logger.warning("pipeline failed to load", exc_info=e)
+            xfail("models not pulled")
         else:
             raise e
 


### PR DESCRIPTION
When the `pipeline` option is passed to `select_articles` but is expicitly `None`, this was not correctly detected in the default pipeline fallback logic.

This PR corrects that, falling back when either `pipeline` is missing or is `None`. It also adds a configuration for the default pipeline, both in a constant and in an environment variable, with a `default_pipeline` function to look up the default.