### PR TITLE
Upgrade to LensKit 2026

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "fastapi[all]~=0.115.11",
   "mangum~=0.19.0",
   "uvicorn~=0.34.0",
-  "lenskit ~=2026.1",
+  "lenskit >=2026.1.1a1.dev121,<2027",
   "nltk>=3.8,<4",
   "torch~=2.2",
   "smart_open==7.*",
@@ -92,13 +92,13 @@ conflicts = [[{ group = "cpu" }, { group = "cuda" }]]
 index-strategy = "unsafe-first-match"
 
 [tool.uv.sources]
-# lenskit = { index = "lenskit-dev" }
+lenskit = { index = "lenskit-dev" }
 torch = [
   { index = "pytorch-cpu", group = "cpu" },
   { index = "pytorch-cuda", group = "cuda" },
 ]
 # following can be uncommented when temporarily using a git checkout
-lenskit = { git = "https://github.com/mdekstrand/lkpy.git", branch = "fix/1101-input-type-forms" }
+# lenskit = { git = "https://github.com/mdekstrand/lkpy.git", branch = "fix/1101-input-type-forms" }
 
 # pre-release version of LensKit
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
 ]
-requires-python = "~=3.12.0"
+requires-python = "~=3.12.5"
 readme = "README.md"
 license = { file = "LICENSE.md" }
 dynamic = ["version"]
