### PR TITLE
Tell `distilbert` to run in eval mode when computing token embeddings

### DIFF
--- a/src/poprox_recommender/model/nrms/news_encoder.py
+++ b/src/poprox_recommender/model/nrms/news_encoder.py
@@ -12,6 +12,7 @@ class NewsEncoder(torch.nn.Module):
         self.plm_config = AutoConfig.from_pretrained(model_path, cache_dir="/tmp/")
         self.plm = AutoModel.from_config(self.plm_config)
         self.plm.requires_grad_(False)
+        self.plm.eval()
 
         self.multihead_attention = nn.MultiheadAttention(
             embed_dim=self.plm_config.hidden_size,


### PR DESCRIPTION
This prevents drop-out from being applied, which is important for training but counter-productive for serving. Before this change, the produced token embeddings were non-deterministic due to drop-out, which was filtering through our whole recommender and producing non-deterministic recs.