### PR TITLE
Refactor evaluation to expose separate tasks for each pipeline

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -15,7 +15,7 @@ stages:
   recommend-mind-val:
     foreach: ${pipelines}
     do:
-      cmd: python -m poprox_recommender.evaluation.generate -M MINDlarge_dev -o outputs/mind-val ${item}
+      cmd: python -m poprox_recommender.evaluation.generate -M MINDlarge_dev -o outputs/mind-val/${item} ${item}
       deps:
         - src/poprox_recommender/evaluation/generate/
         - src/poprox_recommender/recommenders/configurations/${item}.py
@@ -40,7 +40,7 @@ stages:
   recommend-mind-small:
     foreach: ${pipelines}
     do:
-      cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev -o outputs/mind-small ${item}
+      cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev -o outputs/mind-small/${item} ${item}
       deps:
         - src/poprox_recommender/evaluation/generate/
         - src/poprox_recommender/recommenders/configurations/${item}.py
@@ -66,7 +66,7 @@ stages:
   recommend-mind-subset:
     foreach: ${pipelines}
     do:
-      cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev --subset=1000 -o outputs/mind-subset ${item}
+      cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev --subset=1000 -o outputs/mind-subset/${item} ${item}
       deps:
         - src/poprox_recommender/evaluation/generate/
         - src/poprox_recommender/recommenders/configurations/${item}.py

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,13 +1,29 @@
+vars:
+  - pipelines:
+      - nrms
+      - mmr
+      - pfar
+      - softmax
+      - topic_cali
+      - nrms_rrf_static_user
+      - nrms_topic_scores
+      - nrms_topics_static
+      - nrms_images
+
 stages:
+  # these are *foreach stages*: they have multiple versions, one for each pipeline.
   recommend-mind-val:
-    cmd: python -m poprox_recommender.evaluation.generate -M MINDlarge_dev -o outputs/mind-val
-    deps:
-      - src/poprox_recommender/evaluation/generate/
-      - models/nrms-mind/
-      - data/MINDlarge_dev.zip
-    outs:
-      - outputs/mind-val/recommendations
-      - outputs/mind-val/embeddings.parquet
+    foreach: ${pipelines}
+    do:
+      cmd: python -m poprox_recommender.evaluation.generate -M MINDlarge_dev -o outputs/mind-val ${item}
+      deps:
+        - src/poprox_recommender/evaluation/generate/
+        - src/poprox_recommender/recommenders/configurations/${item}.py
+        - models/nrms-mind/
+        - data/MINDlarge_dev.zip
+      outs:
+        - outputs/mind-val/${item}/recommendations
+        - outputs/mind-val/${item}/embeddings.parquet
 
   measure-mind-val:
     cmd: python -m poprox_recommender.evaluation.evaluate -M MINDlarge_dev mind-val
@@ -22,14 +38,18 @@ stages:
           cache: false
 
   recommend-mind-small:
-    cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev -o outputs/mind-small
-    deps:
-      - src/poprox_recommender/evaluation/generate/
-      - models/nrms-mind/
-      - data/MINDsmall_dev.zip
-    outs:
-      - outputs/mind-small/recommendations
-      - outputs/mind-small/embeddings.parquet
+    foreach: ${pipelines}
+    do:
+      cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev -o outputs/mind-small ${item}
+      deps:
+        - src/poprox_recommender/evaluation/generate/
+        - src/poprox_recommender/recommenders/configurations/${item}.py
+        - models/nrms-mind/
+        - data/MINDsmall_dev.zip
+      outs:
+        - outputs/mind-small/${item}/recommendations
+        - outputs/mind-small/${item}/embeddings.parquet
+
   measure-mind-small:
     cmd: python -m poprox_recommender.evaluation.evaluate -M MINDsmall_dev mind-small
     deps:
@@ -44,14 +64,18 @@ stages:
 
   # small subset for quick testing
   recommend-mind-subset:
