### PR TITLE
nrms_topic_scorer with topical feature in the article embedding

### DIFF
--- a/scripts/local_req.py
+++ b/scripts/local_req.py
@@ -24,9 +24,9 @@ if __name__ == "__main__":
         "queryStringParameters": {"pipeline": "nrms_topic_scores"},
         "isBase64Encoded": False,
     }
-    event_feedback_score = {
+    event_topic_score_ate = {
         "body": raw_json,
-        "queryStringParameters": {"pipeline": "nrms_article_feedback"},
+        "queryStringParameters": {"pipeline": "nrms_topic_scores_ate"},
         "isBase64Encoded": False,
     }
 
@@ -36,8 +36,8 @@ if __name__ == "__main__":
     response_topic_score = root(req.model_dump(), pipeline="nrms_topic_scores")
     response_topic_score = RecommendationResponseV2.model_validate(response_topic_score)
 
-    response_feedback_score = root(req.model_dump(), pipeline="nrms_article_feedback")
-    response_feedback_score = RecommendationResponseV2.model_validate(response_feedback_score)
+    response_topic_scores_ate = root(req.model_dump(), pipeline="nrms_topic_scores_ate")
+    response_topic_scores_ate = RecommendationResponseV2.model_validate(response_topic_scores_ate)
 
     print("\n")
     print(f"{event_nrms['queryStringParameters']['pipeline']}")
@@ -54,8 +54,8 @@ if __name__ == "__main__":
         print(f"{idx + 1}. {article.headline} {article_topics}")
 
     print("\n")
-    print(f"{event_feedback_score['queryStringParameters']['pipeline']}")
+    print(f"{event_topic_score_ate['queryStringParameters']['pipeline']}")
 
-    for idx, article in enumerate(response_feedback_score.recommendations.articles):
+    for idx, article in enumerate(response_topic_scores_ate.recommendations.articles):
         article_topics = extract_general_topics(article)
         print(f"{idx + 1}. {article.headline} {article_topics}")

--- a/src/poprox_recommender/components/embedders/topic_included_article.py
+++ b/src/poprox_recommender/components/embedders/topic_included_article.py
@@ -1,0 +1,84 @@
+# pyright: basic
+from dataclasses import dataclass
+
+import torch as th
+import torch.nn.functional as F
+
+from poprox_concepts import CandidateSet
+from poprox_recommender.components.embedders import NRMSArticleEmbedder, NRMSArticleEmbedderConfig
+from poprox_recommender.components.embedders.user_topic_prefs import TOPIC_DESCRIPTIONS
+from poprox_recommender.pytorch.decorators import torch_inference
+
+TITLE_LENGTH_LIMIT = 30
+MAX_ATTRIBUTES = 15
+
+
+def find_topical_text(topic_descriptions, article):
+    unique_mention = {mention.entity.name for mention in article.mentions}
+    topical_texts = []
+    for mention in unique_mention:
+        if mention in topic_descriptions:
+            topical_texts.append(topic_descriptions[mention])
+    return topical_texts
+
+
+@dataclass
+class NRMSArticleTopicEmbedder(NRMSArticleEmbedder):
+    config: NRMSArticleEmbedderConfig
+
+    def __init__(self, config: NRMSArticleEmbedderConfig | None = None, **kwargs):
+        super().__init__(config, **kwargs)
+
+    @torch_inference
+    def __call__(self, article_set: CandidateSet) -> CandidateSet:
+        if not article_set.articles:
+            article_set.embeddings = th.zeros((0, self.news_encoder.embedding_size))  # type: ignore
+            return article_set
+
+        all_article_embeddings = []
+
+        for article in article_set.articles:
+            attribute_text = [article.headline]
+
+            # this part is for topical embedddings, remove this for topicless embeddings
+            topical_text = find_topical_text(TOPIC_DESCRIPTIONS, article)
+            num_topic = len(topical_text)
+            attribute_text.extend(topical_text)
+
+            while len(attribute_text) < MAX_ATTRIBUTES:
+                attribute_text.append("")
+            # this part is for topical embedddings, remove this for topicless embeddings
+
+            attribute_tensors = th.stack(
+                [
+                    th.tensor(
+                        self.tokenizer.encode(
+                            text, padding="max_length", max_length=TITLE_LENGTH_LIMIT, truncation=True
+                        ),
+                        dtype=th.int32,
+                    ).to(self.config.device)
+                    for text in attribute_text
+                ]
+            )
+
+            attribute_embeddings = self.news_encoder(attribute_tensors)
+
+            attribute_embeddings = F.normalize(attribute_embeddings, dim=1)
+
+            headline_embedding = attribute_embeddings[0]
+
+            if num_topic > 0:
+                topic_embeddings = attribute_embeddings[1 : num_topic + 1]
+                topic_embedding = topic_embeddings.mean(dim=0)
+                final_embedding = 0.5 * headline_embedding + 0.5 * topic_embedding
+            else:
+                final_embedding = headline_embedding
+
+            all_article_embeddings.append(final_embedding)
+
+        embed_tensor = th.stack(all_article_embeddings)
+
+        article_set.embeddings = embed_tensor  # type: ignore
+
+        # breakpoint()
+        return article_set

--- a/src/poprox_recommender/components/embedders/user_topic_prefs.py
+++ b/src/poprox_recommender/components/embedders/user_topic_prefs.py
@@ -87,7 +87,7 @@ TOPIC_DESCRIPTIONS = {
 TOPIC_ARTICLES = [
     Article(
         article_id=uuid4(),
-        headline=description,
+        headline=f"{topic}: {description}",
         subhead=None,
         url=None,
         preview_image_id=None,

--- a/src/poprox_recommender/recommenders/configurations/nrms_topic_scores_ate.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_topic_scores_ate.py
@@ -1,0 +1,114 @@
+# pyright: basic
+
+from lenskit.pipeline import PipelineBuilder
+
+from poprox_concepts import CandidateSet, InterestProfile
+from poprox_recommender.components.embedders import NRMSArticleEmbedder
+from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
+from poprox_recommender.components.embedders.topic_included_article import NRMSArticleTopicEmbedder
+from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user_topic_prefs import UserOnboardingConfig, UserOnboardingEmbedder
+from poprox_recommender.components.joiners.score import ScoreFusion
+from poprox_recommender.components.rankers.topk import TopkRanker
+from poprox_recommender.components.scorers.article import ArticleScorer
+from poprox_recommender.paths import model_file_path
+
+##TODO:
+# allow weigths for the scores (1/-1)
+
+
+def configure(builder: PipelineBuilder, num_slots: int, device: str):
+    # standard practice is to put these calls in this order, to reuse logic
+    # Define pipeline inputs
+    i_candidates = builder.create_input("candidate", CandidateSet)
+    i_clicked = builder.create_input("clicked", CandidateSet)
+    i_profile = builder.create_input("profile", InterestProfile)
+
+    # Embed candidate and clicked articles
+    ae_config = NRMSArticleEmbedderConfig(
+        model_path=model_file_path("nrms-mind/news_encoder.safetensors"), device=device
+    )
+    e_candidates = builder.add_component(
+        "candidate-embedder", NRMSArticleTopicEmbedder, ae_config, article_set=i_candidates
+    )
+    e_clicked = builder.add_component(
+        "history-NRMSArticleEmbedder", NRMSArticleEmbedder, ae_config, article_set=i_clicked
+    )
+
+    # Embed the user (historical clicks)
+    ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
+    e_user = builder.add_component(
+        "user-embedder",
+        NRMSUserEmbedder,
+        ue_config,
+        candidate_articles=e_candidates,
+        clicked_articles=e_clicked,
+        interest_profile=i_profile,
+    )
+
+    # Embed the user (topics)
+    ue_config2 = UserOnboardingConfig(
+        model_path=model_file_path("nrms-mind/user_encoder.safetensors"),
+        device=device,
+        embedding_source="static",
+        topic_embedding="nrms",
+        topic_pref_values=[4, 5],
+    )
+    e_user_positive = builder.add_component(
+        "pos-topic-embedder",
+        UserOnboardingEmbedder,
+        ue_config2,
+        candidate_articles=e_candidates,
+        clicked_articles=e_clicked,
+        interest_profile=i_profile,
+    )
+
+    # Embed the user2 (topics)
+    ue_config3 = UserOnboardingConfig(
+        model_path=model_file_path("nrms-mind/user_encoder.safetensors"),
+        device=device,
+        embedding_source="static",
+        topic_embedding="nrms",
+        topic_pref_values=[1, 2],
+    )
+    e_user_negative = builder.add_component(
+        "neg-topic-embedder",
+        UserOnboardingEmbedder,
+        ue_config3,
+        candidate_articles=e_candidates,
+        clicked_articles=e_clicked,
+        interest_profile=i_profile,
+    )
+
+    # Score and rank articles (history)
+    n_scorer = builder.add_component("scorer", ArticleScorer, candidate_articles=e_candidates, interest_profile=e_user)
+
+    # Score and rank articles (topics)
+    positive_topic_score = builder.add_component(
+        "positive_topic_score",
+        ArticleScorer,
+        candidate_articles=builder.node("candidate-embedder"),
+        interest_profile=e_user_positive,
+    )
+
+    negative_topic_score = builder.add_component(
+        "negative_topic_score",
+        ArticleScorer,
+        candidate_articles=builder.node("candidate-embedder"),
+        interest_profile=e_user_negative,
+    )
+
+    topic_fusion = builder.add_component(
+        "topic_fusion",
+        ScoreFusion,
+        {"combiner": "sub"},
+        candidates1=positive_topic_score,
+        candidates2=negative_topic_score,
+    )
+
+    # Combine click and topic scoring
+    fusion = builder.add_component(
+        "fusion", ScoreFusion, {"combiner": "avg"}, candidates1=n_scorer, candidates2=topic_fusion
+    )
+
+    builder.add_component("recommender", TopkRanker, {"num_slots": num_slots}, candidate_articles=fusion)

--- a/tests/request_data/onboarding.json
+++ b/tests/request_data/onboarding.json
@@ -27,7 +27,7 @@
       {
         "entity_id": "c74a986e-3bd9-4be0-b8c1-bd95e376d064",
         "entity_name": "Education",
-        "preference": 3
+        "preference": 1
       },
       {
         "entity_id": "e531cbd0-d967-4d87-ad13-3649fc00ffb4",
@@ -37,7 +37,7 @@
       {
         "entity_id": "16323227-4b42-4363-b67c-fd2be57c9aa1",
         "entity_name": "Oddities",
-        "preference": 3
+        "preference": 1
       },
       {
         "entity_id": "b822877a-c1e2-44a9-8d6c-4610d8047a9a",
@@ -52,7 +52,7 @@
       {
         "entity_id": "b2bb4e26-6684-4cbd-9fd8-fa98ae87ca57",
         "entity_name": "Religion",
-        "preference": 3
+        "preference": 1
       },
       {
         "entity_id": "f984b26b-4333-42b3-a463-bc232bf95d5f",
@@ -62,7 +62,7 @@
       {
         "entity_id": "66ba9689-3ad7-4626-9d20-03930d88e302",
         "entity_name": "U.S. news",
-        "preference": 5
+        "preference": 1
       },
       {
         "entity_id": "1e813fd6-0998-43fb-9839-75fa96b69b32",
@@ -77,7 +77,7 @@
       {
         "entity_id": "ec489f76-18c6-4f78-b53b-fda5849a1056",
         "entity_name": "Politics",
-        "preference": 3
+        "preference": 1
       },
       {
         "entity_id": "606afcb8-3fc1-47a7-9da7-3d95115373a3",
@@ -87,12 +87,12 @@
       {
         "entity_id": "4554dcf2-6472-43a3-bfd6-e904a2936315",
         "entity_name": "Entertainment",
-        "preference": 3
+        "preference": 1
       },
       {
         "entity_id": "45770171-36d1-4568-a270-bf80d6fe18e7",
         "entity_name": "World news",
-        "preference": 3
+        "preference": 5
       }
     ]
   },


### PR DESCRIPTION
As the very first attempt, topical embedding is computed by averaging the embeddings of matched topic descriptions (if any) and then combined equally (50–50 weighted average) with the article's headline embedding to form the final article embedding (which we tried with baseline NRMS)