### PR TITLE
Add recommender test request generation script

### DIFF
--- a/src/poprox_recommender/data/poprox.py
+++ b/src/poprox_recommender/data/poprox.py
@@ -12,7 +12,8 @@ from uuid import UUID
 import pandas as pd
 
 from poprox_concepts import AccountInterest, Article, Click, Entity, InterestProfile, Mention
-from poprox_concepts.api.recommendations import RecommendationRequest
+from poprox_concepts.api.recommendations import RecommendationRequestV2
+from poprox_concepts.domain import CandidateSet
 from poprox_recommender.data.eval import EvalData
 from poprox_recommender.paths import project_root
 
@@ -65,7 +66,7 @@ class PoproxData(EvalData):
         clicked_items = newsletter_clicks["article_id"].unique()
         return pd.DataFrame({"item_id": clicked_items, "rating": [1.0] * len(clicked_items)}).set_index("item_id")
 
-    def iter_profiles(self) -> Generator[RecommendationRequest]:
+    def iter_profiles(self) -> Generator[RecommendationRequestV2]:
         newsletter_ids = self.newsletters_df["newsletter_id"].unique()
 
         for newsletter_id in newsletter_ids:
@@ -118,9 +119,9 @@ class PoproxData(EvalData):
             ].itertuples():
                 candidate_articles.append(self.lookup_candidate_article(article_row.article_id))
 
-            yield RecommendationRequest(
-                todays_articles=candidate_articles,
-                past_articles=past_articles,
+            yield RecommendationRequestV2(
+                candidates=CandidateSet(articles=candidate_articles),
+                interacted=CandidateSet(articles=past_articles),
                 interest_profile=profile,
                 num_recs=TEST_REC_COUNT,
             )

--- a/tests/generate_test_request.py
+++ b/tests/generate_test_request.py
@@ -1,0 +1,60 @@
+"""
+With exported dataset, this script can help generate test request body for recommender pipieline testing
+The data export dataset needs to be placed in side poprox-recommender/data/POPROX folder, with timestamp removed
+
+Usage:
+    generate_test_request.py [--account_id ID] [--output_file OUTPUT]
+
+Options:
+    --account_id ID      Specific user account id to process request data
+    --output_file OUTPUT Path to the output file
+"""
+
+import json
+import random
+
+from docopt import docopt
+
+from poprox_concepts.api.recommendations import RecommendationRequestV2
+from poprox_recommender.data.poprox import PoproxData
+from poprox_recommender.paths import project_root
+
+
+def get_single_request() -> str:
+    options = docopt(__doc__)
+    eval_data = PoproxData()
+    requests = list(eval_data.iter_profiles())
+    excluded_fields = {"__all__": {"raw_data": True, "images": {"__all__": {"raw_data"}}}}
+
+    request_body = ""
+    if options["--account_id"]:
+        account_id = options["--account_id"]
+        for req in requests:
+            if req.interest_profile.profile_id == account_id:
+                request_body = RecommendationRequestV2.model_dump_json(
+                    req,
+                    exclude={
+                        "candidates": excluded_fields,
+                        "interacted": excluded_fields,
+                    },
+                )
+    else:
+        random_index = random.randint(0, len(requests) - 1)
+        request_body = RecommendationRequestV2.model_dump_json(
+            requests[random_index],
+            exclude={
+                "candidates": excluded_fields,
+                "interacted": excluded_fields,
+            },
+        )
+    if options["--output_file"]:
+        with open(options["--output_file"], "w") as file:
+            json.dump(request_body, file)
+    else:
+        request_data_path = project_root() / "tests" / "request_data" / "request_body_1.json"
+        with open(request_data_path, "w") as file:
+            json.dump(request_body, file)
+
+
+if __name__ == "__main__":
+    get_single_request()

--- a/tests/generate_test_request.py
+++ b/tests/generate_test_request.py
@@ -33,27 +33,22 @@ def get_single_request() -> str:
             if req.interest_profile.profile_id == account_id:
                 request_body = RecommendationRequestV2.model_dump_json(
                     req,
-                    exclude={
-                        "candidates": excluded_fields,
-                        "interacted": excluded_fields,
-                    },
+                    exclude={"candidates": excluded_fields, "interacted": excluded_fields, "protocol_version": True},
                 )
     else:
         random_index = random.randint(0, len(requests) - 1)
         request_body = RecommendationRequestV2.model_dump_json(
             requests[random_index],
-            exclude={
-                "candidates": excluded_fields,
-                "interacted": excluded_fields,
-            },
+            exclude={"candidates": excluded_fields, "interacted": excluded_fields, "protocol_version": True},
         )
+
     if options["--output_file"]:
         with open(options["--output_file"], "w") as file:
-            json.dump(request_body, file)
+            file.write(request_body)
     else:
         request_data_path = project_root() / "tests" / "request_data" / "request_body_1.json"
         with open(request_data_path, "w") as file:
-            json.dump(request_body, file)
+            file.write(request_body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two issues observed so far:
1. Some clicked articles are missing in the exported data (just contain the data from the day of 3/25), like the following error shows; so need to add exception check in the `poprox.py` code.
```
Traceback (most recent call last):
  File "/workspaces/poprox-recommender/tests/generate_test_request.py", line 60, in <module>
    get_single_request()
  File "/workspaces/poprox-recommender/tests/generate_test_request.py", line 26, in get_single_request
    requests = list(eval_data.iter_profiles())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/poprox-recommender/src/poprox_recommender/data/poprox.py", line 88, in iter_profiles
    article = self.lookup_clicked_article(article_row.article_id)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/poprox-recommender/src/poprox_recommender/data/poprox.py", line 136, in lookup_clicked_article
    article_row = self.clicked_articles_df.loc[str(article_id)]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/vscode/poprox-venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 1191, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/poprox-venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 1431, in _getitem_axis
    return self._get_label(key, axis=axis)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/poprox-venv/lib/python3.12/site-packages/pandas/core/indexing.py", line 1381, in _get_label
    return self.obj.xs(label, axis=axis)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/poprox-venv/lib/python3.12/site-packages/pandas/core/generic.py", line 4301, in xs
    loc = index.get_loc(key)
          ^^^^^^^^^^^^^^^^^^
  File "/home/vscode/poprox-venv/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    raise KeyError(key) from err
KeyError: '35506a36-3346-487c-82b4-8821b0850057'
```
2. If we want to test with our own account, there's no way to differentiate who is who since all `account_id` in the export data now is random. We might be able to tell if we additionally send test emails during the same day (so experimenter's ids would get two newsletters, instead of one), but It's not a sustainable way.