-    cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev --subset=1000 -o outputs/mind-subset
-    deps:
-      - src/poprox_recommender/evaluation/generate/
-      - models/nrms-mind/
-      - data/MINDsmall_dev.zip
-    outs:
-      - outputs/mind-subset/recommendations
-      - outputs/mind-subset/embeddings.parquet
+    foreach: ${pipelines}
+    do:
+      cmd: python -m poprox_recommender.evaluation.generate -M MINDsmall_dev --subset=1000 -o outputs/mind-subset ${item}
+      deps:
+        - src/poprox_recommender/evaluation/generate/
+        - src/poprox_recommender/recommenders/configurations/${item}.py
+        - models/nrms-mind/
+        - data/MINDsmall_dev.zip
+      outs:
+        - outputs/mind-subset/${item}/recommendations
+        - outputs/mind-subset/${item}/embeddings.parquet
+
   measure-mind-subset:
     cmd: python -m poprox_recommender.evaluation.evaluate -M MINDsmall_dev mind-subset
     deps:

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -22,7 +22,8 @@ stages:
         - models/nrms-mind/
         - data/MINDlarge_dev.zip
       outs:
-        - outputs/mind-val/${item}/recommendations
+        - outputs/mind-val/${item}/recommendations.parquet
+        - outputs/mind-val/${item}/recommendations.ndjson.zst
         - outputs/mind-val/${item}/embeddings.parquet
 
   measure-mind-val:
@@ -47,7 +48,8 @@ stages:
         - models/nrms-mind/
         - data/MINDsmall_dev.zip
       outs:
-        - outputs/mind-small/${item}/recommendations
+        - outputs/mind-small/${item}/recommendations.parquet
+        - outputs/mind-small/${item}/recommendations.ndjson.zst
         - outputs/mind-small/${item}/embeddings.parquet
 
   measure-mind-small:
@@ -73,7 +75,8 @@ stages:
         - models/nrms-mind/
         - data/MINDsmall_dev.zip
       outs:
-        - outputs/mind-subset/${item}/recommendations
+        - outputs/mind-subset/${item}/recommendations.parquet
+        - outputs/mind-subset/${item}/recommendations.ndjson.zst
         - outputs/mind-subset/${item}/embeddings.parquet
 
   measure-mind-subset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "safetensors>=0.4,<1",
   "transformers[torch]>=4.41,<5",
   "rich ~=13.9",
-  "poprox-concepts @ git+https://github.com/CCRI-POPROX/poprox-concepts.git",
+  "poprox-concepts @ git+https://github.com/CCRI-POPROX/poprox-concepts.git@mdekstrand/relax-pydantic",
 ]
 
 [project.optional-dependencies]

--- a/src/poprox_recommender/evaluation/evaluate.py
+++ b/src/poprox_recommender/evaluation/evaluate.py
@@ -34,7 +34,7 @@ from lenskit.parallel.ray import init_cluster
 from poprox_recommender.data.eval import EvalData
 from poprox_recommender.data.mind import MindData
 from poprox_recommender.data.poprox import PoproxData
-from poprox_recommender.evaluation.metrics import ProfileRecs, measure_batch, measure_profile_recs
+from poprox_recommender.evaluation.metrics import ProfileRecs, measure_profile_recs
 from poprox_recommender.paths import project_root
 
 logger = logging.getLogger(__name__)
@@ -134,6 +134,14 @@ def main():
     out_fn = project_root() / "outputs" / eval_name / "metrics.csv"
     logger.info("saving evaluation to %s", out_fn)
     agg_metrics.to_csv(out_fn)
+
+
+@ray.remote(num_cpus=1)
+def measure_batch(profiles: list[ProfileRecs]) -> list[list[dict[str, Any]]]:
+    """
+    Measure a batch of profile recommendations.
+    """
+    return [measure_profile_recs(profile) for profile in profiles]
 
 
 if __name__ == "__main__":

--- a/src/poprox_recommender/evaluation/generate/__main__.py
+++ b/src/poprox_recommender/evaluation/generate/__main__.py
@@ -2,7 +2,7 @@
 Generate recommendations for offline test data.
 
 Usage:
-    poprox_recommender.evaluation.generate [options]
+    poprox_recommender.evaluation.generate [options] PIPELINE
 
 Options:
     -v, --verbose
@@ -17,6 +17,8 @@ Options:
             read POPROX test data DATA
     --subset=N
             test only on the first N test profiles
