### PR TITLE
Least Item Promoted Fix

### DIFF
--- a/src/poprox_recommender/evaluation/metrics/lip.py
+++ b/src/poprox_recommender/evaluation/metrics/lip.py
@@ -7,11 +7,12 @@ def least_item_promoted(reference_article_set: CandidateSet, reranked_article_se
     if not reference_article_set.articles:
         return np.nan
     lip_rank = k
+    reference_size = len(reference_article_set.articles)
     for item in reranked_article_set.articles[:k]:
         try:
             rank = reference_article_set.articles.index(item)
             if rank > lip_rank:
                 lip_rank = rank
         except ValueError:
-            continue
+            lip_rank = max(lip_rank, reference_size + 1)
     return lip_rank - k


### PR DESCRIPTION
Current LIP implementation would always return 0 since the reference set is terminated at top k
TODO: Test cases to be fixed accordingly