### PR TITLE
Create a new recommender that adds exploration to `nrms_topic_scores`

### DIFF
--- a/src/poprox_recommender/components/filters/topic.py
+++ b/src/poprox_recommender/components/filters/topic.py
@@ -10,28 +10,47 @@ logger = logging.getLogger(__name__)
 class TopicFilter(Component):
     config: None
 
-    def __call__(self, candidate: CandidateSet, interest_profile: InterestProfile) -> CandidateSet:
+    def __call__(self, candidates: CandidateSet, interest_profile: InterestProfile) -> CandidateSet:
         # Preference values from onboarding are 1-indexed, where 1 means "absolutely no interest."
         # We might want to normalize them to 0-indexed somewhere upstream, but in the mean time
         # this is one of the simpler ways to filter out topics people aren't interested in from
         # their early newsletters
-        profile_topics = {
-            interest.entity_name for interest in interest_profile.onboarding_topics if interest.preference > 1
-        }
+        interests = {interest.entity_name: interest.preference for interest in interest_profile.onboarding_topics}
 
-        if len(profile_topics) == 0:
-            return candidate
+        very_high = {key for key, value in interests.items() if value == 5}
+        high = {key for key, value in interests.items() if value == 4}
+        low = {key for key, value in interests.items() if value == 2}
+        very_low = {key for key, value in interests.items() if value == 1}
 
         topical_articles = []
-        for article in candidate.articles:
+        for article in candidates.articles:
             article_topics = {mention.entity.name for mention in article.mentions}
-            if len(profile_topics.intersection(article_topics)) > 0:
+
+            # Articles with very high interest topics are included in the candidate set
+            if overlap(article_topics, very_high):
                 topical_articles.append(article)
+                continue
+
+            # Remaining articles with a very low interest are excluded from the candidate set
+            if overlap(article_topics, very_low):
+                continue
+
+            # In the middle, exclude articles with more low than high interest topics
+            if overlap(article_topics, high) < overlap(article_topics, low):
+                continue
+
+            # If none of the above apply, default to including the article
+            topical_articles.append(article)
 
         logger.debug(
-            "filter accepted %d of %d articles for user %s",
+            "topic filter accepted %d of %d articles for user %s",
             len(topical_articles),
-            len(candidate.articles),
+            len(candidates.articles),
             interest_profile.profile_id,
         )
+
         return CandidateSet(articles=topical_articles)
+
+
+def overlap(a: set, b: set):
+    return len(a.intersection(b))

--- a/src/poprox_recommender/components/samplers/epsilon_greedy.py
+++ b/src/poprox_recommender/components/samplers/epsilon_greedy.py
@@ -1,0 +1,37 @@
+import logging
+import random
+
+from lenskit.pipeline import Component
+from pydantic import BaseModel
+
+from poprox_concepts import CandidateSet
+from poprox_concepts.domain import RecommendationList
+
+logger = logging.getLogger(__name__)
+
+
+class EpsilonGreedyConfig(BaseModel):
+    num_slots: int = 10
+    epsilon: float = 0.1
+
+
+class EpsilonGreedy(Component):
+    config: EpsilonGreedyConfig
+
+    def __call__(self, ranked: RecommendationList, candidates: CandidateSet) -> RecommendationList:
+        selected_articles = []
+        ranked_idx = 0
+        candidate_idx = 0
+
+        # Shuffle the candidates so taking the first one amounts to sampling uniformly at random
+        candidates.articles = random.sample(candidates.articles, len(candidates.articles))
+
+        for slot_idx in range(self.config.num_slots):
+            if random.random() < self.config.epsilon:
+                selected_articles.append(candidates.articles[candidate_idx])
+                candidate_idx += 1
+            else:
+                selected_articles.append(ranked.articles[ranked_idx])
+                ranked_idx += 1
+
+        return RecommendationList(articles=selected_articles)

