### PR TITLE
Load `distilbert` model architecture but not the pre-trained weights

### DIFF
--- a/src/poprox_recommender/model/nrms/news_encoder.py
+++ b/src/poprox_recommender/model/nrms/news_encoder.py
@@ -10,7 +10,7 @@ class NewsEncoder(torch.nn.Module):
         super(NewsEncoder, self).__init__()
 
         self.plm_config = AutoConfig.from_pretrained(model_path, cache_dir="/tmp/")
-        self.plm = AutoModel.from_pretrained(model_path, cache_dir="/tmp/")
+        self.plm = AutoModel.from_config(self.plm_config)
         self.plm.requires_grad_(False)
 
         self.multihead_attention = nn.MultiheadAttention(


### PR DESCRIPTION
Since we're going to overwrite the weights with the ones from our `safetensors` file anyway, we can skip loading the original pretrained weights and just load the model architecture here. It's a little faster but it's hard to say how much it'll help when deployed; on my local machine it's ~30% faster but it could be more or less on AWS.