### PR TITLE
refactoring the user embedder into single and multi vector

### DIFF
--- a/src/poprox_recommender/recommenders/configurations/nrms.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms.py
@@ -3,9 +3,9 @@
 from lenskit.pipeline import PipelineBuilder
 
 from poprox_concepts import CandidateSet, InterestProfile
-from poprox_recommender.components.embedders import NRMSArticleEmbedder, NRMSUserEmbedder
+from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.filters.topic import TopicFilter
 from poprox_recommender.components.joiners.fill import FillRecs
 from poprox_recommender.components.rankers.topk import TopkRanker
@@ -33,10 +33,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_article_feedback.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_article_feedback.py
@@ -3,7 +3,7 @@ from lenskit.pipeline import PipelineBuilder
 from poprox_concepts import CandidateSet, InterestProfile
 from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.embedders.user_article_feedback import (
     UserArticleFeedbackConfig,
     UserArticleFeedbackEmbedder,
@@ -35,10 +35,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_feedback_filter.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_feedback_filter.py
@@ -3,7 +3,7 @@ from lenskit.pipeline import PipelineBuilder
 from poprox_concepts import CandidateSet, InterestProfile
 from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.embedders.user_article_feedback import (
     UserArticleFeedbackConfig,
     UserArticleFeedbackEmbedder,
@@ -41,10 +41,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_feedback_filter_exp.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_feedback_filter_exp.py
@@ -3,7 +3,7 @@ from lenskit.pipeline import PipelineBuilder
 from poprox_concepts import CandidateSet, InterestProfile
 from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.embedders.user_article_feedback import (
     UserArticleFeedbackConfig,
     UserArticleFeedbackEmbedder,
@@ -42,10 +42,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_rrf_static_user.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_rrf_static_user.py
@@ -5,7 +5,7 @@ from lenskit.pipeline import PipelineBuilder
 from poprox_concepts import CandidateSet, InterestProfile
 from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.embedders.user_topic_prefs import UserOnboardingConfig, UserOnboardingEmbedder
 from poprox_recommender.components.joiners.rrf import ReciprocalRankFusion
 from poprox_recommender.components.rankers.topk import TopkRanker
@@ -33,10 +33,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_topic_exploration.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_topic_exploration.py
@@ -5,7 +5,7 @@ from lenskit.pipeline import PipelineBuilder
 from poprox_concepts import CandidateSet, InterestProfile
 from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.embedders.user_topic_prefs import UserOnboardingConfig, UserOnboardingEmbedder
 from poprox_recommender.components.filters.topic import TopicFilter
 from poprox_recommender.components.joiners.score import ScoreFusion
@@ -40,10 +40,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/nrms_topic_scores.py
+++ b/src/poprox_recommender/recommenders/configurations/nrms_topic_scores.py
@@ -5,7 +5,7 @@ from lenskit.pipeline import PipelineBuilder
 from poprox_concepts import CandidateSet, InterestProfile
 from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedder, NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.embedders.user_topic_prefs import UserOnboardingConfig, UserOnboardingEmbedder
 from poprox_recommender.components.joiners.score import ScoreFusion
 from poprox_recommender.components.rankers.topk import TopkRanker
@@ -36,10 +36,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/src/poprox_recommender/recommenders/configurations/softmax.py
+++ b/src/poprox_recommender/recommenders/configurations/softmax.py
@@ -3,9 +3,9 @@
 from lenskit.pipeline import PipelineBuilder
 
 from poprox_concepts import CandidateSet, InterestProfile
-from poprox_recommender.components.embedders import NRMSArticleEmbedder, NRMSUserEmbedder
+from poprox_recommender.components.embedders import NRMSArticleEmbedder
 from poprox_recommender.components.embedders.article import NRMSArticleEmbedderConfig
-from poprox_recommender.components.embedders.user import NRMSUserEmbedderConfig
+from poprox_recommender.components.embedders.user import NRMSSingleVectorUserEmbedder, NRMSUserEmbedderConfig
 from poprox_recommender.components.filters.topic import TopicFilter
 from poprox_recommender.components.joiners.fill import FillRecs
 from poprox_recommender.components.rankers.topk import TopkRanker
@@ -35,10 +35,10 @@ def configure(builder: PipelineBuilder, num_slots: int, device: str):
     ue_config = NRMSUserEmbedderConfig(model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device=device)
     e_user = builder.add_component(
         "user-embedder",
-        NRMSUserEmbedder,
+        NRMSSingleVectorUserEmbedder,
         ue_config,
         candidate_articles=e_candidates,
-        clicked_articles=e_clicked,
+        interacted_articles=e_clicked,
         interest_profile=i_profile,
     )
 

--- a/tests/components/test_onboarding_embedder.py
+++ b/tests/components/test_onboarding_embedder.py
@@ -7,14 +7,14 @@ import pytest
 import torch as th
 
 from poprox_concepts.domain import AccountInterest, Article, CandidateSet, Click, InterestProfile
-from poprox_recommender.components.embedders import NRMSUserEmbedder
+from poprox_recommender.components.embedders import NRMSSingleVectorUserEmbedder
 from poprox_recommender.components.embedders.user_topic_prefs import TOPIC_ARTICLES, UserOnboardingEmbedder
 from poprox_recommender.paths import model_file_path
 
 
 def test_embed_user():
     try:
-        plain_nrms_embedder = NRMSUserEmbedder(
+        plain_nrms_embedder = NRMSSingleVectorUserEmbedder(
             model_path=model_file_path("nrms-mind/user_encoder.safetensors"), device="cpu"
         )
         topic_aware_embedder = UserOnboardingEmbedder(


### PR DESCRIPTION
FM style NRMS requires multiple vector user ember which is almost similar to the NRMS user embedder except for the last additive layer which leads to single vector user embedder and multi vector user embedder.