--- a/src/poprox_recommender/recommenders/configurations/mmr.py
+++ b/src/poprox_recommender/recommenders/configurations/mmr.py
@@ -51,7 +51,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/src/poprox_recommender/recommenders/configurations/nrms.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms.py
@@ -46,7 +46,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_images.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_images.py
@@ -45,7 +45,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_topic_exploration.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_topic_exploration.py
@@ -1,0 +1,80 @@
+# pyright: basic
+
+from lenskit.pipeline import PipelineBuilder
+
+from poprox_concepts import CandidateSet, InterestProfile
+from poprox_recommender.components.embedders import NRMSArticleEmbedder
+from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
+from poprox_recommender.components.embedders.topic_wise_user import UserOnboardingConfig, UserOnboardingEmbedder
+from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.filters.topic import TopicFilter
+from poprox_recommender.components.joiners.score import ScoreFusion
+from poprox_recommender.components.rankers.topk import TopkRanker
+from poprox_recommender.components.samplers.epsilon_greedy import EpsilonGreedy
+from poprox_recommender.components.scorers.article import ArticleScorer
+from poprox_recommender.paths import model_file_path
+
+
+def configure(builder: PipelineBuilder, num_slots: int, device: str):
+    # standard practice is to put these calls in this order, to reuse logic
+    # Define pipeline inputs
+    i_candidates = builder.create_input("candidate", CandidateSet)
+    i_clicked = builder.create_input("clicked", CandidateSet)
+    i_profile = builder.create_input("profile", InterestProfile)
+
+    # Filter articles based on topic preferences
+    f_candidates = builder.add_component(
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
+    )
+
+    # Embed candidate and clicked articles
+    ae_config = NRMSArticleEmbedderConfig(
+        model_path=model_file_path("nrms-mind/news_encoder.safetensors"), device=device
+    )
+    e_candidates = builder.add_component("candidate-embedder", NRMSArticleEmbedder, ae_config, article_set=f_candidates)
+    e_clicked = builder.add_component(
+        "history-NRMSArticleEmbedder", NRMSArticleEmbedder, ae_config, article_set=i_clicked
+    )
+
+    # Embed the user (historical clicks)
+    ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
+    e_user = builder.add_component(
+        "user-embedder",
+        NRMSUserEmbedder,
+        ue_config,
+        candidate_articles=e_candidates,
+        clicked_articles=e_clicked,
+        interest_profile=i_profile,
+    )
+
+    # Embed the user (topics)
+    ue_config2 = UserOnboardingConfig(
+        model_path=model_file_path("nrms-mind/user_encoder.safetensors"),
+        device=device,
+        embedding_source="static",
+        topic_embedding="nrms",
+    )
+    e_user2 = builder.add_component(
+        "user-embedder2",
+        UserOnboardingEmbedder,
+        ue_config2,
+        candidate_articles=e_candidates,
+        clicked_articles=e_clicked,
+        interest_profile=i_profile,
+    )
+
+    # Score and rank articles (history)
+    n_scorer = builder.add_component("scorer", ArticleScorer, candidate_articles=e_candidates, interest_profile=e_user)
+
+    # Score and rank articles (topics)
+    n_scorer2 = builder.add_component(
+        "scorer2", ArticleScorer, candidate_articles=builder.node("candidate-embedder"), interest_profile=e_user2
+    )
+
+    # Combine click and topic scoring
+    s_fusion = builder.add_component(
+        "fusion", ScoreFusion, {"combiner": "avg"}, candidates1=n_scorer, candidates2=n_scorer2
+    )
+
+    r_topk = builder.add_component("ranker", TopkRanker, {"num_slots": num_slots}, candidate_articles=s_fusion)
+    builder.add_component("recommender", EpsilonGreedy, ranked=r_topk, candidates=f_candidates)

--- a/src/poprox_recommender/recommenders/configurations/nrms_topics_static.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_topics_static.py
@@ -52,7 +52,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/src/poprox_recommender/recommenders/configurations/pfar.py
+++ b/src/poprox_recommender/recommenders/configurations/pfar.py
@@ -54,7 +54,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/src/poprox_recommender/recommenders/configurations/softmax.py
+++ b/src/poprox_recommender/recommenders/configurations/softmax.py
@@ -55,7 +55,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/src/poprox_recommender/recommenders/configurations/topic_cali.py
+++ b/src/poprox_recommender/recommenders/configurations/topic_cali.py
@@ -51,7 +51,7 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
 
     # Fallback: sample from user topic interests
     n_topic_filter = builder.add_component(
-        "topic-filter", TopicFilter, candidate=i_candidates, interest_profile=i_profile
+        "topic-filter", TopicFilter, candidates=i_candidates, interest_profile=i_profile
     )
     n_sampler = builder.add_component("sampler", UniformSampler, candidates1=n_topic_filter, candidates2=i_candidates)
 

--- a/tests/components/test_joiners.py
+++ b/tests/components/test_joiners.py
@@ -15,7 +15,7 @@ def init_builder(total_slots):
     builder = PipelineBuilder(name="random_concat")
     in_cand = builder.create_input("candidate", CandidateSet)
     in_prof = builder.create_input("profile", InterestProfile)
-    tf = builder.add_component("topic-filter", topic_filter, candidate=in_cand, interest_profile=in_prof)
+    tf = builder.add_component("topic-filter", topic_filter, candidates=in_cand, interest_profile=in_prof)
     builder.add_component("sampler", sampler, candidates1=tf, candidates2=in_cand)
 
     return builder

--- a/tests/components/test_topic_filter.py
+++ b/tests/components/test_topic_filter.py
@@ -50,7 +50,7 @@ def test_select_by_topic_filters_articles():
     builder = PipelineBuilder()
     i_profile = builder.create_input("profile", InterestProfile)
     i_cand = builder.create_input("candidates", CandidateSet)
-    c_filter = builder.add_component("topic-filter", topic_filter, candidate=i_cand, interest_profile=i_profile)
+    c_filter = builder.add_component("topic-filter", topic_filter, candidates=i_cand, interest_profile=i_profile)
     c_sampler = builder.add_component("sampler", sampler, candidates1=c_filter, candidates2=i_cand)
     pipeline = builder.build()
 

--- a/tests/components/test_topic_filter.py
+++ b/tests/components/test_topic_filter.py
@@ -12,8 +12,9 @@ def test_select_by_topic_filters_articles():
     profile = InterestProfile(
         click_history=[],
         onboarding_topics=[
-            AccountInterest(entity_id=uuid4(), entity_name="U.S. News", preference=2, frequency=1),
-            AccountInterest(entity_id=uuid4(), entity_name="Politics", preference=3, frequency=2),
+            AccountInterest(entity_id=uuid4(), entity_name="U.S. News", preference=4, frequency=1),
+            AccountInterest(entity_id=uuid4(), entity_name="Politics", preference=5, frequency=2),
+            AccountInterest(entity_id=uuid4(), entity_name="Entertainment", preference=1, frequency=1),
         ],
     )
 


### PR DESCRIPTION
This does three things:
* Updates the `TopicFilter` logic to be smarter about how it uses topic prefs to include/exclude articles
* Creates an `EpsilonGreedy` sampler that selects a random article from a candidate pool for 10% of the slots in the newsletter
* Adds both of those to a new recommender based on `nrms_topic_scores` so that 10% of the articles in the newsletter are chosen at random from the filtered candidate pool