### PR TITLE
Section-aware RBP metric with browsing model weights

### DIFF
--- a/outputs/poprox-recent-subset/nrms_sections/metrics.json
+++ b/outputs/poprox-recent-subset/nrms_sections/metrics.json
@@ -1,0 +1,15 @@
+{
+  "num_truth":0.056,
+  "RBP":0.0484784311,
+  "section_aware_RBP":0.0668867127,
+  "NDCG@5":0.1359108128,
+  "NDCG@10":0.2477493929,
+  "MRR":0.1704365079,
+  "RBO@5":0.0,
+  "RBO@10":0.0,
+  "rank_based_entropy":0.0,
+  "least_item_promoted":null,
+  "intralist_similarity":null,
+  "total_articles":12.0,
+  "num_sections":4.0
+}

--- a/src/poprox_recommender/evaluation/measure/section_browsing_model.py
+++ b/src/poprox_recommender/evaluation/measure/section_browsing_model.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from poprox_concepts.domain import ImpressedSection
+
+
+def section_browsing_weights(
+    sections: list[ImpressedSection],
+    alpha: float = 0.10,  # abandon probability
+    sigma: float = 0.20,  # skip to next section probability
+) -> np.ndarray:
+    """
+    Compute per-item visit probability weights for section-aware RBP.
+
+    Based on a browsing model where after each item the user can:
+    - abandon with probability alpha
+    - skip to next section with probability sigma
+    - continue within section with probability gamma = 1 - alpha - sigma
+
+    Args:
+        sections: list of ImpressedSection objects
+        alpha: probability of abandoning reading entirely
+        sigma: probability of skipping to next section
+
+    Returns:
+        numpy array of visit probabilities, one per article across all sections
+    """
+    gamma = 1.0 - alpha - sigma
+    weights = []
+    P_s = 1.0  # probability of visiting first section
+
+    for section in sections:
+        section_item_probs = []
+
+        for j in range(len(section.impressions)):
+            if j == 0:
+                P_v = gamma * P_s
+            else:
+                P_v = gamma * section_item_probs[-1]
+            section_item_probs.append(P_v)
+            weights.append(P_v)
+
+        # probability of reaching next section
+        P_s_next = sigma * P_s  # skip from header
+        for p_v in section_item_probs:
+            P_s_next += sigma * p_v  # skip from each item
+        P_s_next += gamma * section_item_probs[-1]  # continue past last item
+
+        P_s = P_s_next
+
+    return np.array(weights)

--- a/src/poprox_recommender/evaluation/metrics/__init__.py
+++ b/src/poprox_recommender/evaluation/metrics/__init__.py
@@ -9,6 +9,7 @@ from lenskit.metrics.ranking import NDCG, RBP, RecipRank
 
 from poprox_concepts.domain import Article, CandidateSet
 from poprox_recommender.data.eval import EvalData
+from poprox_recommender.evaluation.measure.section_browsing_model import section_browsing_weights
 from poprox_recommender.evaluation.metrics.ils import intralist_similarity
 from poprox_recommender.evaluation.metrics.lip import least_item_promoted
 from poprox_recommender.evaluation.metrics.rbe import rank_bias_entropy