@@ -19,7 +19,7 @@ dependencies = [
   "fastapi[all]~=0.115.11",
   "mangum~=0.19.0",
   "uvicorn~=0.34.0",
-  "lenskit>=2025.6.2,<2026",
+  "lenskit ~=2026.1",
   "nltk>=3.8,<4",
   "torch~=2.2",
   "smart_open==7.*",
@@ -66,7 +66,7 @@ dev = [
 ]
 data = [
   "invoke ~=2.2",
-  "dvc[s3] ~=3.51",
+  "dvc[s3,webdav] ~=3.51",
   "docopt-ng >=0.9",
   "pandas ~=2.0",
   "matplotlib ~=3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ torch = [
   { index = "pytorch-cuda", group = "cuda" },
 ]
 # following can be uncommented when temporarily using a git checkout
-# lenskit = { git = "https://github.com/mdekstrand/lkpy.git", branch = "feature/settings-and-metrics" }
+lenskit = { git = "https://github.com/mdekstrand/lkpy.git", branch = "fix/1101-input-type-forms" }
 
 # pre-release version of LensKit
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "fastapi[all]~=0.115.11",
   "mangum~=0.19.0",
   "uvicorn~=0.34.0",
-  "lenskit >=2026.1.1a1.dev121,<2027",
+  "lenskit >=2026.2.0,<2027",
   "nltk>=3.8,<4",
   "torch~=2.2",
   "smart_open==7.*",
@@ -92,7 +92,7 @@ conflicts = [[{ group = "cpu" }, { group = "cuda" }]]
 index-strategy = "unsafe-first-match"
 
 [tool.uv.sources]
-lenskit = { index = "lenskit-dev" }
+# lenskit = { index = "lenskit-dev" }
 torch = [
   { index = "pytorch-cpu", group = "cpu" },
   { index = "pytorch-cuda", group = "cuda" },

--- a/src/poprox_recommender/components/joiners/fill.py
+++ b/src/poprox_recommender/components/joiners/fill.py
@@ -1,5 +1,4 @@
-from lenskit.pipeline import Component
-from lenskit.pipeline.types import Lazy
+from lenskit.pipeline import Component, Lazy
 from pydantic import BaseModel
 
 from poprox_concepts.domain import ImpressedSection, Impression

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -106,7 +106,7 @@ def cluster_recommend(
     """
     Generate and save recommendations with parallel worker processes.
     """
-    logger.info("starting parallel evaluation with task limit of %d", pc.processes)
+    logger.info("starting parallel evaluation with task limit of %d", pc.num_procs)
     init_cluster(global_logging=True)
 
     device = default_device()

--- a/src/poprox_recommender/evaluation/generate/worker.py
+++ b/src/poprox_recommender/evaluation/generate/worker.py
@@ -5,8 +5,9 @@ from uuid import UUID
 import ray
 import torch
 from humanize import metric, naturaldelta
+from lenskit.config import ParallelSettings
 from lenskit.logging import Progress, Task, get_logger, item_progress
-from lenskit.parallel.config import ParallelConfig, get_parallel_config, subprocess_config
+from lenskit.parallel import get_parallel_config
 from lenskit.parallel.ray import TaskLimiter, init_cluster
 from lenskit.pipeline import Pipeline, PipelineState
 from torch.multiprocessing.reductions import reduce_tensor
@@ -42,7 +43,7 @@ def generate_recs_for_requests(dataset: EvalData, outs: RecOutputs, pipeline: st
 
     # check for parallel operation
     pc = get_parallel_config()
-    cluster = pc.processes > 1
+    cluster = pc.num_procs > 1
 
     count = n_requests if n_requests is not None else dataset.n_requests
     logger.info("recommending for %d requests", count)
@@ -98,7 +99,7 @@ def cluster_recommend(
     pipeline: str,
     max_recommendations: int | None,
     outs: RecOutputs,
-    pc: ParallelConfig,
+    pc: ParallelSettings,
     task: Task,
     pb: Progress,
 ):
@@ -131,7 +132,7 @@ def cluster_recommend(
 
     # Set up parallel task and throttle for running the eval
     rec_batch = dynamic_remote(recommend_batch)
-    limit = TaskLimiter(pc.processes)
+    limit = TaskLimiter(pc.num_procs)
 
     writes = []
     for n, btask, bwrites in limit.imap(
@@ -241,7 +242,7 @@ def dynamic_remote(task_or_actor):
     Dynamically configure the resource requirements of a task or actor based on
     CUDA availability and parallelism configuration.
     """
-    pc = subprocess_config()
+    pc = get_parallel_config()
     logger.debug("worker parallel config: %s", pc)
     if torch.cuda.is_available():
         _cuda_props = torch.cuda.get_device_properties()

--- a/src/poprox_recommender/evaluation/measure/batch_measure.py
+++ b/src/poprox_recommender/evaluation/measure/batch_measure.py
@@ -21,11 +21,11 @@ BATCH_SIZE = 1000
 def recommendation_eval_results(eval_data: EvalData, rec_path: Path) -> Iterator[dict[str, Any]]:
     pc = get_parallel_config()
     with xopen(rec_path, "rb") as f:
-        if pc.processes > 1:
-            logger.info("starting parallel measurement with up to %d tasks", pc.processes)
+        if pc.num_procs > 1:
+            logger.info("starting parallel measurement with up to %d tasks", pc.num_procs)
             init_cluster(global_logging=True, configure_logging=False)
             eval_data_ref = ray.put(eval_data)
-            limit = TaskLimiter(pc.processes)
+            limit = TaskLimiter(pc.num_procs)
             for bres in limit.imap(
                 lambda batch: measure_batch.remote(batch, eval_data_ref),
                 batched(f, BATCH_SIZE),

--- a/src/poprox_recommender/recommenders/hooks.py
+++ b/src/poprox_recommender/recommenders/hooks.py
@@ -6,12 +6,13 @@ from collections.abc import MutableMapping, MutableSequence, MutableSet
 from copy import copy
 from typing import Any
 
+from lenskit.pipeline.components import ComponentInput
 from lenskit.pipeline.nodes import ComponentInstanceNode
 from pydantic import BaseModel
 
 
 def shallow_copy_pydantic_model(
-    node: ComponentInstanceNode[Any], input_name: str, input_type: Any, value: Any, **context: Any
+    node: ComponentInstanceNode[Any], input: ComponentInput, value: Any, **context: Any
 ) -> Any:
     """
     LensKit component-input hook to perform shallow copies of Pydantic models

--- a/uv.lock
+++ b/uv.lock
@@ -1927,8 +1927,8 @@ wheels = [
 
 [[package]]
 name = "lenskit"
-version = "2026.1.1a1"
-source = { git = "https://github.com/mdekstrand/lkpy.git?branch=fix%2F1101-input-type-forms#39a8c7101a7cd77641e319f789ab8bf8de05b557" }
+version = "2026.1.1a1.dev121+g3a8c1939"
+source = { registry = "https://pypi.lenskit.org/lenskit-dev/" }
 dependencies = [
     { name = "click" },
     { name = "humanize" },
@@ -1955,6 +1955,13 @@ dependencies = [
     { name = "torch", version = "2.7.1+cu128", source = { registry = "https://pypi.lenskit.org/torch/cu128/" }, marker = "(sys_platform != 'darwin' and extra != 'group-18-poprox-recommender-cpu') or (extra == 'group-18-poprox-recommender-cpu' and extra == 'group-18-poprox-recommender-cuda')" },
     { name = "typing-extensions" },
     { name = "xopen" },
+]
+sdist = { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939.tar.gz" }
+wheels = [
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-macosx_11_0_arm64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-manylinux_2_28_aarch64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-manylinux_2_28_x86_64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-win_amd64.whl" },
 ]
 
 [[package]]
@@ -2776,7 +2783,7 @@ requires-dist = [
     { name = "awslambdaric", marker = "extra == 'deploy'", specifier = "~=2.2" },
     { name = "fastapi", extras = ["all"], specifier = "~=0.115.11" },
     { name = "httpx", specifier = "~=0.28.1" },
-    { name = "lenskit", git = "https://github.com/mdekstrand/lkpy.git?branch=fix%2F1101-input-type-forms" },
+    { name = "lenskit", specifier = ">=2026.1.1a1.dev121,<2027", index = "https://pypi.lenskit.org/lenskit-dev/" },
     { name = "mangum", specifier = "~=0.19.0" },
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git" },

--- a/uv.lock
+++ b/uv.lock
@@ -1927,7 +1927,7 @@ wheels = [
 
 [[package]]
 name = "lenskit"
-version = "2026.1.1a1.dev121+g3a8c1939"
+version = "2026.1.1a1.dev129+g2b705a83"
 source = { registry = "https://pypi.lenskit.org/lenskit-dev/" }
 dependencies = [
     { name = "click" },
@@ -1956,12 +1956,12 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xopen" },
 ]
-sdist = { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939.tar.gz" }
+sdist = { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83.tar.gz" }
 wheels = [
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-macosx_11_0_arm64.whl" },
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-manylinux_2_28_aarch64.whl" },
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-manylinux_2_28_x86_64.whl" },
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev121%2Bg3a8c1939-cp312-abi3-win_amd64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-macosx_11_0_arm64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-manylinux_2_28_aarch64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-manylinux_2_28_x86_64.whl" },
+    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-win_amd64.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = "==3.12.*"
+requires-python = ">=3.12.5, <3.13"
 resolution-markers = [
     "sys_platform != 'darwin'",
     "sys_platform == 'darwin'",
@@ -828,6 +828,9 @@ wheels = [
 s3 = [
     { name = "dvc-s3" },
 ]
+webdav = [
+    { name = "dvc-webdav" },
+]
 
 [[package]]
 name = "dvc-data"
@@ -926,6 +929,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/ef/da712c4d9c7d6cacac27d7b2779e6a97c3381ef2c963c33719d39113b6a3/dvc_task-0.40.2.tar.gz", hash = "sha256:909af541bf5fde83439da56c4c0ebac592af178a59b702708fadaacfd6e7b704", size = 36147, upload-time = "2024-10-08T12:47:31.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/bf/f23e8eff38556d479ab421f8b9ac9a9a0b44f8400098c934dce0607da1de/dvc_task-0.40.2-py3-none-any.whl", hash = "sha256:3891b94cf9d349072ee32ce47217b73530b1905e6dd5a1e378bd74afc8b4c030", size = 21392, upload-time = "2024-10-08T12:47:30.317Z" },
+]
+
+[[package]]
+name = "dvc-webdav"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dvc" },
+    { name = "webdav4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/12/71c963fa0f1c1200983c40ab54978ba36e2a459a646c7266248c8594dd37/dvc_webdav-3.0.1.tar.gz", hash = "sha256:3c0d04afb0985a2c156f0b719f4b9437ce4acd346647d8f6fee043b5e917c76e", size = 15411, upload-time = "2025-12-05T04:43:49.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/5a/018ee41cc0e8ea88823b1dccaa97d02597f7cdcd80840acd18ec707c753d/dvc_webdav-3.0.1-py3-none-any.whl", hash = "sha256:e7ad8d1d1a1cb04505752a71474d183f934a493acc5deb07a72530e6cfd03448", size = 13338, upload-time = "2025-12-05T04:43:48.536Z" },
 ]
 
 [[package]]
@@ -1920,15 +1936,15 @@ wheels = [
 
 [[package]]
 name = "lenskit"
-version = "2025.6.2"
+version = "2026.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "deepmerge" },
     { name = "humanize" },
     { name = "lazy-loader" },
-    { name = "more-itertools" },
     { name = "numpy" },
+    { name = "packaging" },
     { name = "pandas" },
     { name = "prettytable" },
     { name = "psutil" },
@@ -1950,15 +1966,12 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xopen" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/32/f405d7df84a8a2701b2b0d4cfde785557c9d7a22c4793c0e7e4a41d4128b/lenskit-2025.6.2.tar.gz", hash = "sha256:39451d22e8b4c7318ff310bc22c9c04c589c6e60a4261eb3c65a318b07494c9a", size = 2966972, upload-time = "2025-12-08T16:43:56.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/c9/091982bd5998f64bf4788d47fe41831b2be10e43a315f2d37346ca0b61d2/lenskit-2026.1.0.tar.gz", hash = "sha256:69ea9d3c5a46797d7a6f5fcb3caf27e10bdcb2292a1d7da260a4941a9a1db214", size = 2964205, upload-time = "2026-04-18T21:56:24.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/63/c3c4e519b57d0c4bf204d87122d9c8b90d4f435d93159656cf097c0664a4/lenskit-2025.6.2-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0dff0ba554af824562aaa71c76d353b338f881c7087da7ca4e491ed02d156a3d", size = 2779002, upload-time = "2025-12-08T16:43:44.193Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/cc/7602b8d75b2b283eed1f89c28374e6b7a2735898520ccbf805a7c8884d26/lenskit-2025.6.2-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:3e375c9690871c9b99e6d27b529c53860189c589a80e2a3fe753c95b24b0fa99", size = 2538522, upload-time = "2025-12-08T16:43:46.577Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/19/f45f8d4e3e6628f65192cf87816df82ab80f5b84d32cb90d719dffd59398/lenskit-2025.6.2-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f12433d571d52f639144afa784c3070d06f6be121389aacf65461c7a23e96bd7", size = 8060169, upload-time = "2025-12-08T16:43:48.409Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f8/d0735ea27d9f74ada6771e64c82507fc27eee8c1413f01b5c6109afe1bbc/lenskit-2025.6.2-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:461bb933db51fa897a59bd66022e66d329d224e15de831aaf436a26f66c2eda4", size = 7290318, upload-time = "2025-12-08T16:43:50.207Z" },
-    { url = "https://files.pythonhosted.org/packages/27/7a/800618f64eb0b8ab6839266f0e50534727367126f0d1e0e27a66f63c24a1/lenskit-2025.6.2-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e48e4db25f798936fad737d36079a6e7739d3b343b60b92a3517b9d274fc1bef", size = 7801531, upload-time = "2025-12-08T16:43:51.987Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/eb/2a6b548d7a8ce28836b7441f57950f0015a7a24f7919c41a39699d674eb4/lenskit-2025.6.2-cp311-abi3-win32.whl", hash = "sha256:ae94066048662decdc1859e5b5fd0793ff6aedd319d6d4e3b26efbf6ada987d3", size = 2463123, upload-time = "2025-12-08T16:43:53.492Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/2c/1692a9e03f0093e519d52c385f0c953d34a2360e7761e0a2b6a52a8c1f95/lenskit-2025.6.2-cp311-abi3-win_amd64.whl", hash = "sha256:f57206852ef752381259dedffa3b74073f0958cfb15909fd8934da09acdfd45d", size = 2731507, upload-time = "2025-12-08T16:43:55.218Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e0/02eb33532129fd31814d60d5156147ead21f4ee4e9bfe02782736d80cfec/lenskit-2026.1.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:bae58c14beb4ef238be28ce4c453526f54473627d1b284ce60640b9d2b6de2de", size = 3228086, upload-time = "2026-04-18T21:56:06.489Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b8/8561eda68d3c89ca70b22e14621c746f464a80706340c96300ac553a2b1b/lenskit-2026.1.0-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6beae6e6fab0e2c36fba06bf3b4e0f92c41ab4dee5bc28fdcc31af8e12e31449", size = 9500124, upload-time = "2026-04-18T21:56:08.747Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/de9eb8703eabfb4bc5d7d12a37ec31361ca16e8df187cfe7ff21614c9c09/lenskit-2026.1.0-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f7988c8e7a89dd288be69c79e440208e473d166b5df0657951578c6871e5ed4c", size = 9986776, upload-time = "2026-04-18T21:56:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ad/492c7009426a3ac8a2bac94f824262ea8196c0910d282891826265e26344/lenskit-2026.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:c219348861ab975523ec538fe1e182a915dae4440bb8f430566bf322deb7d193", size = 3398602, upload-time = "2026-04-18T21:56:13.605Z" },
 ]
 
 [[package]]
@@ -2698,7 +2711,7 @@ cuda = [
 data = [
     { name = "docopt-ng" },
     { name = "duckdb" },
-    { name = "dvc", extra = ["s3"] },
+    { name = "dvc", extra = ["s3", "webdav"] },
     { name = "invoke" },
     { name = "jq" },
     { name = "jupytext" },
@@ -2716,7 +2729,7 @@ dev = [
     { name = "coverage" },
     { name = "docopt-ng" },
     { name = "duckdb" },
-    { name = "dvc", extra = ["s3"] },
+    { name = "dvc", extra = ["s3", "webdav"] },
     { name = "hatch" },
     { name = "invoke" },
     { name = "ipython" },
@@ -2746,7 +2759,7 @@ dev = [
 eval = [
     { name = "docopt-ng" },
     { name = "duckdb" },
-    { name = "dvc", extra = ["s3"] },
+    { name = "dvc", extra = ["s3", "webdav"] },
     { name = "invoke" },
     { name = "jq" },
     { name = "jupytext" },
@@ -2780,7 +2793,7 @@ requires-dist = [
     { name = "awslambdaric", marker = "extra == 'deploy'", specifier = "~=2.2" },
     { name = "fastapi", extras = ["all"], specifier = "~=0.115.11" },
     { name = "httpx", specifier = "~=0.28.1" },
-    { name = "lenskit", specifier = ">=2025.6.2,<2026" },
+    { name = "lenskit", specifier = "~=2026.1" },
     { name = "mangum", specifier = "~=0.19.0" },
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git" },
@@ -2798,7 +2811,7 @@ cuda = [{ name = "torch", specifier = "~=2.2", index = "https://pypi.lenskit.org
 data = [
     { name = "docopt-ng", specifier = ">=0.9" },
     { name = "duckdb", specifier = "~=1.3" },
-    { name = "dvc", extras = ["s3"], specifier = "~=3.51" },
+    { name = "dvc", extras = ["s3", "webdav"], specifier = "~=3.51" },
     { name = "invoke", specifier = "~=2.2" },
     { name = "jq", specifier = "~=1.8" },
     { name = "jupytext", specifier = ">=1.16" },
@@ -2816,7 +2829,7 @@ dev = [
     { name = "coverage", specifier = ">=6.5" },
     { name = "docopt-ng", specifier = ">=0.9" },
     { name = "duckdb", specifier = "~=1.3" },
-    { name = "dvc", extras = ["s3"], specifier = "~=3.51" },
+    { name = "dvc", extras = ["s3", "webdav"], specifier = "~=3.51" },
     { name = "hatch", specifier = "~=1.13" },
     { name = "invoke", specifier = "~=2.2" },
     { name = "ipython", specifier = ">=8" },
@@ -2846,7 +2859,7 @@ dev = [
 eval = [
     { name = "docopt-ng", specifier = ">=0.9" },
     { name = "duckdb", specifier = "~=1.3" },
-    { name = "dvc", extras = ["s3"], specifier = "~=3.51" },
+    { name = "dvc", extras = ["s3", "webdav"], specifier = "~=3.51" },
     { name = "invoke", specifier = "~=2.2" },
     { name = "jq", specifier = "~=1.8" },
     { name = "jupytext", specifier = ">=1.16" },
@@ -4234,11 +4247,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -4457,6 +4470,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/29/061ec845fb58521848f3739e466efd8250b4b7b98c1b6c5bf4d40b419b7e/webcolors-24.11.1.tar.gz", hash = "sha256:ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6", size = 45064, upload-time = "2024-11-11T07:43:24.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/e8/c0e05e4684d13459f93d312077a9a2efbe04d59c393bc2b8802248c908d4/webcolors-24.11.1-py3-none-any.whl", hash = "sha256:515291393b4cdf0eb19c155749a096f779f7d909f7cceea072791cb9095b92e9", size = 14934, upload-time = "2024-11-11T07:43:22.529Z" },
+]
+
+[[package]]
+name = "webdav4"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/2d/3d20527d81b25ef039ac92c15f4b9c8760b099e4e0fbf2b1d5d24ef78c3f/webdav4-0.11.0.tar.gz", hash = "sha256:7062c6640e0520bfbd49862bdd335db839e519bf2ca02cd4f89957069ed600ea", size = 228940, upload-time = "2026-02-19T04:43:03.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/72/274a2a641fd7b14a5ad3191cfec31dc65db857da107340863bbfda9b1682/webdav4-0.11.0-py3-none-any.whl", hash = "sha256:9a8690a919bf65b90b5f8159e29b4465bd82d926ea8f334a9c70ba6cd88f52f1", size = 36517, upload-time = "2026-02-19T04:43:04.712Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1927,8 +1927,8 @@ wheels = [
 
 [[package]]
 name = "lenskit"
-version = "2026.1.1a1.dev129+g2b705a83"
-source = { registry = "https://pypi.lenskit.org/lenskit-dev/" }
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "humanize" },
@@ -1956,12 +1956,12 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xopen" },
 ]
-sdist = { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/14/0ef45aa7116c3195ab539a1ad5769cf860d0f9e91166408a4115086c0a5b/lenskit-2026.2.0.tar.gz", hash = "sha256:591ed8998654e55eeb4c6c73c5f5f8eae6f58575a3cd4094d0b8a5911a0ebc7e", size = 2982373, upload-time = "2026-05-25T19:23:21.711Z" }
 wheels = [
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-macosx_11_0_arm64.whl" },
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-manylinux_2_28_aarch64.whl" },
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-manylinux_2_28_x86_64.whl" },
-    { url = "https://inertial.cci.drexel.edu/dist/lenskit-dev/packages/lenskit-2026.1.1a1.dev129%2Bg2b705a83-cp312-abi3-win_amd64.whl" },
+    { url = "https://files.pythonhosted.org/packages/07/7b/67a987213d89d46e3ede32524bd650bd3a979706dc4873d26e6fbfe02e4a/lenskit-2026.2.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:374c736325c9e81e414b77626938d18b55e42af959f6434e6fa310068395fbfe", size = 3219747, upload-time = "2026-05-25T19:23:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/fa/90ff09ebd391ff934eddc9fc31c5a3000107aea78cf6b96da57fedc72ae3/lenskit-2026.2.0-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:feba134f2499978a1428bb4d4b38e3e0807de0e82461b88aa526f8004402995d", size = 9418276, upload-time = "2026-05-25T19:23:09.09Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d1/0150b7d96406a5af4ec269423025efc4d7b4015b928afbe46a725f587867/lenskit-2026.2.0-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9da3f423264b19191adfba57e018fb17008f4573f9620ade36be6076f146fe70", size = 9933365, upload-time = "2026-05-25T19:23:11.294Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8d/49691dfac735ea8fa8c6ead0e75ed76284011576111b1eba6a71ec742dd2/lenskit-2026.2.0-cp312-abi3-win_amd64.whl", hash = "sha256:604aba608ac7974a6be7e625576388275450132182ccac07befb3af8666959c0", size = 3394465, upload-time = "2026-05-25T19:23:13.314Z" },
 ]
 
 [[package]]
@@ -2783,7 +2783,7 @@ requires-dist = [
     { name = "awslambdaric", marker = "extra == 'deploy'", specifier = "~=2.2" },
     { name = "fastapi", extras = ["all"], specifier = "~=0.115.11" },
     { name = "httpx", specifier = "~=0.28.1" },
-    { name = "lenskit", specifier = ">=2026.1.1a1.dev121,<2027", index = "https://pypi.lenskit.org/lenskit-dev/" },
+    { name = "lenskit", specifier = ">=2026.2.0,<2027" },
     { name = "mangum", specifier = "~=0.19.0" },
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git" },

--- a/uv.lock
+++ b/uv.lock
@@ -660,15 +660,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deepmerge"
-version = "2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
-]
-
-[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1936,11 +1927,10 @@ wheels = [
 
 [[package]]
 name = "lenskit"
-version = "2026.1.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2026.1.1a1"
+source = { git = "https://github.com/mdekstrand/lkpy.git?branch=fix%2F1101-input-type-forms#39a8c7101a7cd77641e319f789ab8bf8de05b557" }
 dependencies = [
     { name = "click" },
-    { name = "deepmerge" },
     { name = "humanize" },
     { name = "lazy-loader" },
     { name = "numpy" },
@@ -1965,13 +1955,6 @@ dependencies = [
     { name = "torch", version = "2.7.1+cu128", source = { registry = "https://pypi.lenskit.org/torch/cu128/" }, marker = "(sys_platform != 'darwin' and extra != 'group-18-poprox-recommender-cpu') or (extra == 'group-18-poprox-recommender-cpu' and extra == 'group-18-poprox-recommender-cuda')" },
     { name = "typing-extensions" },
     { name = "xopen" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/c9/091982bd5998f64bf4788d47fe41831b2be10e43a315f2d37346ca0b61d2/lenskit-2026.1.0.tar.gz", hash = "sha256:69ea9d3c5a46797d7a6f5fcb3caf27e10bdcb2292a1d7da260a4941a9a1db214", size = 2964205, upload-time = "2026-04-18T21:56:24.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/e0/02eb33532129fd31814d60d5156147ead21f4ee4e9bfe02782736d80cfec/lenskit-2026.1.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:bae58c14beb4ef238be28ce4c453526f54473627d1b284ce60640b9d2b6de2de", size = 3228086, upload-time = "2026-04-18T21:56:06.489Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/b8/8561eda68d3c89ca70b22e14621c746f464a80706340c96300ac553a2b1b/lenskit-2026.1.0-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6beae6e6fab0e2c36fba06bf3b4e0f92c41ab4dee5bc28fdcc31af8e12e31449", size = 9500124, upload-time = "2026-04-18T21:56:08.747Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/de9eb8703eabfb4bc5d7d12a37ec31361ca16e8df187cfe7ff21614c9c09/lenskit-2026.1.0-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f7988c8e7a89dd288be69c79e440208e473d166b5df0657951578c6871e5ed4c", size = 9986776, upload-time = "2026-04-18T21:56:11.226Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ad/492c7009426a3ac8a2bac94f824262ea8196c0910d282891826265e26344/lenskit-2026.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:c219348861ab975523ec538fe1e182a915dae4440bb8f430566bf322deb7d193", size = 3398602, upload-time = "2026-04-18T21:56:13.605Z" },
 ]
 
 [[package]]
@@ -2793,7 +2776,7 @@ requires-dist = [
     { name = "awslambdaric", marker = "extra == 'deploy'", specifier = "~=2.2" },
     { name = "fastapi", extras = ["all"], specifier = "~=0.115.11" },
     { name = "httpx", specifier = "~=0.28.1" },
-    { name = "lenskit", specifier = "~=2026.1" },
+    { name = "lenskit", git = "https://github.com/mdekstrand/lkpy.git?branch=fix%2F1101-input-type-forms" },
     { name = "mangum", specifier = "~=0.19.0" },
     { name = "nltk", specifier = ">=3.8,<4" },
     { name = "poprox-concepts", git = "https://github.com/CCRI-POPROX/poprox-concepts.git" },
@@ -3071,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.7"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -3079,9 +3062,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
 [package.optional-dependencies]
@@ -3091,27 +3074,32 @@ email = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.33.2"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
-    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
 ]
 
 [[package]]
@@ -4256,14 +4244,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This upgrades POPROX to use LensKit 2026, which paves the way to enable pipeline visualization.