### PR TITLE
Use the names of topics in their embedded topic descriptions

### DIFF
--- a/src/poprox_recommender/components/embedders/user_topic_prefs.py
+++ b/src/poprox_recommender/components/embedders/user_topic_prefs.py
@@ -87,7 +87,7 @@ TOPIC_DESCRIPTIONS = {
 TOPIC_ARTICLES = [
     Article(
         article_id=uuid4(),
-        headline=description,
+        headline=f"{topic}: {description}",
         subhead=None,
         url=None,
         preview_image_id=None,


### PR DESCRIPTION
This might improve how well the definitions align with articles about those topics, which could help us get better support for user topic preferences. I'm not sure this will work, but it seems safe to try.