+    PIPELINE
+            The name of the pipeline to generate from
 """
 
 import logging
@@ -60,7 +62,9 @@ def generate_main():
     elif options["--mind-data"]:
         dataset = MindData(options["--mind-data"])
 
-    worker_usage = generate_profile_recs(dataset, outputs, n_profiles)
+    pipe_name = options["PIPELINE"]
+
+    worker_usage = generate_profile_recs(dataset, outputs, pipe_name, n_profiles)
 
     try:
         import resource

--- a/src/poprox_recommender/evaluation/generate/outputs.py
+++ b/src/poprox_recommender/evaluation/generate/outputs.py
@@ -6,6 +6,7 @@ from typing import Protocol, TextIO
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import torch
 import zstandard
 from lenskit.pipeline import PipelineState
 from pydantic import BaseModel
@@ -22,7 +23,7 @@ class OfflineRecommendations(BaseModel):
 
 class OfflineRecResults(BaseModel):
     final: RecommendationList
-    topn: RecommendationList | None = None
+    ranked: RecommendationList | None = None
     reranked: RecommendationList | None = None
 
 
@@ -184,18 +185,30 @@ class JSONRecommendationWriter:
 
         # get the different recommendation lists to record
         recs = pipeline_state["recommender"]
-        results = OfflineRecResults(final=recs)
+        results = OfflineRecResults(final=self._clean_torch(recs))
 
         ranked = pipeline_state.get("ranker", None)
         if ranked is not None:
-            results.topn = ranked
+            results.ranked = self._clean_torch(ranked)
 
         reranked = pipeline_state.get("reranker", None)
         if reranked is not None:
-            results.reranked = reranked
+            results.reranked = self._clean_torch(reranked)
 
         data = OfflineRecommendations(request=request, results=results)
-        print(data.model_dump_json(), file=self.writer)
+        print(data.model_dump_json(serialize_as_any=True), file=self.writer)
+
+    def _clean_torch(self, recs: RecommendationList):
+        """
+        Replace all Torch tensors in a recommendation list with NumPy arrays prior to serializatin.
+
+        NB: this should be provided by RecommendationList?
+        """
+        for k, v in list(recs):
+            if isinstance(v, torch.Tensor):
+                setattr(recs, k, v.numpy())
+
+        return recs
 
     def close(self):
         self.writer.close()

--- a/src/poprox_recommender/evaluation/generate/outputs.py
+++ b/src/poprox_recommender/evaluation/generate/outputs.py
@@ -111,7 +111,8 @@ class ParquetRecommendationWriter:
     writer: ParquetBatchedWriter
 
     def __init__(self, outs: RecOutputs):
-        self.writer = ParquetBatchedWriter(outs.rec_parquet_file)
+        outs.rec_parquet_file.parent.mkdir(exist_ok=True, parents=True)
+        self.writer = ParquetBatchedWriter(outs.rec_parquet_file, compression="snappy")
 
     def write_recommendations(self, request: RecommendationRequest, pipeline_state: PipelineState):
         assert isinstance(request, RecommendationRequest)
@@ -174,6 +175,7 @@ class JSONRecommendationWriter:
     writer: TextIO
 
     def __init__(self, outs: RecOutputs):
+        outs.rec_parquet_file.parent.mkdir(exist_ok=True, parents=True)
         self.writer = zstandard.open(outs.rec_json_file, "wt", zstandard.ZstdCompressor(6))
 
     def write_recommendations(self, request: RecommendationRequest, pipeline_state: PipelineState):
@@ -222,6 +224,7 @@ class EmbeddingWriter:
     def __init__(self, outs: RecOutputs):
         self.outputs = outs
         self.seen = set()
+        outs.rec_parquet_file.parent.mkdir(exist_ok=True, parents=True)
         self.writer = ParquetBatchedWriter(self.outputs.emb_file, compression="snappy")
 
     def write_recommendations(self, request: RecommendationRequest, pipeline_state: PipelineState):

--- a/src/poprox_recommender/evaluation/generate/outputs.py
+++ b/src/poprox_recommender/evaluation/generate/outputs.py
@@ -113,6 +113,7 @@ class ParquetRecommendationWriter:
         self.writer = ParquetBatchedWriter(outs.rec_parquet_file)
 
     def write_recommendations(self, request: RecommendationRequest, pipeline_state: PipelineState):
+        assert isinstance(request, RecommendationRequest)
         # recommendations {account id (uuid): LIST[Article]}
         # use the url of Article
         profile = request.interest_profile.profile_id
@@ -175,6 +176,7 @@ class JSONRecommendationWriter:
         self.writer = zstandard.open(outs.rec_json_file, "wt", zstandard.ZstdCompressor(6))
 
     def write_recommendations(self, request: RecommendationRequest, pipeline_state: PipelineState):
+        assert isinstance(request, RecommendationRequest)
         # recommendations {account id (uuid): LIST[Article]}
         # use the url of Article
         profile = request.interest_profile.profile_id

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -93,11 +93,9 @@ def generate_profile_recs(dataset: str, outs: RecOutputs, pipeline: str, n_profi
 
             for w in writers:
                 w.close()
-            rusage = None
 
     timer.stop()
     logger.info("finished recommending in %s", timer)
-    return rusage
 
 
 def recommend_for_profile(pipeline: str, request: RecommendationRequest) -> PipelineState:

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -1,184 +1,30 @@
 import itertools as it
-import multiprocessing as mp
-from uuid import UUID
 
-import numpy as np
-import pandas as pd
 import ray
 import torch
 from lenskit.logging import get_logger, item_progress
 from lenskit.parallel import get_parallel_config
 from lenskit.parallel.ray import init_cluster
-from lenskit.pipeline import Pipeline
-from lenskit.pipeline.state import PipelineState
+from lenskit.pipeline import PipelineState
 from lenskit.util import Stopwatch
 
 from poprox_concepts.api.recommendations import RecommendationRequest
-from poprox_concepts.domain import CandidateSet, RecommendationList
+from poprox_concepts.domain import CandidateSet
 from poprox_recommender.config import default_device
 from poprox_recommender.data.mind import TEST_REC_COUNT
-from poprox_recommender.evaluation.generate.outputs import EmbeddingWriter, RecOutputs
+from poprox_recommender.evaluation.generate.outputs import (
+    EmbeddingWriter,
+    JSONRecommendationWriter,
+    ParquetRecommendationWriter,
+    RecommendationWriter,
+    RecOutputs,
+)
 from poprox_recommender.recommenders.load import get_pipeline
 
 logger = get_logger(__name__)
 
 BATCH_SIZE = 10
 STAGES = ["final", "ranked", "reranked"]
-
-
-class RecGenerator:
-    """
-    Generate recommendations. Can be used as a Ray actor.
-    """
-
-    pipeline: Pipeline
-    worker_out: RecOutputs
-    emb_seen: set[UUID]
-    emb_writer: EmbeddingWriter
-
-    def __init__(self, pipeline: str, outs: RecOutputs, emb_writer: EmbeddingWriter):
-        proc = mp.current_process()
-        self.pipeline = get_pipeline(pipeline, device=default_device())
-        self.worker_out = outs
-        self.worker_out.open(proc.pid)
-        self.emb_seen = set()
-        self.emb_writer = emb_writer
-
-    def generate(self, request: RecommendationRequest) -> UUID | None:
-        log = logger.bind(profile_id=str(request.interest_profile.profile_id))
-        log.debug("beginning recommendation")
-        if request.num_recs != TEST_REC_COUNT:
-            log.warning(
-                "request for %s had unexpected recommendation count %d",
-                request.interest_profile.profile_id,
-                request.num_recs,
-            )
-
-        inputs = {
-            "candidate": CandidateSet(articles=request.todays_articles),
-            "clicked": CandidateSet(articles=request.past_articles),
-            "profile": request.interest_profile,
-        }
-
-        try:
-            outputs = self.pipeline.run_all(**inputs)
-        except Exception as e:
-            logger.error("error recommending for profile %s: %s", request.interest_profile.profile_id, e)
-            raise e
-
-        rec_df, embeddings = extract_recs(request, outputs)
-        rec_df["stage"] = pd.Categorical(rec_df["stage"].astype("category"), categories=STAGES)
-        self.worker_out.rec_writer.write_frame(rec_df)
-
-        # find any embeddings we haven't yet written (reduces overhead)
-        # the writer will also deduplicate between workers.
-        emb_to_write = {aid: emb for (aid, emb) in embeddings.items() if aid not in self.emb_seen}
-        # call remote if we have an actor
-        if hasattr(self.emb_writer.write_embeddings, "remote"):
-            ray.get(self.emb_writer.write_embeddings.remote(emb_to_write))
-        else:
-            self.emb_writer.write_embeddings(emb_to_write)
-        self.emb_seen |= embeddings.keys()
-
-        # just return the ID to indicate success
-        return request.interest_profile.profile_id
-
-    def generate_batch(self, batch: list[RecommendationRequest]) -> list[UUID | None]:
-        return [self.generate(req) for req in batch]
-
-    def finish(self):
-        self.worker_out.close()
-
-        try:
-            import resource
-
-            return resource.getrusage(resource.RUSAGE_SELF)
-        except ImportError:
-            return None
-
-
-def dynamic_remote(actor):
-    pc = get_parallel_config()
-    if torch.cuda.is_available():
-        _cuda_props = torch.cuda.get_device_properties()
-        # Let's take a wild guess that 20 MP units are enough per worker, so a
-        # 80-MP A40 can theoretically run 4 workers.  Even though we limit
-        # parallelism through an actor pool, if we do not request GPUs, Ray will
-        # keep us from accessing them.
-        remote = ray.remote(
-            num_cpus=pc.backend_threads,
-            num_gpus=20 / _cuda_props.multi_processor_count,
-        )
-    else:
-        # if we don't have CUDA, don't request GPU
-        logger.debug("setting up remote CPU-only actor with %d threads", pc.total_threads)
-        remote = ray.remote(
-            num_cpus=pc.total_threads,
-            num_gpus=0,
-        )
-
-    return remote(actor)
-
-
-def extract_recs(
-    request: RecommendationRequest,
-    pipeline_state: PipelineState,
-) -> tuple[pd.DataFrame, dict[UUID, np.ndarray]]:
-    # recommendations {account id (uuid): LIST[Article]}
-    # use the url of Article
-    profile = request.interest_profile.profile_id
-    assert profile is not None
-
-    # get the different recommendation lists to record
-    recs = pipeline_state["recommender"]
-    rec_lists = [
-        pd.DataFrame(
-            {
-                "profile_id": str(profile),
-                "stage": "final",
-                "item_id": [str(a.article_id) for a in recs.articles],
-                "rank": np.arange(len(recs.articles), dtype=np.int16) + 1,
-            }
-        )
-    ]
-    ranked = pipeline_state.get("ranker", None)
-    if ranked is not None:
-        assert isinstance(ranked, RecommendationList), f"reranked has unexpected type {type(ranked)}"
-        rec_lists.append(
-            pd.DataFrame(
-                {
-                    "profile_id": str(profile),
-                    "stage": "ranked",
-                    "item_id": [str(a.article_id) for a in ranked.articles],
-                    "rank": np.arange(len(ranked.articles), dtype=np.int16) + 1,
-                }
-            )
-        )
-    reranked = pipeline_state.get("reranker", None)
-    if reranked is not None:
-        assert isinstance(reranked, RecommendationList), f"reranked has unexpected type {type(reranked)}"
-        rec_lists.append(
-            pd.DataFrame(
-                {
-                    "profile_id": str(profile),
-                    "stage": "reranked",
-                    "item_id": [str(a.article_id) for a in reranked.articles],
-                    "rank": np.arange(len(reranked.articles), dtype=np.int16) + 1,
-                }
-            )
-        )
-    output_df = pd.concat(rec_lists, ignore_index=True)
-
-    # get the embeddings
-    embedded = pipeline_state.get("candidate-embedder", None)
-    embeddings = {}
-    if embedded is not None:
-        assert isinstance(embedded, CandidateSet), f"embedded has unexpected type {type(embedded)}"
-        assert hasattr(embedded, "embeddings")
-
-        for idx, article in enumerate(embedded.articles):
-            embeddings[article.article_id] = embedded.embeddings[idx].cpu().numpy()  # type: ignore
-    return output_df, embeddings
 
 
 def generate_profile_recs(dataset: str, outs: RecOutputs, pipeline: str, n_profiles: int | None = None):
@@ -199,34 +45,133 @@ def generate_profile_recs(dataset: str, outs: RecOutputs, pipeline: str, n_profi
             logger.info("starting evaluation with %d workers", pc.processes)
             init_cluster(global_logging=True)
 
-            emb_out = ray.remote(EmbeddingWriter).remote(outs)
+            writers = [
+                ray.remote(ParquetRecommendationWriter).remote(outs),
+                ray.remote(JSONRecommendationWriter).remote(outs),
+                ray.remote(EmbeddingWriter).remote(outs),
+            ]
 
-            gen_actor = dynamic_remote(RecGenerator)
-            actors = [gen_actor.remote(pipeline, outs, emb_out) for _i in range(pc.processes)]
-            pool = ray.util.ActorPool(actors)
-            batches = it.batched(profile_iter, BATCH_SIZE)
+            task = dynamic_remote(recommend_batch)
 
-            for rbatch in pool.map_unordered(lambda a, b: a.generate_batch.remote(b), batches):
-                pb.update(len(rbatch))
+            tasks = []
+            for batch in it.batched(profile_iter, BATCH_SIZE):
+                # backpressure
+                while len(tasks) >= pc.processes:
+                    logger.debug("waiting for workers to finish")
+                    done, tasks = ray.wait(tasks)
+                    # update # of finished items
+                    pb.update(sum(ray.get(r) for r in done))
 
-            logger.info("closing actors")
-            rusage = [ray.get(actor.finish.remote()) for actor in actors]
-            ray.get(emb_out.close.remote())
+                tasks.append(task.remote(pipeline, batch, writers))
+
+            logger.debug("waiting for remaining actors")
+            while tasks:
+                done, tasks = ray.wait(tasks)
+                pb.update(sum(ray.get(r) for r in done))
+
+            logger.info("closing writers")
+            close = [w.close.remote() for w in writers]
+            while close:
+                _, close = ray.wait(close)
+
+            logger.info("finished recommending")
 
         else:
             logger.info("starting serial evaluation")
             # directly call things in-process
-            emb_out = EmbeddingWriter(outs)
-            gen = RecGenerator(pipeline, outs, emb_out)
+            writers = [
+                ParquetRecommendationWriter(outs),
+                JSONRecommendationWriter(outs),
+                EmbeddingWriter(outs),
+            ]
 
             for request in profile_iter:
-                gen.generate(request)
+                state = recommend_for_profile(pipeline, request)
+                for w in writers:
+                    w.write_recommendations(request, state)
                 pb.update()
 
-            gen.finish()
-            emb_out.close()
+            for w in writers:
+                w.close()
             rusage = None
 
     timer.stop()
     logger.info("finished recommending in %s", timer)
     return rusage
+
+
+def recommend_for_profile(pipeline: str, request: RecommendationRequest) -> PipelineState:
+    """
+    Generate recommendations for a single request, returning the pipeline state.
+    """
+    # get_pipeline caches, so this will load once per worker
+    pipe = get_pipeline(pipeline, device=default_device())
+    log = logger.bind(profile_id=str(request.interest_profile.profile_id))
+    log.debug("beginning recommendation")
+    if request.num_recs != TEST_REC_COUNT:
+        log.warning(
+            "request for %s had unexpected recommendation count %d",
+            request.interest_profile.profile_id,
+            request.num_recs,
+        )
+
+    inputs = {
+        "candidate": CandidateSet(articles=request.todays_articles),
+        "clicked": CandidateSet(articles=request.past_articles),
+        "profile": request.interest_profile,
+    }
+
+    try:
+        return pipe.run_all(**inputs)
+    except Exception as e:
+        logger.error("error recommending for profile %s: %s", request.interest_profile.profile_id, e)
+        raise e
+
+
+def recommend_batch(pipeline, batch: list[RecommendationRequest], writers: list[RecommendationWriter]):
+    """
+    Batch-recommend function, to be used as a Ray worker task.
+    """
+
+    writes = []
+
+    for request in batch:
+        state = recommend_for_profile(pipeline, request)
+        # put once, so all actors share the object
+        state = ray.put(state)
+        # rate-limit our requests to the writers
+        while len(writes) >= 10:
+            _done, writes = ray.wait(writes)
+        writes += [w.write_recommendations.remote(request, state) for w in writers]
+
+    # wait for outstanding writes on this batch
+    while writes:
+        _done, writes = ray.wait(writes)
+
+    return len(batch)
+
+
+def dynamic_remote(task_or_actor):
+    """
+    Dynamically configure the resource requirements of a task or actor based on
+    CUDA availability and parallelism configuration.
+    """
+    pc = get_parallel_config()
+    if torch.cuda.is_available():
+        _cuda_props = torch.cuda.get_device_properties()
+        # Let's take a wild guess that 20 MP units are enough per worker, so a
+        # 80-MP A40 can theoretically run 4 workers.  If we do not request GPUs,
+        # Ray will keep us from accessing them.
+        remote = ray.remote(
+            num_cpus=pc.backend_threads,
+            num_gpus=20 / _cuda_props.multi_processor_count,
+        )
+    else:
+        # if we don't have CUDA, don't request GPU
+        logger.debug("setting up remote CPU-only task with %d threads", pc.total_threads)
+        remote = ray.remote(
+            num_cpus=pc.total_threads,
+            num_gpus=0,
+        )
+
+    return remote(task_or_actor)

--- a/src/poprox_recommender/evaluation/metrics/__init__.py
+++ b/src/poprox_recommender/evaluation/metrics/__init__.py
@@ -3,7 +3,6 @@ from typing import Any, NamedTuple
 from uuid import UUID
 
 import pandas as pd
-import ray
 from lenskit.data import ItemList
 from lenskit.metrics import call_metric
 from lenskit.metrics.ranking import NDCG, RecipRank
@@ -97,11 +96,3 @@ def measure_profile_recs(profile: ProfileRecs) -> list[dict[str, Any]]:
         )
 
     return results
-
-
-@ray.remote(num_cpus=1)
-def measure_batch(profiles: list[ProfileRecs]) -> list[list[dict[str, Any]]]:
-    """
-    Measure a batch of profile recommendations.
-    """
-    return [measure_profile_recs(profile) for profile in profiles]

--- a/uv.lock
+++ b/uv.lock
@@ -2776,7 +2776,7 @@ wheels = [
 [[package]]
 name = "poprox-concepts"
 version = "0.0.1"
-source = { git = "https://github.com/CCRI-POPROX/poprox-concepts.git#c5a57c1e040ba49072775f27742bad05e2e77a37" }
+source = { git = "https://github.com/CCRI-POPROX/poprox-concepts.git?rev=mdekstrand%2Frelax-pydantic#68c8c631e9d391d4c0725c1a1b79927e4255bd36" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -2878,7 +2878,7 @@ requires-dist = [
     { name = "mangum", specifier = "~=0.19.0" },
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "numpy", specifier = ">=1.26,<2" },
-    { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git" },
+    { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git?rev=mdekstrand%2Frelax-pydantic" },
     { name = "rich", specifier = "~=13.9" },
     { name = "safetensors", specifier = ">=0.4,<1" },
     { name = "smart-open", specifier = "==7.*" },
@@ -3149,40 +3149,59 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.7.4"
+version = "2.11.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/fc/ccd0e8910bc780f1a4e1ab15e97accbb1f214932e796cff3131f9a943967/pydantic-2.7.4.tar.gz", hash = "sha256:0c84efd9548d545f63ac0060c1e4d39bb9b14db8b3c0652338aecc07b5adec52", size = 714127 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/ba/1b65c9cbc49e0c7cd1be086c63209e9ad883c2a409be4746c21db4263f41/pydantic-2.7.4-py3-none-any.whl", hash = "sha256:ee8538d41ccb9c0a9ad3e0e5f07bf15ed8015b481ced539a1759d8cc89ae90d0", size = 409017 },
+    { url = "https://files.pythonhosted.org/packages/e7/12/46b65f3534d099349e38ef6ec98b1a5a81f42536d17e0ba382c28c67ba67/pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb", size = 443900 },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.18.4"
+version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/d0/622cdfe12fb138d035636f854eb9dc414f7e19340be395799de87c1de6f6/pydantic_core-2.18.4.tar.gz", hash = "sha256:ec3beeada09ff865c344ff3bc2f427f5e6c26401cc6113d77e372c3fdac73864", size = 385098 }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/37/a46d4741a88f7223ef3ec68490e638fb93570127f28fd76cbc2c89c0a7ec/pydantic_core-2.18.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6f5c4d41b2771c730ea1c34e458e781b18cc668d194958e0112455fff4e402b2", size = 1846298 },
-    { url = "https://files.pythonhosted.org/packages/e9/93/46f546b40aba72683032c167aef9ccd568a54e28f28687081d10a6735294/pydantic_core-2.18.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2fdf2156aa3d017fddf8aea5adfba9f777db1d6022d392b682d2a8329e087cef", size = 1766852 },
-    { url = "https://files.pythonhosted.org/packages/e5/84/864556db336393f2433eda50b7e047a8d485b95dd48d1d277750ce0042bf/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4748321b5078216070b151d5271ef3e7cc905ab170bbfd27d5c83ee3ec436695", size = 1786599 },
-    { url = "https://files.pythonhosted.org/packages/79/7b/a4f002cf3603672de868ae913dec7d561509bcd17401f4cc719ab8a46213/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847a35c4d58721c5dc3dba599878ebbdfd96784f3fb8bb2c356e123bdcd73f34", size = 1769558 },
-    { url = "https://files.pythonhosted.org/packages/bc/36/c3e7665d84f692b095d11e9f4af71bfc339471b7153d22a7526584b75b92/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c40d4eaad41f78e3bbda31b89edc46a3f3dc6e171bf0ecf097ff7a0ffff7cb1", size = 1976988 },
-    { url = "https://files.pythonhosted.org/packages/c8/91/4bbb89ef7aade8095bbb26055c16d8026a3bbe97f6ad9a827f8265c00350/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:21a5e440dbe315ab9825fcd459b8814bb92b27c974cbc23c3e8baa2b76890077", size = 2792471 },
-    { url = "https://files.pythonhosted.org/packages/d8/36/5676d758ccb008de9ae48db1614ffaa381e1971677e4a7e365cb7004e61c/pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01dd777215e2aa86dfd664daed5957704b769e726626393438f9c87690ce78c3", size = 2082097 },
-    { url = "https://files.pythonhosted.org/packages/a0/d7/05be10426e0a338a84dc2699c143d8d1a3ad2a79aefe0dd0ce17a7dea81d/pydantic_core-2.18.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4b06beb3b3f1479d32befd1f3079cc47b34fa2da62457cdf6c963393340b56e9", size = 1902982 },
-    { url = "https://files.pythonhosted.org/packages/73/c8/784718a31831eda4446ba3d5c9d9a259a10d01f71f9684300f1bbac65d2f/pydantic_core-2.18.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:564d7922e4b13a16b98772441879fcdcbe82ff50daa622d681dd682175ea918c", size = 2001850 },
-    { url = "https://files.pythonhosted.org/packages/83/f8/9d59e352b3d168984b2e67e347365afe9698f08b2167e9582a03abf4f961/pydantic_core-2.18.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0eb2a4f660fcd8e2b1c90ad566db2b98d7f3f4717c64fe0a83e0adb39766d5b8", size = 2115674 },
-    { url = "https://files.pythonhosted.org/packages/0f/98/fb23c03b5b96a4e6196d24ebc05026dbcd3ec05e9b0c85ae34a3c40f6d58/pydantic_core-2.18.4-cp312-none-win32.whl", hash = "sha256:8b8bab4c97248095ae0c4455b5a1cd1cdd96e4e4769306ab19dda135ea4cdb07", size = 1721997 },
-    { url = "https://files.pythonhosted.org/packages/d9/c9/85bbe091e0f0f5a99f38cda2774b810ac593fd36dae2f9d777e215d2fa6b/pydantic_core-2.18.4-cp312-none-win_amd64.whl", hash = "sha256:14601cdb733d741b8958224030e2bfe21a4a881fb3dd6fbb21f071cabd48fa0a", size = 1905580 },
-    { url = "https://files.pythonhosted.org/packages/35/ea/fba944f8e29860a3e1d535223427a657e7b29118e114188b3e2fda02c69e/pydantic_core-2.18.4-cp312-none-win_arm64.whl", hash = "sha256:c1322d7dd74713dcc157a2b7898a564ab091ca6c58302d5c7b4c07296e3fd00f", size = 1781973 },
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000 },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996 },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957 },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199 },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296 },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109 },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028 },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044 },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881 },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034 },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187 },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628 },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866 },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894 },
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688 },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808 },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580 },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859 },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810 },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498 },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611 },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924 },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196 },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389 },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223 },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473 },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269 },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921 },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162 },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560 },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777 },
 ]
 
 [[package]]
@@ -4386,6 +4405,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates the evaluation to expose separate tasks for each pipeline and output more complete recommendation data.

- Take pipeline name as an input to the evaluation scripts, so we can run one pipeline without rerunning all (making it much less expensive to compare a new pipeline against the ones already in the repository).
- Write full recommendation output to `recommendations.ndjson.zst` so we can get articles, headlines, etc.
- Abstract recommendation data extraction and writing, producing each output in a separate actor (so output is concurrent with inference). Tabular Parquet, JSON, and embedding collection are all just "recommendation writers".
- Use Ray tasks instead of actors for generating recommendations, simplifying parallelism configuration.