### PR TITLE
Benchmark request serialization methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
   "requests >=2.31,<3",
   "coverage >=6.5",
   "pytest >=8",
+  "pytest-benchmark >=5",
   "scikit-learn>=1.3,<2",
 ]
 eval = [
@@ -166,3 +167,6 @@ tests = ["tests"]
 
 [tool.coverage.report]
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
+
+[tool.pytest.ini_options]
+addopts = "--benchmark-skip"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,119 @@
+"""
+Tests to benchmark and measure serialization methods.
+
+Based on Karl's WIP at https://github.com/CCRI-POPROX/poprox-platform/pull/454.
+"""
+
+import gzip
+from pathlib import Path
+
+import numpy as np
+import orjson
+import zstandard
+from humanize import naturalsize
+from pytest import fixture, mark
+from rich.console import Console
+from rich.table import Table
+
+from poprox_concepts.api.recommendations import RecommendationRequestV2
+
+data_dir = Path(__file__).resolve().parent / "request_data"
+req_file = data_dir / "request_body.json"
+
+
+@fixture
+def basic_request():
+    text = req_file.read_text()
+    yield RecommendationRequestV2.model_validate_json(text)
+
+
+@fixture
+def enhanced_request(basic_request: RecommendationRequestV2):
+    req_body = basic_request.model_dump()
+    embeddings = {}
+
+    # Article embeddings
+    for article in basic_request.candidates.articles:
+        embeddings[article.article_id] = {
+            "headline": np.random.randn(768),
+            "subhead": np.random.randn(768),
+            "body": np.random.randn(768),
+        }
+
+    # Image embeddings
+    for article in basic_request.candidates.articles:
+        for image in article.images or []:
+            embeddings[image.image_id] = np.random.randn(1024)
+
+    req_body["embeddings"] = embeddings
+
+    yield req_body
+
+
+@mark.benchmark(group="basic")
+def test_pydantic_basic(basic_request, benchmark):
+    def serialize():
+        _serialized_req = basic_request.model_dump_json()
+
+    benchmark(serialize)
+
+
+@mark.benchmark(group="basic")
+def test_orjson_basic(basic_request, benchmark):
+    def serialize():
+        br = basic_request.model_dump()
+        _serialized_req = orjson.dumps(br, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS)
+
+    benchmark(serialize)
+
+
+@mark.benchmark(group="basic")
+def test_orjson(enhanced_request, benchmark):
+    def serialize():
+        _serialized_req = orjson.dumps(enhanced_request, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS)
+
+    benchmark(serialize)
+
+
+@mark.benchmark(group="basic")
+def test_orjson_gzip(enhanced_request, benchmark):
+    def serialize():
+        serialized_req = orjson.dumps(enhanced_request, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS)
+        _gizpped_req = gzip.compress(serialized_req)
+
+    benchmark(serialize)
+
+
+@mark.benchmark(group="basic")
+def test_orjson_zstd(enhanced_request, benchmark):
+    def serialize():
+        serialized_req = orjson.dumps(enhanced_request, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS)
+        _zst_req = zstandard.compress(serialized_req, level=1)
+
+    benchmark(serialize)
+
+
+def dump_size_versions():
+    console = Console()
+    br = next(basic_request._fixture_function())
+    er = next(enhanced_request._fixture_function(br))
+
+    br_json = br.model_dump_json()
+    er_json = orjson.dumps(er, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS)
+    er_gzip = gzip.compress(er_json)
+    er_zstd = zstandard.compress(er_json, level=1)
+
+    table = Table("Method", "Size", "Increase", title="Serialization Sizes")
+
+    table.add_row("Baseline", naturalsize(len(br_json)))
+    table.add_section()
+
+    table.add_row("orjson", naturalsize(len(er_json)), "{:.2%}".format(len(er_json) / len(br_json) - 1))
+    table.add_row("orjson + gz", naturalsize(len(er_gzip)), "{:.2%}".format(len(er_gzip) / len(br_json) - 1))
+    table.add_row("orjson + zst", naturalsize(len(er_zstd)), "{:.2%}".format(len(er_zstd) / len(br_json) - 1))
+
+    console.print(table)
+
+
+if __name__ == "__main__":
+    dump_size_versions()

--- a/uv.lock
+++ b/uv.lock
@@ -2681,6 +2681,7 @@ dev = [
     { name = "pylatex" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "ray" },
     { name = "requests" },
     { name = "ruff" },
@@ -2716,6 +2717,7 @@ lint = [
 test = [
     { name = "coverage" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "requests" },
     { name = "scikit-learn" },
 ]
@@ -2775,6 +2777,7 @@ dev = [
     { name = "pylatex", specifier = "~=1.4.2" },
     { name = "pyright", specifier = "~=1.1" },
     { name = "pytest", specifier = ">=8" },
+    { name = "pytest-benchmark", specifier = ">=5" },
     { name = "ray", specifier = "~=2.44" },
     { name = "requests", specifier = ">=2.31,<3" },
     { name = "ruff", specifier = ">=0.4" },
@@ -2810,6 +2813,7 @@ lint = [
 test = [
     { name = "coverage", specifier = ">=6.5" },
     { name = "pytest", specifier = ">=8" },
+    { name = "pytest-benchmark", specifier = ">=5" },
     { name = "requests", specifier = ">=2.31,<3" },
     { name = "scikit-learn", specifier = ">=1.3,<2" },
 ]
@@ -3145,6 +3149,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d0/a8bd08d641b393db3be3819b03e2d9bb8760ca8479080a26a5f6e540e99c/pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105", size = 337810, upload-time = "2024-10-30T11:51:48.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/d6/b41653199ea09d5969d4e385df9bbfd9a100f28ca7e824ce7c0a016e3053/pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89", size = 44259, upload-time = "2024-10-30T11:51:45.94Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Based on CCRI-POPROX/poprox-platform#454, this implements benchmarks for several serialization methods for recommendation requests with embeddings, along with a pretty size table.

Sizes:

```console
$ python tests/test_serialization.py
+--------------+---------+----------+
| Method       | Size    | Increase |
+--------------+---------+----------+
| Baseline     | 3.8 MB  |          |
+--------------+---------+----------+
| orjson       | 14.7 MB | 285.25%  |
| orjson + gz  | 5.5 MB  | 45.04%   |
| orjson + zst | 5.3 MB  | 39.78%   |
+--------------+---------+----------+
```

Times:

```
-------------------------- benchmark 'basic': 2 tests -------------------------
Name (time in ms)          Mean             Median                OPS
-------------------------------------------------------------------------------
test_pydantic_basic     11.2894 (1.0)      11.2535 (1.0)      88.5783 (1.0)
test_orjson_basic       15.9660 (1.41)     15.9409 (1.42)     62.6330 (0.71)
-------------------------------------------------------------------------------

----------------------- benchmark 'embeddings': 3 tests -----------------------
Name (time in ms)         Mean              Median                OPS
-------------------------------------------------------------------------------
test_orjson            20.5786 (1.0)       20.7782 (1.0)      48.5941 (1.0)
test_orjson_zstd       43.1349 (2.10)      42.8487 (2.06)     23.1831 (0.48)
test_orjson_gzip      896.6447 (43.57)    872.6127 (42.00)     1.1153 (0.02)
-------------------------------------------------------------------------------
```