@@ -51,11 +52,24 @@ def measure_rec_metrics(
     if isinstance(final, list):
         articles = [imp.article for section in final for imp in section.impressions]
         num_sections = len(final)
+        browsing_weights = section_browsing_weights(final)
     else:
         articles = [imp.article for imp in final.impressions]
         num_sections = None
+        browsing_weights = None
 
-    final_rec = ItemList(item_ids=[str(a.article_id) for a in articles], ordered=True)
+    if browsing_weights is not None:  # build weighted ItemList
+        final_rec = ItemList(
+            item_ids=[str(a.article_id) for a in articles],
+            ordered=True,
+            weight=browsing_weights,
+        )
+    else:
+        final_rec = ItemList(
+            item_ids=[str(a.article_id) for a in articles],
+            ordered=True,
+        )
+
     total_articles = len(final_rec)
 
     # we only compute effectiveness with truth
@@ -64,8 +78,16 @@ def measure_rec_metrics(
         single_rr = call_metric(RecipRank, final_rec, truth)
         single_ndcg5 = call_metric(NDCG, final_rec, truth, k=5)
         single_ndcg10 = call_metric(NDCG, final_rec, truth, k=10)
+
+        # section-aware RBP
+        if browsing_weights is not None:
+            section_aware_rbp = RBP(weight_field="weight")
+            sa_rbp = section_aware_rbp.measure_list(final_rec, truth)
+        else:
+            sa_rbp = None
+
     else:
-        single_rbp = single_rr = single_ndcg5 = single_ndcg10 = None
+        single_rbp = single_rr = single_ndcg5 = single_ndcg10 = sa_rbp = None
 
     ranked = (
         CandidateSet(articles=[imp.article for imp in results.ranked.impressions])
@@ -115,6 +137,7 @@ def measure_rec_metrics(
         # count the number of instances with non-empty truth sets
         "num_truth": len(truth),
         "RBP": single_rbp,
+        "section_aware_RBP": sa_rbp,
         "NDCG@5": single_ndcg5,
         "NDCG@10": single_ndcg10,
         "RR": single_rr,

--- a/tests/test_section_browsing_model.py
+++ b/tests/test_section_browsing_model.py
@@ -1,0 +1,77 @@
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from poprox_concepts.domain import Article, ImpressedSection, Impression
+from poprox_recommender.evaluation.measure.section_browsing_model import section_browsing_weights
+
+
+def make_section(n_articles: int) -> ImpressedSection:
+    impressions = [Impression(article=Article(article_id=uuid4(), headline=f"Article {i}")) for i in range(n_articles)]
+    return ImpressedSection(impressions=impressions)
+
+
+def test_weights_shape():
+    sections = [make_section(3) for _ in range(5)]
+    weights = section_browsing_weights(sections)
+    assert len(weights) == 15
+
+
+def test_weights():
+    """
+    Verify weights match:
+    alpha=0.10, sigma=0.20, gamma=0.70
+    """
+    sections = [make_section(3) for _ in range(5)]
+    weights = section_browsing_weights(sections, alpha=0.10, sigma=0.20)
+
+    expected = np.array(
+        [
+            0.700,
+            0.490,
+            0.343,  # Section 1
+            0.52269,
+            0.365883,
+            0.256118,  # Section 2
+            0.390293,
+            0.273205,
+            0.191243,  # Section 3
+            0.291432,
+            0.204002,
+            0.142801,  # Section 4
+            0.217612,
+            0.152328,
+            0.10663,  # Section 5
+        ]
+    )
+
+    np.testing.assert_allclose(weights, expected, rtol=1e-2)
+
+
+def test_weights_decay_within_section():
+    sections = [make_section(3)]
+    weights = section_browsing_weights(sections, alpha=0.10, sigma=0.20)
+    assert weights[0] > weights[1] > weights[2]
+
+
+def test_weights_decay_across_sections():
+    sections = [make_section(3) for _ in range(3)]
+    weights = section_browsing_weights(sections, alpha=0.10, sigma=0.20)
+    # first item of each section
+    assert weights[0] > weights[3] > weights[6]
+
+
+def test_weights_all_positive():
+    sections = [make_section(3) for _ in range(5)]
+    weights = section_browsing_weights(sections, alpha=0.15, sigma=0.30)
+    assert np.all(weights > 0)
+
+
+def test_weights_single_section():
+    """Single section degrades to geometric decay by gamma."""
+    sections = [make_section(3)]
+    gamma = 0.70
+    weights = section_browsing_weights(sections, alpha=0.10, sigma=0.20)
+    expected = np.array([gamma, gamma**2, gamma**3])
+    np.testing.assert_allclose(weights, expected, rtol=1e-10)


### PR DESCRIPTION
- Added `section_browsing_model.py` with `section_browsing_weights` function. Per-item visit probabilities are computed using abandon, skip, and continue parameters: `0.10`, `0.20`, and `0.70` respectively. 
- Added `section_aware_RBP` to `measures_rec_metrics` 
- Added tests for `section_browsing_weights`