### PR TITLE
Correctly resolve model path for news encoder

### DIFF
--- a/src/poprox_recommender/model/nrms/news_encoder.py
+++ b/src/poprox_recommender/model/nrms/news_encoder.py
@@ -2,13 +2,16 @@ import torch
 from torch import nn
 from transformers import AutoConfig, AutoModel
 
+from poprox_recommender.paths import model_file_path
+
 from ..general.attention.additive import AdditiveAttention
 
 
 class NewsEncoder(torch.nn.Module):
-    def __init__(self, model_path, num_attention_heads, additive_attn_hidden_dim):
+    def __init__(self, model_name, num_attention_heads, additive_attn_hidden_dim):
         super(NewsEncoder, self).__init__()
 
+        model_path = model_file_path(model_name)
         self.plm_config = AutoConfig.from_pretrained(model_path, cache_dir="/tmp/")
         self.plm = AutoModel.from_config(self.plm_config)
         self.plm.requires_grad_(False)

--- a/tests/model/nrms/test_attention_padding.py
+++ b/tests/model/nrms/test_attention_padding.py
@@ -14,7 +14,7 @@ def test_masked_padding_with_real_model():
         checkpoint = load_file(model_file_path("nrms-mind/news_encoder.safetensors"))
         model_cfg = ModelConfig()
         news_encoder = NewsEncoder(
-            model_file_path("distilbert-base-uncased/"),
+            "distilbert-base-uncased",
             model_cfg.num_attention_heads,
             model_cfg.additive_attn_hidden_dim,
         )


### PR DESCRIPTION
This might fix Aishwarya's other problem. I think the old code was re-fetching pretrained models from HuggingFace and we didn't realize it.