### PR TITLE
Remove MINDlarge_test data

### DIFF
--- a/data/MINDlarge_test.zip.dvc
+++ b/data/MINDlarge_test.zip.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: 2b69c2cdb7e1bacbdd99b4d6718aa7db
-  size: 605020713
-  hash: md5
-  path: MINDlarge_test.zip

--- a/data/dvc.lock
+++ b/data/dvc.lock
@@ -70,17 +70,12 @@ stages:
     deps:
     - path: ../src/poprox_recommender/training/preprocess.py
       hash: md5
-      md5: 1564e172ad7c9494c33996a28510411c
-      size: 5156
+      md5: cba1f3375bae5782e5f53eaf618c4527
+      size: 4773
     - path: MINDlarge_dev
       hash: md5
       md5: a90bc1810ca5c0c4c4ef4320474cb67f.dir
       size: 322720668
-      nfiles: 5
-    - path: MINDlarge_test
-      hash: md5
-      md5: 0c6ffa13aff376a03efef4e6fe8bfb4a.dir
-      size: 1607849223
       nfiles: 5
     - path: MINDlarge_train
       hash: md5
@@ -93,13 +88,8 @@ stages:
       md5: b46257fa21d5847dbb140fffee7bc289.dir
       size: 65658285
       nfiles: 1
-    - path: MINDlarge_post_test
-      hash: md5
-      md5: 76ef57e4d4f5c9c965bfc4b99334ce84.dir
-      size: 112514303
-      nfiles: 1
     - path: MINDlarge_post_train
       hash: md5
-      md5: 1596fb67e704f44da0f990adfdb8975c.dir
-      size: 1163363644
+      md5: 3c827b4fd624bde959628b117929a9b4.dir
+      size: 1163363710
       nfiles: 3

--- a/data/dvc.yaml
+++ b/data/dvc.yaml
@@ -2,7 +2,6 @@ stages:
   unzip:
     foreach:
       - MINDlarge_dev
-      - MINDlarge_test
       - MINDlarge_train
       - MINDsmall_dev
       - MINDsmall_train
@@ -19,8 +18,6 @@ stages:
       - ../src/poprox_recommender/training/preprocess.py
       - MINDlarge_train
       - MINDlarge_dev
-      - MINDlarge_test
     outs:
       - MINDlarge_post_train
       - MINDlarge_post_dev
-      - MINDlarge_post_test

--- a/models/dvc.yaml
+++ b/models/dvc.yaml
@@ -2,11 +2,10 @@ stages:
   train-nrms-mind:
     cmd: python -m poprox_recommender.training.train
     deps:
-    - ../data/MINDlarge_dev
-    - ../data/MINDlarge_post_dev
-    - ../data/MINDlarge_post_test
-    - ../data/MINDlarge_post_train
-    - ../src/poprox_recommender/training/train.py
+      - ../data/MINDlarge_dev
+      - ../data/MINDlarge_post_dev
+      - ../data/MINDlarge_post_train
+      - ../src/poprox_recommender/training/train.py
     outs:
-    - nrms-mind
+      - nrms-mind
     frozen: true

--- a/src/poprox_recommender/training/preprocess.py
+++ b/src/poprox_recommender/training/preprocess.py
@@ -102,15 +102,12 @@ if __name__ == "__main__":
     root = project_root()
     train_dir = root / "data/MINDlarge_train"
     val_dir = root / "data/MINDlarge_dev"
-    test_dir = root / "data/MINDlarge_test"
 
     post_train_dir = root / "data/MINDlarge_post_train"
     post_val_dir = root / "data/MINDlarge_post_dev"
-    post_test_dir = root / "data/MINDlarge_post_test"
 
     os.makedirs(post_train_dir, exist_ok=True)
     os.makedirs(post_val_dir, exist_ok=True)
-    os.makedirs(post_test_dir, exist_ok=True)
 
     pretrain_tokenizer = (
         "distilbert-base-uncased"  # the model needs to be consistent with the pretrained model during training
@@ -140,14 +137,6 @@ if __name__ == "__main__":
     parse_news(
         path.join(val_dir, "news.tsv"),
         path.join(post_val_dir, "news_parsed.tsv"),
-        pretrained_tokenizer=pretrain_tokenizer,
-        token_length=max_length,
-    )
-
-    print("\nProcess news for Testing")
-    parse_news(
-        path.join(test_dir, "news.tsv"),
-        path.join(post_test_dir, "news_parsed.tsv"),
         pretrained_tokenizer=pretrain_tokenizer,
         token_length=max_length,
     )


### PR DESCRIPTION
The MIND Large Test data set does not actually have clicks / relevance signals — it is only providing the test items for users to generate their submissions to the MIND leaderboard.

We also weren't actually using it for anything.

This PR removes it, along with its output in training preprocessing, from our code and workflow.